### PR TITLE
Fix JSON parsing error on game join

### DIFF
--- a/app/game/page.tsx
+++ b/app/game/page.tsx
@@ -64,16 +64,37 @@ export default function Game() {
         choices: '4',
       });
 
-      const res = await fetch(`/api/lighthouse-questions?${params.toString()}`, { 
-        cache: 'no-store' 
-      });
-      
-      if (!res.ok) {
-        const errorData = await res.json();
-        throw new Error(errorData.error || 'Failed to load question');
+      const endpoints = [
+        '/api/lighthouse-questions',
+        '/api/spacetime-questions'
+      ];
+      let lastError: Error | null = null;
+      let data: { questions: TriviaQuestion[] } | null = null;
+
+      for (const endpoint of endpoints) {
+        try {
+          const res = await fetch(`${endpoint}?${params.toString()}`, { cache: 'no-store' });
+          const contentType = res.headers.get('content-type') || '';
+          if (!res.ok) {
+            const message = contentType.includes('application/json')
+              ? (await res.json()).error || res.statusText
+              : await res.text();
+            throw new Error(message || 'Failed to load question');
+          }
+          if (!contentType.includes('application/json')) {
+            throw new Error('Invalid response format from questions API');
+          }
+          const parsed = await res.json();
+          data = parsed;
+          break;
+        } catch (err) {
+          lastError = err instanceof Error ? err : new Error('Failed to load question');
+        }
       }
 
-      const data: { questions: TriviaQuestion[] } = await res.json();
+      if (!data) {
+        throw lastError || new Error('Failed to load question');
+      }
 
       if (!data.questions?.length) {
         throw new Error('No questions available');

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -73,16 +73,37 @@ export default function Home() {
         choices: '4',
       });
 
-      const res = await fetch(`/api/lighthouse-questions?${params.toString()}`, { 
-        cache: 'no-store' 
-      });
-      
-      if (!res.ok) {
-        const errorData = await res.json();
-        throw new Error(errorData.error || 'Failed to load question');
+      const endpoints = [
+        '/api/lighthouse-questions',
+        '/api/spacetime-questions'
+      ];
+      let lastError: Error | null = null;
+      let data: { questions: TriviaQuestion[] } | null = null;
+
+      for (const endpoint of endpoints) {
+        try {
+          const res = await fetch(`${endpoint}?${params.toString()}`, { cache: 'no-store' });
+          const contentType = res.headers.get('content-type') || '';
+          if (!res.ok) {
+            const message = contentType.includes('application/json')
+              ? (await res.json()).error || res.statusText
+              : await res.text();
+            throw new Error(message || 'Failed to load question');
+          }
+          if (!contentType.includes('application/json')) {
+            throw new Error('Invalid response format from questions API');
+          }
+          const parsed = await res.json();
+          data = parsed;
+          break;
+        } catch (err) {
+          lastError = err instanceof Error ? err : new Error('Failed to load question');
+        }
       }
 
-      const data: { questions: TriviaQuestion[] } = await res.json();
+      if (!data) {
+        throw lastError || new Error('Failed to load question');
+      }
 
       if (!data.questions?.length) {
         throw new Error('No questions available');


### PR DESCRIPTION
Add content-type check and fallback for question loading to prevent JSON parsing errors from non-JSON responses.

The original code would attempt to parse any response from `/api/lighthouse-questions` as JSON, even if it was an HTML error page, leading to "Unexpected token '<'" errors. This change ensures responses are only parsed as JSON if their `Content-Type` header indicates JSON, and provides a fallback to `/api/spacetime-questions` for improved reliability.

---
<a href="https://cursor.com/background-agent?bcId=bc-e41916e5-9523-464e-a565-93dc1813ca30"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-e41916e5-9523-464e-a565-93dc1813ca30"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

