### PR TITLE
feat: integrate Base Builder Code (ERC-8021)

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -50,6 +50,9 @@ ADMIN_API_SECRET=your_super_secret_admin_key_here
 # OPTIONAL CONFIGURATION
 ############################################
 
+# Base Builder Code (ERC-8021 transaction attribution)
+NEXT_PUBLIC_BUILDER_CODE=bc_5l04cy7v
+
 # OnchainKit API Key (for enhanced wallet features)
 NEXT_PUBLIC_ONCHAINKIT_API_KEY=your_onchainkit_api_key
 

--- a/hooks/usePaidGameEntry.ts
+++ b/hooks/usePaidGameEntry.ts
@@ -1,5 +1,5 @@
 import { useCallback, useMemo, useState, useEffect } from 'react';
-import { useWriteContract, useWaitForTransactionReceipt, usePublicClient, useAccount, useWalletClient } from 'wagmi';
+import { useWaitForTransactionReceipt, usePublicClient, useAccount, useWalletClient } from 'wagmi';
 import { useAccountCapabilities } from './useAccountCapabilities';
 import { usePaidGameEntryWithERC20Gas } from './usePaidGameEntryWithERC20Gas';
 import { TRIVIA_ABI, TRIVIA_CONTRACT_ADDRESS, USDC_ABI, USDC_CONTRACT_ADDRESS, ENTRY_FEE_USDC } from '@/lib/blockchain/contracts';
