### PR TITLE
feat: production-ready prize pool, session data, and CRE safety

### DIFF
--- a/app/page.tsx
+++ b/app/page.tsx
@@ -90,6 +90,10 @@ function HomePage() {
     refreshBalance: refreshContractUsdcBalance,
     entryFee: contractEntryFee,
     sessionPrizePool,
+    playerCount: onChainPlayerCount,
+    isSessionActive: onChainSessionActive,
+    lastSessionTime: onChainLastSessionTime,
+    sessionInterval: onChainSessionInterval,
   } = useContractUSDCBalance();
 
   // Automatically switch to paid solo if trial is exhausted
@@ -1115,12 +1119,20 @@ function HomePage() {
                     </p>
                   </div>
                   <p className="font-['Audiowide:Regular',_sans-serif] text-[#000000] text-[9px] leading-snug max-w-full">
-                    On-chain prize pot. Grows by {contractEntryFee > 0 ? contractEntryFee : ENTRY_FEE_USDC} USDC per paid entry. Updates every few seconds.
+                    Current session prize pool. Grows by {contractEntryFee > 0 ? contractEntryFee : ENTRY_FEE_USDC} USDC per paid entry.
                   </p>
+                  {/* Prize distribution breakdown */}
+                  {!contractBalanceLoading && sessionPrizePool > 0 && (
+                    <div className="flex gap-3 w-full font-['Audiowide:Regular',_sans-serif] text-[#000000] text-[8px]">
+                      <span>1st: {(sessionPrizePool * 0.9 * 0.6).toFixed(2)}</span>
+                      <span>2nd: {(sessionPrizePool * 0.9 * 0.3).toFixed(2)}</span>
+                      <span>3rd: {(sessionPrizePool * 0.9 * 0.1).toFixed(2)}</span>
+                    </div>
+                  )}
                   <div className="content-stretch flex gap-4 items-center justify-start relative shrink-0 w-full" data-node-id="3:161">
                     <div className="font-['Audiowide:Regular',_sans-serif] leading-[0] not-italic relative shrink-0 text-[#000000] text-[8px] text-nowrap" data-node-id="3:159">
                       <p className="leading-[normal] whitespace-pre">
-                        {getPlayerCountDisplay()}
+                        {onChainPlayerCount > 0 ? `${onChainPlayerCount} on-chain players` : getPlayerCountDisplay()}
                       </p>
                     </div>
                   </div>

--- a/chainlink-cre-workflows/weekly-prize-distribution/main.ts
+++ b/chainlink-cre-workflows/weekly-prize-distribution/main.ts
@@ -116,8 +116,22 @@ const onWeeklyDistribution = (
     }
   }
 
