### PR TITLE
fix: correct prize pool display and suppress leave game warning

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -6,7 +6,7 @@
 
 # Contract Addresses (Base Mainnet)
 # Must match the live Trivia contract that emits PlayerJoined (paid verify filters logs by this address).
-NEXT_PUBLIC_TRIVIA_CONTRACT_ADDRESS=0xc166a6FB38636e8430d6A2Efb7A601c226659425
+NEXT_PUBLIC_TRIVIA_CONTRACT_ADDRESS=0xfF52Ed1DEb46C197aD7fce9DEC93ff9e987f8dB6
 NEXT_PUBLIC_USDC_ADDRESS=0x833589fcd6edb6e08f4c7c32d4f71b54bda02913
 
 # SpaceTimeDB Configuration (REQUIRED)

--- a/app/game/page.tsx
+++ b/app/game/page.tsx
@@ -166,7 +166,6 @@ export default function Game() {
   // Cleanup effect - leave game session when component unmounts
   useEffect(() => {
     return () => {
-      // Leave the game session when component unmounts
       leaveGame().catch((error: any) => {
         console.error('Error leaving game session on unmount:', error);
       });

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -88,6 +88,7 @@ function HomePage() {
     isLoading: contractBalanceLoading,
     error: contractBalanceError,
     refreshBalance: refreshContractUsdcBalance,
+    entryFee: contractEntryFee,
   } = useContractUSDCBalance();
 
   // Automatically switch to paid solo if trial is exhausted
@@ -1114,7 +1115,7 @@ function HomePage() {
                     </p>
                   </div>
                   <p className="font-['Audiowide:Regular',_sans-serif] text-[#000000] text-[9px] leading-snug max-w-full">
-                    On-chain prize pot. Grows by {ENTRY_FEE_USDC} USDC per paid entry. Updates every few seconds.
+                    On-chain prize pot. Grows by {contractEntryFee > 0 ? contractEntryFee : ENTRY_FEE_USDC} USDC per paid entry. Updates every few seconds.
                   </p>
                   <div className="content-stretch flex gap-4 items-center justify-start relative shrink-0 w-full" data-node-id="3:161">
                     <div className="font-['Audiowide:Regular',_sans-serif] leading-[0] not-italic relative shrink-0 text-[#000000] text-[8px] text-nowrap" data-node-id="3:159">

--- a/hooks/useContractUSDCBalance.ts
+++ b/hooks/useContractUSDCBalance.ts
@@ -1,10 +1,7 @@
 'use client';
 
 import { useState, useEffect, useCallback, useRef } from 'react';
-
-// Contract addresses (Base Mainnet)
-const TRIVIA_CONTRACT_ADDRESS = process.env.NEXT_PUBLIC_TRIVIA_CONTRACT_ADDRESS || '0xc166a6FB38636e8430d6A2Efb7A601c226659425';
-const USDC_CONTRACT_ADDRESS = '0x833589fcd6edb6e08f4c7c32d4f71b54bda02913';
+import { TRIVIA_CONTRACT_ADDRESS, USDC_CONTRACT_ADDRESS } from '@/lib/blockchain/contracts';
 
 // Public Base RPC endpoint — no wallet connection required
 const BASE_RPC_URL = process.env.NEXT_PUBLIC_BASE_RPC_URL || 'https://mainnet.base.org';
@@ -16,6 +13,7 @@ export interface ContractUSDCBalanceState {
   error: string | null;
   symbol: string;
   decimals: number;
+  entryFee: number;
 }
 
 // Helper function to decode ABI-encoded string
@@ -53,6 +51,7 @@ export function useContractUSDCBalance() {
     error: null,
     symbol: 'USDC',
     decimals: 6,
+    entryFee: 0,
   });
 
   const hasFetchedOnce = useRef(false);
@@ -79,10 +78,17 @@ export function useContractUSDCBalance() {
         data: '0x95d89b41',
       }, 'latest']);
 
+      // Read the on-chain entry fee from the Trivia contract (entryFee() selector: 0x072ea61c)
+      const entryFeeRaw = await rpcCall('eth_call', [{
+        to: TRIVIA_CONTRACT_ADDRESS,
+        data: '0x072ea61c',
+      }, 'latest']);
+
       const balanceWeiBigInt = BigInt(balanceWei);
       const decimalsNum = parseInt(decimals, 16);
       const symbolStr = decodeString(symbol);
       const balance = Number(balanceWeiBigInt) / (10 ** decimalsNum);
+      const entryFee = Number(BigInt(entryFeeRaw)) / (10 ** decimalsNum);
 
       hasFetchedOnce.current = true;
 
@@ -93,6 +99,7 @@ export function useContractUSDCBalance() {
         symbol: symbolStr,
         isLoading: false,
         error: null,
+        entryFee,
       });
     } catch (error) {
       console.error('Error fetching contract data:', error);

--- a/hooks/useGameSession.ts
+++ b/hooks/useGameSession.ts
@@ -206,7 +206,6 @@ export const useGameSession = (): UseGameSessionReturn => {
 
   const leaveGame = useCallback(async () => {
     if (!playerId) {
-      console.warn('No player ID to leave game');
       return;
     }
 


### PR DESCRIPTION
## Summary
- **Prize pool fix:** `useContractUSDCBalance` was reading from an old contract address (`0xc166a...`) instead of the current deployed contract (`0xfF52E...`). Imported `TRIVIA_CONTRACT_ADDRESS` from the single source of truth in `lib/blockchain/contracts.ts`.
- **Entry fee:** Now reads the entry fee dynamically from the on-chain contract instead of using the hardcoded `ENTRY_FEE_USDC` constant, so it always matches what's deployed.
- **Leave game warning:** Removed the noisy "No player ID to leave game" console warning that fired on every unmount when a player hadn't joined — this is expected behavior, not an error.
- **`.env.example`:** Updated to the current deployed contract address.

## Important
Check that the Vercel env var `NEXT_PUBLIC_TRIVIA_CONTRACT_ADDRESS` is set to `0xfF52Ed1DEb46C197aD7fce9DEC93ff9e987f8dB6` (the current contract). If it's set to the old address, the prize pool will still show the wrong balance.

## Test plan
- [ ] Verify prize pool on home screen reflects actual contract USDC balance
- [ ] Verify entry fee text shows the on-chain value (currently 1 USDC)
- [ ] Navigate to game and back — no "No player ID to leave game" in console
- [ ] Build passes (`bun run build`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)