@@ -27,9 +27,8 @@ export function usePaidGameEntry() {
   const [currentStep, setCurrentStep] = useState<TransactionStep>('idle');
   const [finalTxHash, setFinalTxHash] = useState<string | undefined>(undefined);
   const [approvalHash, setApprovalHash] = useState<string | undefined>(undefined);
+  const [txError, setTxError] = useState<Error | null>(null);
 
-  // For EOA (Normal Account) - uses ETH for gas
-  const { error: eoaError } = useWriteContract();
   const publicClient = usePublicClient();
   const { data: walletClient } = useWalletClient();
   const { address } = useAccount();
@@ -63,6 +62,7 @@ export function usePaidGameEntry() {
   const joinGameEOA = useCallback(async () => {
     setFinalTxHash(undefined);
     setApprovalHash(undefined);
+    setTxError(null);
 
     try {
       if (!publicClient || !address) {
@@ -141,12 +141,14 @@ export function usePaidGameEntry() {
       setCurrentStep('complete');
     } catch (error) {
       console.error('❌ EOA transaction error:', error);
+      setTxError(error instanceof Error ? error : new Error(String(error)));
       throw error;
     }
   }, [walletClient, publicClient, address, supportsMagicSpend]);
 
   const joinGameBatch = useCallback(async () => {
     setFinalTxHash(undefined);
+    setTxError(null);
     setCurrentStep('batching_transaction');
 
     try {
@@ -232,6 +234,7 @@ export function usePaidGameEntry() {
 
     } catch (error) {
       console.error('❌ Batch transaction failed:', error);
+      setTxError(error instanceof Error ? error : new Error(String(error)));
       throw error;
     }
   }, [walletClient, address, publicClient, capabilities]);
@@ -281,17 +284,17 @@ export function usePaidGameEntry() {
 
   // Reset step on success/fail
   useEffect(() => {
-    if (result.success || eoaError) {
+    if (result.success || txError) {
       // If error, reset quickly. If success, maybe keep it 'complete' a bit?
       // Keeping existing logic
     }
-  }, [result, eoaError]);
+  }, [result, txError]);
 
 
   return {
     joinGameUniversal,
     result,
-    error: eoaError, // or batch error state if we add it
+    error: txError,
     isSmartAccount: !!supportsAtomicBatch,
     isEOA: !supportsAtomicBatch,
     isLoading: currentStep !== 'idle' && currentStep !== 'complete',

--- a/hooks/usePaidGameEntry.ts
+++ b/hooks/usePaidGameEntry.ts
@@ -1,10 +1,10 @@
 import { useCallback, useMemo, useState, useEffect } from 'react';
 import { useWriteContract, useWaitForTransactionReceipt, usePublicClient, useAccount, useWalletClient } from 'wagmi';
-import { createPaidGameCalls } from '@/lib/transaction/paidGameCalls';
 import { useAccountCapabilities } from './useAccountCapabilities';
 import { usePaidGameEntryWithERC20Gas } from './usePaidGameEntryWithERC20Gas';
 import { TRIVIA_ABI, TRIVIA_CONTRACT_ADDRESS, USDC_ABI, USDC_CONTRACT_ADDRESS, ENTRY_FEE_USDC } from '@/lib/blockchain/contracts';
-import { parseUnits, decodeErrorResult, encodeFunctionData, toHex } from 'viem';
+import { BUILDER_CODE_DATA_SUFFIX, appendBuilderCode } from '@/lib/blockchain/builderCode';
+import { parseUnits, encodeFunctionData, toHex } from 'viem';
 import { base } from 'wagmi/chains';
 
 interface GameEntryResult {
@@ -29,7 +29,7 @@ export function usePaidGameEntry() {
   const [approvalHash, setApprovalHash] = useState<string | undefined>(undefined);
 
   // For EOA (Normal Account) - uses ETH for gas
-  const { writeContractAsync: writeContractEOA, error: eoaError } = useWriteContract();
+  const { error: eoaError } = useWriteContract();
   const publicClient = usePublicClient();
   const { data: walletClient } = useWalletClient();
   const { address } = useAccount();
@@ -61,7 +61,6 @@ export function usePaidGameEntry() {
 
 
   const joinGameEOA = useCallback(async () => {
-    const calls = createPaidGameCalls();
     setFinalTxHash(undefined);
     setApprovalHash(undefined);
 
@@ -95,14 +94,23 @@ export function usePaidGameEntry() {
         console.log('✨ MagicSpend detected, skipping strict balance check');
       }
 
-      // Sequential Execution
+      if (!walletClient) {
+        throw new Error('Wallet client not available');
+      }
+
+      // Sequential Execution with Builder Code (ERC-8021) attribution
+      const entryFeeWei = parseUnits(ENTRY_FEE_USDC, 6);
+
       setCurrentStep('approving_usdc');
       console.log('EOA: Approving USDC...');
-      const approvalTxHash = await writeContractEOA({
-        address: calls[0].address,
-        abi: calls[0].abi,
-        functionName: calls[0].functionName as "approve",
-        args: calls[0].args as [`0x${string}`, bigint],
+      const approveData = appendBuilderCode(encodeFunctionData({
+        abi: USDC_ABI,
+        functionName: 'approve',
+        args: [TRIVIA_CONTRACT_ADDRESS as `0x${string}`, entryFeeWei],
+      }));
+      const approvalTxHash = await walletClient.sendTransaction({
+        to: USDC_CONTRACT_ADDRESS as `0x${string}`,
+        data: approveData,
       });
 
       setApprovalHash(approvalTxHash);
@@ -119,11 +127,14 @@ export function usePaidGameEntry() {
 
       setCurrentStep('joining_battle');
       console.log('EOA: Joining battle...');
-      const hash = await writeContractEOA({
-        address: calls[1].address,
-        abi: calls[1].abi,
-        functionName: calls[1].functionName as "joinBattle",
-        args: calls[1].args as [],
+      const joinData = appendBuilderCode(encodeFunctionData({
+        abi: TRIVIA_ABI,
+        functionName: 'joinBattle',
+        args: [],
+      }));
+      const hash = await walletClient.sendTransaction({
+        to: TRIVIA_CONTRACT_ADDRESS as `0x${string}`,
+        data: joinData,
       });
 
       setFinalTxHash(hash);
@@ -132,7 +143,7 @@ export function usePaidGameEntry() {
       console.error('❌ EOA transaction error:', error);
       throw error;
     }
-  }, [writeContractEOA, publicClient, address, supportsMagicSpend]);
+  }, [walletClient, publicClient, address, supportsMagicSpend]);
 
   const joinGameBatch = useCallback(async () => {
     setFinalTxHash(undefined);
@@ -179,7 +190,10 @@ export function usePaidGameEntry() {
           chainId: `0x${base.id.toString(16)}`, // 8453 in hex
           from: address,
           calls: batchCalls,
-          capabilities: capabilities // Pass discovered capabilities (paymaster etc)
+          capabilities: {
+            ...capabilities,
+            dataSuffix: { value: BUILDER_CODE_DATA_SUFFIX, optional: true }
+          }
         }]
       });
 

--- a/lib/blockchain/builderCode.ts
+++ b/lib/blockchain/builderCode.ts
@@ -1,0 +1,18 @@
+import type { Hex } from 'viem';
+
+// Base Builder Code: bc_5l04cy7v
+// ERC-8021 data suffix for transaction attribution
+// Format: <builder_code_hex><8021_marker>
+// - Builder code "bc_5l04cy7v" as ASCII hex: 62635f356c303463793776
+// - ERC-8021 marker (repeated): 80218021802180218021802180218021
+export const BUILDER_CODE_DATA_SUFFIX: Hex =
+  '0x62635f356c30346379377680218021802180218021802180218021';
+
+/**
+ * Appends the ERC-8021 builder code suffix to transaction calldata.
+ * The suffix is ignored by the EVM and read by offchain indexers.
+ */
+export function appendBuilderCode(data: Hex | undefined): Hex {
+  const calldata = data ?? '0x';
+  return `${calldata}${BUILDER_CODE_DATA_SUFFIX.slice(2)}` as Hex;
+}

--- a/lib/blockchain/builderCode.ts
+++ b/lib/blockchain/builderCode.ts
@@ -1,12 +1,12 @@
-import type { Hex } from 'viem';
+import { type Hex, stringToHex } from 'viem';
 
-// Base Builder Code: bc_5l04cy7v
-// ERC-8021 data suffix for transaction attribution
-// Format: <builder_code_hex><8021_marker>
-// - Builder code "bc_5l04cy7v" as ASCII hex: 62635f356c303463793776
-// - ERC-8021 marker (repeated): 80218021802180218021802180218021
-export const BUILDER_CODE_DATA_SUFFIX: Hex =
-  '0x62635f356c30346379377680218021802180218021802180218021';
+// Base Builder Code (ERC-8021 transaction attribution)
+// Derived from env var with fallback to default code
+const BUILDER_CODE = process.env.NEXT_PUBLIC_BUILDER_CODE || 'bc_5l04cy7v';
+const BUILDER_CODE_HEX = stringToHex(BUILDER_CODE).slice(2);
+const ERC8021_MARKER = '80218021802180218021802180218021';
+
+export const BUILDER_CODE_DATA_SUFFIX: Hex = `0x${BUILDER_CODE_HEX}${ERC8021_MARKER}` as Hex;
 
 /**
  * Appends the ERC-8021 builder code suffix to transaction calldata.

--- a/lib/transaction/batchTransactions.ts
+++ b/lib/transaction/batchTransactions.ts
@@ -1,6 +1,7 @@
 import { createBaseAccountSDK } from '@base-org/account';
 import { base } from 'viem/chains';
 import { Interface } from 'ethers';
+import { BUILDER_CODE_DATA_SUFFIX } from '@/lib/blockchain/builderCode';
 
 export interface BatchCall {
   to: string;
@@ -60,7 +61,10 @@ export async function sendBatchCalls(options: BatchTransactionOptions): Promise<
           value: call.value || '0x0'
         })),
         atomicRequired,
-        gasless
+        gasless,
+        capabilities: {
+          dataSuffix: { value: BUILDER_CODE_DATA_SUFFIX, optional: true }
+        }
       }
     })) as { transactionHash?: string; hash?: string };
 


### PR DESCRIPTION
## Summary
- Adds ERC-8021 builder code (`bc_5l04cy7v`) attribution to all onchain transactions
- **Batch path** (Smart Wallet): adds `dataSuffix` capability to `wallet_sendCalls` in both `usePaidGameEntry` and `batchTransactions`
- **EOA path**: refactors `writeContractAsync` calls to `walletClient.sendTransaction` with `encodeFunctionData` + `appendBuilderCode` suffix
- New `lib/blockchain/builderCode.ts` with pre-computed hex suffix and helper function

## Risk notes
- The ERC-8021 suffix is appended to the **end** of calldata — the EVM ignores trailing bytes, so contract execution is unchanged
- `dataSuffix` uses `optional: true` so wallets that don't support it silently ignore it
- EOA refactor produces identical ABI-encoded calldata as before, just via `encodeFunctionData` instead of `writeContractAsync`

## Test plan
- [ ] Send a paid game entry via Smart Wallet (batch path) — verify on Basescan that calldata ends with `80218021802180218021802180218021`
- [ ] Send a paid game entry via EOA (sequential path) — verify both approve and joinBattle tx calldata contain the suffix
- [ ] Use [Builder Code Validation tool](https://builder-code-checker.vercel.app/) to confirm attribution
- [ ] Check base.dev dashboard for attribution counts

🤖 Generated with [Claude Code](https://claude.com/claude-code)