### PR TITLE
fix: resolve trial flow, replay, and Base sign-in loop

### DIFF
--- a/app/page.tsx
+++ b/app/page.tsx
@@ -722,28 +722,14 @@ function HomePage() {
                 </div>
               )}
 
-              {/* Trial Exhausted Notice */}
-              {trialStatus.requiresWallet && (
+              {/* Trial Exhausted Notice - directs user to home for paid modes */}
+              {trialStatus.requiresWallet && completedAsTrial && (
                 <div className="bg-purple-500/10 border border-purple-500/20 rounded-lg p-4 mb-6">
                   <div className="text-purple-300 text-sm">
-                    <p className="font-medium mb-2">🎯 Trial Games Complete!</p>
-                    <p className="text-purple-200/80 mb-3">
-                      {`You've used all your free games. Connect your wallet to continue playing and earn rewards!`}
+                    <p className="font-medium mb-2">Want to keep playing?</p>
+                    <p className="text-purple-200/80">
+                      Head back to the home screen to connect your wallet and play for real prizes!
                     </p>
-                    <div className="flex justify-center">
-                      <div className="flex flex-col items-center gap-2">
-                        <BaseAccountButton
-                          className="!bg-gradient-to-r !from-purple-500 !to-pink-500 hover:!from-purple-600 hover:!to-pink-600 !text-white !px-6 !py-2 !rounded-lg !text-sm !font-semibold"
-                          onConnect={() => setShowPayment(true)}
-                        />
-                        <button
-                          onClick={() => setShowPayment(true)}
-                          className="w-full text-left px-4 py-2 text-white hover:text-white hover:bg-white/10 transition-colors rounded-md"
-                        >
-                          💳 Buy USDC
-                        </button>
-                      </div>
-                    </div>
                   </div>
                 </div>
               )}
@@ -776,7 +762,7 @@ function HomePage() {
               onClick={handleBackToHome}
               className="bg-purple-600 hover:bg-purple-700 text-white px-6 py-3 rounded-lg text-lg"
             >
-              Play Again
+              Back to Home
             </button>
           </div>
         </div>

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -511,8 +511,8 @@ function HomePage() {
     );
   }
 
-  // Show trial completion screen if user has used all free games
-  if (trialStatus.requiresWallet) {
+  // Show trial completion screen if user has used all free games (but not if a game just finished)
+  if (trialStatus.requiresWallet && !gameCompleted) {
     return (
       <div className="bg-[#000000] min-h-screen w-full flex items-center justify-center px-4">
         <div className="w-full max-w-[390px] md:max-w-[428px]">

--- a/components/base-account/AutoSpendManager.tsx
+++ b/components/base-account/AutoSpendManager.tsx
@@ -64,6 +64,7 @@ export default function AutoSpendManager() {
   };
 
   useEffect(() => {
+    if (!isConnected) return;
     fetchStatus();
     const interval = setInterval(fetchStatus, 15000); // Refresh every 15 seconds
     return () => clearInterval(interval);

--- a/components/game/GameEntry.tsx
+++ b/components/game/GameEntry.tsx
@@ -284,6 +284,12 @@ export default function GameEntry({
 
     setIsStartingGame(true);
 
+    if (playerModeChoice === 'trial' && !trialStatus.isTrialActive) {
+      setError('Your free trial has been used. Please select a paid mode.');
+      setIsStartingGame(false);
+      return;
+    }
+
     if (playerModeChoice === 'trial' && trialStatus.isTrialActive) {
       // Trial player - start game immediately
       console.log('Starting trial game');

--- a/components/game/SpacetimeTriviaGame.tsx
+++ b/components/game/SpacetimeTriviaGame.tsx
@@ -305,7 +305,7 @@ export default function SpacetimeTriviaGame({ className = '', onWalletConnect, o
   };
 
   // Show trial completion screen if user has used all free games
-  if (trialStatus.requiresWallet) {
+  if (trialStatus.requiresWallet && gameState.gameStatus === 'waiting') {
     return (
       <div className={`max-w-4xl mx-auto ${className}`}>
         <Card className="shadow-lg border-0 bg-gradient-to-br from-white to-gray-50">

--- a/hooks/useBaseAccount.ts
+++ b/hooks/useBaseAccount.ts
@@ -243,7 +243,23 @@ export function useBaseAccount(): UseBaseAccountReturn {
           }
         }
       } catch (error) {
-        console.error('Error checking Base Account connection:', error);
+        // Error 4100 or similar means not connected — silently handle
+        // Return prev unchanged when already disconnected to prevent re-render loop
+        setState(prev => {
+          if (prev.isConnected) {
+            return {
+              ...prev,
+              address: null,
+              subAccountAddress: null,
+              universalAddress: null,
+              isConnected: false,
+              isConnecting: false,
+              chainId: null,
+              error: null,
+            };
+          }
+          return prev;
+        });
       }
     };
 

--- a/hooks/useUSDCBalance.ts
+++ b/hooks/useUSDCBalance.ts
@@ -140,15 +140,15 @@ export function useUSDCBalance() {
 
   // Update state when balance changes
   useEffect(() => {
-    if (provider) {
+    if (provider && isConnected && address) {
       fetchUSDCBalance();
-      
+
       // Set up periodic refetch every 30 seconds
       const interval = setInterval(fetchUSDCBalance, 30000);
-      
+
       return () => clearInterval(interval);
     }
-  }, [fetchUSDCBalance, provider]);
+  }, [fetchUSDCBalance, provider, isConnected, address]);
 
   const refreshBalance = useCallback(() => {
     fetchUSDCBalance();

--- a/lib/base-account/auth.ts
+++ b/lib/base-account/auth.ts
@@ -86,15 +86,20 @@ Issued At: ${new Date().toISOString()}`;
  */
 async function getAccountAddress(): Promise<string> {
   const provider = getProvider();
-  const accounts = (await provider.request({
-    method: 'eth_accounts',
-    params: []
-  })) as string[];
-  
+  let accounts: string[] = [];
+  try {
+    accounts = (await provider.request({
+      method: 'eth_accounts',
+      params: []
+    })) as string[];
+  } catch {
+    throw new Error('No account connected');
+  }
+
   if (!accounts || accounts.length === 0) {
     throw new Error('No account connected');
   }
-  
+
   return accounts[0];
 }
 

--- a/lib/base-account/autoSpend.ts
+++ b/lib/base-account/autoSpend.ts
@@ -10,6 +10,37 @@ if (!USDC_ADDRESS) {
   console.error('Missing environment variable: NEXT_PUBLIC_USDC_ADDRESS');
 }
 
+function getAutoSpendSDK() {
+  return createBaseAccountSDK({
+    appName: 'BEAT ME',
+    appLogoUrl: 'https://base.org/logo.png',
+    appChainIds: [base.id],
+    subAccounts: { creation: 'on-connect', defaultAccount: 'sub' },
+    paymasterUrls: process.env.NEXT_PUBLIC_PAYMASTER_AND_BUNDLER_ENDPOINT ? [process.env.NEXT_PUBLIC_PAYMASTER_AND_BUNDLER_ENDPOINT] : undefined,
+  });
+}
+
+/**
+ * Safely get connected accounts from provider.
+ * Returns null if no accounts are connected or if eth_accounts throws (e.g. error 4100).
+ */
+async function getConnectedAccounts(provider: ReturnType<ReturnType<typeof getAutoSpendSDK>['getProvider']>): Promise<{ universal: string; subAccount: string } | null> {
+  let accounts: string[] = [];
+  try {
+    accounts = (await provider.request({ method: 'eth_accounts', params: [] })) as string[];
+  } catch {
+    return null;
+  }
+
+  if (accounts.length === 0) return null;
+
+  const universal = accounts[0];
+  const subAccount = accounts[1];
+  if (!subAccount) return null;
+
+  return { universal, subAccount };
+}
+
 /**
  * Configures Auto Spend Permissions for the current Base Account.
  * This allows the sub-account to automatically spend from the universal account.
@@ -19,41 +50,20 @@ export async function configureAutoSpend(): Promise<{
   transactionHash?: string;
   error?: string;
 }> {
-  const sdk = createBaseAccountSDK({
-    appName: 'BEAT ME',
-    appLogoUrl: 'https://base.org/logo.png',
-    appChainIds: [base.id],
-    subAccounts: { creation: 'on-connect', defaultAccount: 'sub' },
-    paymasterUrls: process.env.NEXT_PUBLIC_PAYMASTER_AND_BUNDLER_ENDPOINT ? [process.env.NEXT_PUBLIC_PAYMASTER_AND_BUNDLER_ENDPOINT] : undefined,
-  });
-
   if (!USDC_ADDRESS) {
     return { success: false, error: 'USDC address not configured' };
   }
 
   try {
-    const provider = sdk.getProvider();
-    let accounts: string[] = [];
-    try {
-      accounts = (await provider.request({ method: 'eth_accounts', params: [] })) as string[];
-    } catch {
+    const provider = getAutoSpendSDK().getProvider();
+    const connected = await getConnectedAccounts(provider);
+    if (!connected) {
       return { success: false, error: 'No Base Account connected' };
-    }
-
-    if (accounts.length === 0) {
-      return { success: false, error: 'No Base Account connected' };
-    }
-
-    const universalAddress = accounts[0];
-    const subAccountAddress = accounts[1];
-
-    if (!subAccountAddress) {
-      return { success: false, error: 'No sub-account found' };
     }
 
     console.log('Configuring Auto Spend Permissions:', {
-      universal: universalAddress,
-      subAccount: subAccountAddress,
+      universal: connected.universal,
+      subAccount: connected.subAccount,
       amount: AUTO_SPEND_AMOUNT,
       duration: AUTO_SPEND_DURATION
     });
@@ -63,7 +73,7 @@ export async function configureAutoSpend(): Promise<{
       method: 'wallet_requestSpendPermission',
       params: {
         tokenAddress: USDC_ADDRESS,
-        spenderAddress: subAccountAddress,
+        spenderAddress: connected.subAccount,
         amount: parseUnits(AUTO_SPEND_AMOUNT, 6).toString(),
         duration: AUTO_SPEND_DURATION,
         autoSpend: true // Enable auto-spend functionality
@@ -95,36 +105,15 @@ export async function checkAutoSpendStatus(): Promise<{
   spender?: string;
   error?: string;
 }> {
-  const sdk = createBaseAccountSDK({
-    appName: 'BEAT ME',
-    appLogoUrl: 'https://base.org/logo.png',
-    appChainIds: [base.id],
-    subAccounts: { creation: 'on-connect', defaultAccount: 'sub' },
-    paymasterUrls: process.env.NEXT_PUBLIC_PAYMASTER_AND_BUNDLER_ENDPOINT ? [process.env.NEXT_PUBLIC_PAYMASTER_AND_BUNDLER_ENDPOINT] : undefined,
-  });
-
   if (!USDC_ADDRESS) {
     return { isConfigured: false, error: 'USDC address not configured' };
   }
 
   try {
-    const provider = sdk.getProvider();
-    let accounts: string[] = [];
-    try {
-      accounts = (await provider.request({ method: 'eth_accounts', params: [] })) as string[];
-    } catch {
+    const provider = getAutoSpendSDK().getProvider();
+    const connected = await getConnectedAccounts(provider);
+    if (!connected) {
       return { isConfigured: false, error: 'No Base Account connected' };
-    }
-
-    if (accounts.length === 0) {
-      return { isConfigured: false, error: 'No Base Account connected' };
-    }
-
-    const universalAddress = accounts[0];
-    const subAccountAddress = accounts[1];
-
-    if (!subAccountAddress) {
-      return { isConfigured: false, error: 'No sub-account found' };
     }
 
     // Check current allowance
@@ -134,13 +123,13 @@ export async function checkAutoSpendStatus(): Promise<{
       new JsonRpcProvider()
     );
 
-    const allowance = await tokenContract.allowance(universalAddress, subAccountAddress);
+    const allowance = await tokenContract.allowance(connected.universal, connected.subAccount);
     const requiredAllowance = parseUnits(AUTO_SPEND_AMOUNT, 6);
 
     return {
       isConfigured: allowance.gte(requiredAllowance),
       allowance: formatUnits(allowance, 6),
-      spender: subAccountAddress
+      spender: connected.subAccount
     };
 
   } catch (error: any) {
@@ -160,41 +149,20 @@ export async function revokeAutoSpend(): Promise<{
   transactionHash?: string;
   error?: string;
 }> {
-  const sdk = createBaseAccountSDK({
-    appName: 'BEAT ME',
-    appLogoUrl: 'https://base.org/logo.png',
-    appChainIds: [base.id],
-    subAccounts: { creation: 'on-connect', defaultAccount: 'sub' },
-    paymasterUrls: process.env.NEXT_PUBLIC_PAYMASTER_AND_BUNDLER_ENDPOINT ? [process.env.NEXT_PUBLIC_PAYMASTER_AND_BUNDLER_ENDPOINT] : undefined,
-  });
-
   if (!USDC_ADDRESS) {
     return { success: false, error: 'USDC address not configured' };
   }
 
   try {
-    const provider = sdk.getProvider();
-    let accounts: string[] = [];
-    try {
-      accounts = (await provider.request({ method: 'eth_accounts', params: [] })) as string[];
-    } catch {
+    const provider = getAutoSpendSDK().getProvider();
+    const connected = await getConnectedAccounts(provider);
+    if (!connected) {
       return { success: false, error: 'No Base Account connected' };
-    }
-
-    if (accounts.length === 0) {
-      return { success: false, error: 'No Base Account connected' };
-    }
-
-    const universalAddress = accounts[0];
-    const subAccountAddress = accounts[1];
-
-    if (!subAccountAddress) {
-      return { success: false, error: 'No sub-account found' };
     }
 
     console.log('Revoking Auto Spend Permissions:', {
-      universal: universalAddress,
-      subAccount: subAccountAddress
+      universal: connected.universal,
+      subAccount: connected.subAccount
     });
 
     // Revoke Auto Spend Permission
@@ -202,7 +170,7 @@ export async function revokeAutoSpend(): Promise<{
       method: 'wallet_revokeSpendPermission',
       params: {
         tokenAddress: USDC_ADDRESS,
-        spenderAddress: subAccountAddress
+        spenderAddress: connected.subAccount
       }
     })) as { transactionHash?: string; hash?: string };
 
@@ -234,39 +202,18 @@ export async function getAutoSpendConfig(): Promise<{
   isActive?: boolean;
   error?: string;
 }> {
-  const sdk = createBaseAccountSDK({
-    appName: 'BEAT ME',
-    appLogoUrl: 'https://base.org/logo.png',
-    appChainIds: [base.id],
-    subAccounts: { creation: 'on-connect', defaultAccount: 'sub' },
-    paymasterUrls: process.env.NEXT_PUBLIC_PAYMASTER_AND_BUNDLER_ENDPOINT ? [process.env.NEXT_PUBLIC_PAYMASTER_AND_BUNDLER_ENDPOINT] : undefined,
-  });
-
   try {
-    const provider = sdk.getProvider();
-    let accounts: string[] = [];
-    try {
-      accounts = (await provider.request({ method: 'eth_accounts', params: [] })) as string[];
-    } catch {
+    const provider = getAutoSpendSDK().getProvider();
+    const connected = await getConnectedAccounts(provider);
+    if (!connected) {
       return { error: 'No Base Account connected' };
-    }
-
-    if (accounts.length === 0) {
-      return { error: 'No Base Account connected' };
-    }
-
-    const universalAddress = accounts[0];
-    const subAccountAddress = accounts[1];
-
-    if (!subAccountAddress) {
-      return { error: 'No sub-account found' };
     }
 
     const status = await checkAutoSpendStatus();
 
     return {
-      universalAddress,
-      subAccountAddress,
+      universalAddress: connected.universal,
+      subAccountAddress: connected.subAccount,
       tokenAddress: USDC_ADDRESS,
       amount: AUTO_SPEND_AMOUNT,
       duration: AUTO_SPEND_DURATION,

--- a/lib/base-account/autoSpend.ts
+++ b/lib/base-account/autoSpend.ts
@@ -33,8 +33,13 @@ export async function configureAutoSpend(): Promise<{
 
   try {
     const provider = sdk.getProvider();
-    const accounts = (await provider.request({ method: 'eth_accounts', params: [] })) as string[];
-    
+    let accounts: string[] = [];
+    try {
+      accounts = (await provider.request({ method: 'eth_accounts', params: [] })) as string[];
+    } catch {
+      return { success: false, error: 'No Base Account connected' };
+    }
+
     if (accounts.length === 0) {
       return { success: false, error: 'No Base Account connected' };
     }
@@ -104,8 +109,13 @@ export async function checkAutoSpendStatus(): Promise<{
 
   try {
     const provider = sdk.getProvider();
-    const accounts = (await provider.request({ method: 'eth_accounts', params: [] })) as string[];
-    
+    let accounts: string[] = [];
+    try {
+      accounts = (await provider.request({ method: 'eth_accounts', params: [] })) as string[];
+    } catch {
+      return { isConfigured: false, error: 'No Base Account connected' };
+    }
+
     if (accounts.length === 0) {
       return { isConfigured: false, error: 'No Base Account connected' };
     }
@@ -164,8 +174,13 @@ export async function revokeAutoSpend(): Promise<{
 
   try {
     const provider = sdk.getProvider();
-    const accounts = (await provider.request({ method: 'eth_accounts', params: [] })) as string[];
-    
+    let accounts: string[] = [];
+    try {
+      accounts = (await provider.request({ method: 'eth_accounts', params: [] })) as string[];
+    } catch {
+      return { success: false, error: 'No Base Account connected' };
+    }
+
     if (accounts.length === 0) {
       return { success: false, error: 'No Base Account connected' };
     }
@@ -229,8 +244,13 @@ export async function getAutoSpendConfig(): Promise<{
 
   try {
     const provider = sdk.getProvider();
-    const accounts = (await provider.request({ method: 'eth_accounts', params: [] })) as string[];
-    
+    let accounts: string[] = [];
+    try {
+      accounts = (await provider.request({ method: 'eth_accounts', params: [] })) as string[];
+    } catch {
+      return { error: 'No Base Account connected' };
+    }
+
     if (accounts.length === 0) {
       return { error: 'No Base Account connected' };
     }


### PR DESCRIPTION
## Summary
- **Post-trial score screen**: Removes the wallet connect modal that appeared after completing a trial game — now shows the final score with a "Back to Home" button
- **Trial replay prevention**: Hides the Trial button entirely once the free game is used; adds a guard in GameEntry to reject trial mode when exhausted
- **Base sign-in infinite loop**: Fixes the `eth_requestAccounts` error cascade by wrapping `eth_accounts` calls in try-catch across all wallet hooks and gating polling intervals on connection state

## Test plan
- [ ] Complete a trial game → verify score screen appears without wallet connect UI
- [ ] After trial, verify Trial button is hidden on the mode selection screen
- [ ] Click "Sign in with Base" for paid mode → verify no console spam of error 4100 and no infinite re-renders
- [ ] Verify wallet connection flow works normally when user approves
- [ ] Build passes: `npm run build`

🤖 Generated with [Claude Code](https://claude.com/claude-code)