-  // Step 3: Call distributePrizes()
-  runtime.log("Conditions met. Executing distributePrizes()...")
+  // Step 3: Verify player scores exist before distribution
+  // The contract's _findTopPlayers() sorts by playerScores mapping.
+  // If no scores have been submitted, distribution would give prizes to arbitrary players.
+  const hasScores = verifyScoresExist(runtime, network.chainSelector.selector, evmConfig)
+
+  if (!hasScores) {
+    const reason = `No player scores submitted for session ${sessionInfo.sessionCounter}. Scores must be set via submitScores() before distribution. Skipping to prevent incorrect prize allocation.`
+    runtime.log(reason)
+    return {
+      distributionExecuted: false,
+      reason,
+    }
+  }
+
+  // Step 4: Call distributePrizes()
+  runtime.log("All conditions met including score verification. Executing distributePrizes()...")
 
   try {
     const txHash = callDistributePrizes(
@@ -281,6 +295,74 @@ function readSessionInfo(
     prizesDistributed,
     sessionCounter, // Include sessionCounter in return value
   }
+}
+
+// Verify that at least one player has a non-zero score submitted on-chain.
+// Without scores, _findTopPlayers() would return players in arbitrary order.
+function verifyScoresExist(
+  runtime: Runtime<Config>,
+  chainSelector: bigint,
+  evmConfig: EvmConfig
+): boolean {
+  const evmClient = new cre.capabilities.EVMClient(chainSelector)
+  const contractAddress = evmConfig.contractAddress as `0x${string}`
+
+  // First get the current players list
+  const getCurrentPlayersCall = encodeFunctionData({
+    abi: [{ inputs: [], name: "getCurrentPlayers", outputs: [{ type: "address[]" }], stateMutability: "view", type: "function" }],
+    functionName: "getCurrentPlayers",
+  })
+  const playersResult = evmClient
+    .callContract(runtime, {
+      call: encodeCallMsg({ from: zeroAddress, to: contractAddress, data: getCurrentPlayersCall }),
+      blockNumber: LAST_FINALIZED_BLOCK_NUMBER,
+    })
+    .result()
+  const players = decodeFunctionResult({
+    abi: [{ inputs: [], name: "getCurrentPlayers", outputs: [{ type: "address[]" }], stateMutability: "view", type: "function" }],
+    functionName: "getCurrentPlayers",
+    data: bytesToHex(playersResult.data),
+  }) as `0x${string}`[]
+
+  if (players.length === 0) {
+    runtime.log("No players found in current session")
+    return false
+  }
+
+  // Check scores for up to the first 10 players (sufficient to verify scores were submitted)
+  const playersToCheck = players.slice(0, Math.min(players.length, 10))
+  let hasAnyScore = false
+
+  for (const player of playersToCheck) {
+    const getScoreCall = encodeFunctionData({
+      abi: [{ inputs: [{ name: "player", type: "address" }], name: "getPlayerScore", outputs: [{ type: "uint256" }], stateMutability: "view", type: "function" }],
+      functionName: "getPlayerScore",
+      args: [player],
+    })
+    const scoreResult = evmClient
+      .callContract(runtime, {
+        call: encodeCallMsg({ from: zeroAddress, to: contractAddress, data: getScoreCall }),
+        blockNumber: LAST_FINALIZED_BLOCK_NUMBER,
+      })
+      .result()
+    const score = decodeFunctionResult({
+      abi: [{ inputs: [{ name: "player", type: "address" }], name: "getPlayerScore", outputs: [{ type: "uint256" }], stateMutability: "view", type: "function" }],
+      functionName: "getPlayerScore",
+      data: bytesToHex(scoreResult.data),
+    }) as bigint
+
+    if (score > BigInt(0)) {
+      hasAnyScore = true
+      runtime.log(`Player ${player} has score: ${score}`)
+      break
+    }
+  }
+
+  if (!hasAnyScore) {
+    runtime.log(`Checked ${playersToCheck.length} players - no scores found`)
+  }
+
+  return hasAnyScore
 }
 
 // Call distributePrizes() on the contract

--- a/chainlink-cre-workflows/weekly-prize-distribution/main.ts
+++ b/chainlink-cre-workflows/weekly-prize-distribution/main.ts
@@ -329,8 +329,10 @@ function verifyScoresExist(
     return false
   }
 
-  // Check scores for up to the first 10 players (sufficient to verify scores were submitted)
-  const playersToCheck = players.slice(0, Math.min(players.length, 10))
+  // Check all players for scores. The contract caps at MAX_PLAYERS (100),
+  // and submitScores() sets all scores atomically, so if any player has a
+  // score they all should. We check all to be safe.
+  const playersToCheck = players
   let hasAnyScore = false
 
   for (const player of playersToCheck) {

--- a/components/game/PrizePoolCard.tsx
+++ b/components/game/PrizePoolCard.tsx
@@ -82,35 +82,30 @@ export default function PrizePoolCard({
           </div>
         </div>
 
-        {/* Prize Distribution */}
+        {/* Prize Distribution — matches deployed TriviaBattle contract (10% platform fee, then 60/30/10) */}
         <div className="bg-black/20 rounded-lg p-4">
           <h4 className="text-sm font-semibold text-gray-200 mb-3">Prize Distribution</h4>
-          <div className="grid grid-cols-2 gap-3">
+          <div className="grid grid-cols-3 gap-3">
             <div className="text-center">
               <div className="text-yellow-400 font-bold text-lg">
                 {formatCurrency(prizePool.distribution.first)}
               </div>
-              <div className="text-xs text-gray-300">1st Place</div>
+              <div className="text-xs text-gray-300">1st (60%)</div>
             </div>
             <div className="text-center">
               <div className="text-gray-400 font-bold text-lg">
                 {formatCurrency(prizePool.distribution.second)}
               </div>
-              <div className="text-xs text-gray-300">2nd Place</div>
+              <div className="text-xs text-gray-300">2nd (30%)</div>
             </div>
             <div className="text-center">
               <div className="text-amber-600 font-bold text-lg">
                 {formatCurrency(prizePool.distribution.third)}
               </div>
-              <div className="text-xs text-gray-300">3rd Place</div>
-            </div>
-            <div className="text-center">
-              <div className="text-blue-400 font-bold text-lg">
-                {formatCurrency(prizePool.distribution.participation)}
-              </div>
-              <div className="text-xs text-gray-300">Participation</div>
+              <div className="text-xs text-gray-300">3rd (10%)</div>
             </div>
           </div>
+          <div className="text-xs text-gray-400 mt-2 text-center">10% platform fee deducted before distribution</div>
         </div>
 
         {/* Participants */}

--- a/components/game/SessionCountdown.tsx
+++ b/components/game/SessionCountdown.tsx
@@ -3,14 +3,18 @@
 import { Clock } from 'lucide-react';
 import { Card, CardContent } from '@/components/ui/card';
 import { useSessionCountdown } from '@/hooks/useSessionCountdown';
-import { useTriviaContract } from '@/hooks/useTriviaContract';
+import { useContractUSDCBalance } from '@/hooks/useContractUSDCBalance';
 
 export default function SessionCountdown() {
-  const { sessionActive } = useTriviaContract();
-  // useTriviaContract (Base Account) does not expose lastSessionTime/sessionInterval yet
-  const countdown = useSessionCountdown(undefined, undefined);
+  const { isSessionActive, lastSessionTime, sessionInterval } = useContractUSDCBalance();
 
-  if (sessionActive || !countdown || countdown.isExpired) {
+  // Convert to bigint for useSessionCountdown (expects bigint | undefined)
+  const lastSessionTimeBigInt = lastSessionTime > 0 ? BigInt(lastSessionTime) : undefined;
+  const sessionIntervalBigInt = sessionInterval > 0 ? BigInt(sessionInterval) : undefined;
+
+  const countdown = useSessionCountdown(lastSessionTimeBigInt, sessionIntervalBigInt);
+
+  if (isSessionActive || !countdown || countdown.isExpired) {
     return null;
   }
 

--- a/hooks/useContractUSDCBalance.ts
+++ b/hooks/useContractUSDCBalance.ts
@@ -1,6 +1,7 @@
 'use client';
 
 import { useState, useEffect, useCallback, useRef } from 'react';
+import { decodeFunctionResult } from 'viem';
 import { TRIVIA_CONTRACT_ADDRESS, USDC_CONTRACT_ADDRESS } from '@/lib/blockchain/contracts';
 
 // Public Base RPC endpoint — no wallet connection required
@@ -101,11 +102,15 @@ export function useContractUSDCBalance() {
       const sessionInterval = Number(BigInt(sessionIntervalRaw));
       const isSessionActive = BigInt(isSessionActiveRaw) !== BigInt(0);
 
-      // getCurrentPlayers() returns a dynamic array — parse length from ABI encoding
-      // Format: offset (32 bytes) + length (32 bytes) + elements
+      // Decode getCurrentPlayers() using viem for proper ABI handling
       let playerCount = 0;
-      if (currentPlayersRaw && currentPlayersRaw.length >= 130) {
-        playerCount = parseInt(currentPlayersRaw.slice(66, 130), 16);
+      if (currentPlayersRaw && currentPlayersRaw !== '0x') {
+        const players = decodeFunctionResult({
+          abi: [{ inputs: [], name: 'getCurrentPlayers', outputs: [{ type: 'address[]' }], stateMutability: 'view', type: 'function' }],
+          functionName: 'getCurrentPlayers',
+          data: currentPlayersRaw as `0x${string}`,
+        }) as `0x${string}`[];
+        playerCount = players.length;
       }
 
       hasFetchedOnce.current = true;

--- a/hooks/useContractUSDCBalance.ts
+++ b/hooks/useContractUSDCBalance.ts
@@ -16,6 +16,10 @@ export interface ContractUSDCBalanceState {
   entryFee: number;
   sessionPrizePool: number;
   sessionPrizePoolWei: bigint;
+  lastSessionTime: number;
+  sessionInterval: number;
+  playerCount: number;
+  isSessionActive: boolean;
 }
 
 // Helper function to decode ABI-encoded string
@@ -56,6 +60,10 @@ export function useContractUSDCBalance() {
     entryFee: 0,
     sessionPrizePool: 0,
     sessionPrizePoolWei: BigInt(0),
+    lastSessionTime: 0,
+    sessionInterval: 0,
+    playerCount: 0,
+    isSessionActive: false,
   });
 
   const hasFetchedOnce = useRef(false);
@@ -67,34 +75,20 @@ export function useContractUSDCBalance() {
     }
 
     try {
-      const balanceWei = await rpcCall('eth_call', [{
-        to: USDC_CONTRACT_ADDRESS,
-        data: `0x70a08231${TRIVIA_CONTRACT_ADDRESS.slice(2).padStart(64, '0')}`,
-      }, 'latest']);
-
-      const decimals = await rpcCall('eth_call', [{
-        to: USDC_CONTRACT_ADDRESS,
-        data: '0x313ce567',
-      }, 'latest']);
-
-      const symbol = await rpcCall('eth_call', [{
-        to: USDC_CONTRACT_ADDRESS,
-        data: '0x95d89b41',
-      }, 'latest']);
-
-      // Read the on-chain entry fee from the Trivia contract (entryFee() selector: 0x072ea61c)
-      const entryFeeRaw = await rpcCall('eth_call', [{
-        to: TRIVIA_CONTRACT_ADDRESS,
-        data: '0x072ea61c',
-      }, 'latest']);
-
-      // Read the current session prize pool (currentSessionPrizePool() selector: 0x1a7dd42a)
-      // This reflects the actual prize pool for the active session, unlike balanceOf which
-      // includes pending withdrawals and platform fees
-      const sessionPrizePoolRaw = await rpcCall('eth_call', [{
-        to: TRIVIA_CONTRACT_ADDRESS,
-        data: '0x1a7dd42a',
-      }, 'latest']);
+      // Batch all RPC calls in parallel for better latency
+      const [balanceWei, decimals, symbol, entryFeeRaw, sessionPrizePoolRaw, lastSessionTimeRaw, sessionIntervalRaw, currentPlayersRaw, isSessionActiveRaw] = await Promise.all([
+        // USDC contract reads
+        rpcCall('eth_call', [{ to: USDC_CONTRACT_ADDRESS, data: `0x70a08231${TRIVIA_CONTRACT_ADDRESS.slice(2).padStart(64, '0')}` }, 'latest']),
+        rpcCall('eth_call', [{ to: USDC_CONTRACT_ADDRESS, data: '0x313ce567' }, 'latest']),
+        rpcCall('eth_call', [{ to: USDC_CONTRACT_ADDRESS, data: '0x95d89b41' }, 'latest']),
+        // Trivia contract reads
+        rpcCall('eth_call', [{ to: TRIVIA_CONTRACT_ADDRESS, data: '0x072ea61c' }, 'latest']), // entryFee()
+        rpcCall('eth_call', [{ to: TRIVIA_CONTRACT_ADDRESS, data: '0x1a7dd42a' }, 'latest']), // currentSessionPrizePool()
+        rpcCall('eth_call', [{ to: TRIVIA_CONTRACT_ADDRESS, data: '0xcf0902af' }, 'latest']), // lastSessionTime()
+        rpcCall('eth_call', [{ to: TRIVIA_CONTRACT_ADDRESS, data: '0x36dc7bc0' }, 'latest']), // sessionInterval()
+        rpcCall('eth_call', [{ to: TRIVIA_CONTRACT_ADDRESS, data: '0x02cac05c' }, 'latest']), // getCurrentPlayers()
+        rpcCall('eth_call', [{ to: TRIVIA_CONTRACT_ADDRESS, data: '0x031a65f4' }, 'latest']), // isSessionActive()
+      ]);
 
       const balanceWeiBigInt = BigInt(balanceWei);
       const decimalsNum = parseInt(decimals, 16);
@@ -103,6 +97,16 @@ export function useContractUSDCBalance() {
       const entryFee = Number(BigInt(entryFeeRaw)) / (10 ** decimalsNum);
       const sessionPrizePoolWei = (sessionPrizePoolRaw && sessionPrizePoolRaw !== '0x') ? BigInt(sessionPrizePoolRaw) : BigInt(0);
       const sessionPrizePool = Number(sessionPrizePoolWei) / (10 ** decimalsNum);
+      const lastSessionTime = Number(BigInt(lastSessionTimeRaw));
+      const sessionInterval = Number(BigInt(sessionIntervalRaw));
+      const isSessionActive = BigInt(isSessionActiveRaw) !== BigInt(0);
+
+      // getCurrentPlayers() returns a dynamic array — parse length from ABI encoding
+      // Format: offset (32 bytes) + length (32 bytes) + elements
+      let playerCount = 0;
+      if (currentPlayersRaw && currentPlayersRaw.length >= 130) {
+        playerCount = parseInt(currentPlayersRaw.slice(66, 130), 16);
+      }
 
       hasFetchedOnce.current = true;
 
@@ -116,6 +120,10 @@ export function useContractUSDCBalance() {
         entryFee,
         sessionPrizePool,
         sessionPrizePoolWei,
+        lastSessionTime,
+        sessionInterval,
+        playerCount,
+        isSessionActive,
       });
     } catch (error) {
       console.error('Error fetching contract data:', error);

--- a/types/game.ts
+++ b/types/game.ts
@@ -96,16 +96,15 @@ export interface PrizePool {
   totalAmount: number;
   entryFee: number;
   participants: number;
-  trialParticipants: number; // New field to track trial participants
+  trialParticipants: number;
   distribution: {
     first: number;
     second: number;
     third: number;
-    participation: number;
+    participation?: number; // Not used in deployed TriviaBattle contract (60/30/10 split)
   };
   contractAddress: string;
-  isEqualOpportunity: boolean; // New field to indicate equal opportunity for trial players
-  // No maximum limit - prize pool scales with number of participants
+  isEqualOpportunity: boolean;
 }
 
 export interface PlayerStats {


### PR DESCRIPTION
## Summary
- **Fix prize pool display**: Home page now shows `currentSessionPrizePool` (actual session funds) instead of total contract USDC balance which included platform fees
- **Add session data to hook**: `useContractUSDCBalance` now reads `lastSessionTime`, `sessionInterval`, `playerCount`, and `isSessionActive` — all batched in `Promise.all` for better latency
- **Connect session countdown**: `SessionCountdown` component now uses real contract timing data instead of `undefined` values
- **CRE distribution safety**: Added score verification to Chainlink CRE weekly workflow — skips distribution if no player scores have been submitted, preventing incorrect prize allocation
- **Fix distribution percentages**: Updated `PrizePoolCard` and `PrizePool` type to match deployed contract (60/30/10 split, 10% platform fee)

## Test plan
- [ ] Verify home page displays `sessionPrizePool` (should be 0 when no active session, increases by ~0.9 USDC per paid entry)
- [ ] Confirm distribution breakdown (1st/2nd/3rd) renders when prize pool > 0
- [ ] Check on-chain player count displays correctly
- [ ] Verify session countdown renders between sessions (when `lastSessionTime + sessionInterval > now`)
- [ ] Review CRE workflow logic: `verifyScoresExist()` reads `getPlayerScore()` and skips if all zero
- [ ] Run `npm run build` — passes with no type errors

🤖 Generated with [Claude Code](https://claude.com/claude-code)