### PR TITLE
Add CDP Onramp button for funding sub accounts

### DIFF
--- a/components/game/GameEntry.tsx
+++ b/components/game/GameEntry.tsx
@@ -622,6 +622,37 @@ export default function GameEntry({
                     <div className="text-xs text-gray-400 mt-1">
                       {hasEnoughForEntry ? 'Sufficient funds for entry' : 'Need 1 USDC to play'}
                     </div>
+
+                    {/* CDP Onramp - Buy USDC button when balance is insufficient */}
+                    {!hasEnoughForEntry && !balanceLoading && (
+                      <div className="mt-3 pt-3 border-t border-gray-700/50">
+                        <Button
+                          onClick={() => {
+                            if (fundingUrl) {
+                              window.open(fundingUrl, '_blank', 'noopener,noreferrer');
+                            }
+                          }}
+                          disabled={!fundingUrl || isFundingUrlGenerating}
+                          className="w-full bg-gradient-to-r from-blue-500 to-indigo-500 hover:from-blue-400 hover:to-indigo-400 text-white text-sm cursor-pointer disabled:opacity-50 disabled:cursor-not-allowed"
+                          size="sm"
+                        >
+                          {isFundingUrlGenerating ? (
+                            <>
+                              <Loader2 className="h-3 w-3 mr-2 animate-spin" />
+                              Initializing Onramp...
+                            </>
+                          ) : (
+                            <>
+                              <Coins className="h-3 w-3 mr-2" />
+                              Buy USDC with Card
+                            </>
+                          )}
+                        </Button>
+                        <p className="text-[10px] text-gray-500 text-center mt-1.5">
+                          Powered by Coinbase Onramp &middot; Card or Apple Pay
+                        </p>
+                      </div>
+                    )}
                   </div>
 
                   <div className="text-sm text-gray-300 text-center mb-4">

--- a/components/game/GameEntry.tsx
+++ b/components/game/GameEntry.tsx
@@ -95,6 +95,11 @@ export default function GameEntry({
     return () => window.clearTimeout(t);
   }, [isProcessingPayment, paymentFlowId]);
 
+  // Reset funding URL when wallet address changes to prevent funding the wrong account
+  useEffect(() => {
+    setFundingUrl(null);
+  }, [address]);
+
   // Auto-generate funding URL with CDP session token when address is available
   useEffect(() => {
     const generateInitialFundingUrl = async () => {
@@ -633,7 +638,7 @@ export default function GameEntry({
                             }
                           }}
                           disabled={!fundingUrl || isFundingUrlGenerating}
-                          className="w-full bg-gradient-to-r from-blue-500 to-indigo-500 hover:from-blue-400 hover:to-indigo-400 text-white text-sm cursor-pointer disabled:opacity-50 disabled:cursor-not-allowed"
+                          className="w-full !bg-gradient-to-r !from-blue-500 !to-indigo-500 hover:!from-blue-400 hover:!to-indigo-400 text-white text-sm cursor-pointer disabled:opacity-50 disabled:cursor-not-allowed"
                           size="sm"
                         >
                           {isFundingUrlGenerating ? (
@@ -648,7 +653,7 @@ export default function GameEntry({
                             </>
                           )}
                         </Button>
-                        <p className="text-[10px] text-gray-500 text-center mt-1.5">
+                        <p className="text-[10px] text-gray-400 text-center mt-1.5">
                           Powered by Coinbase Onramp &middot; Card or Apple Pay
                         </p>
                       </div>


### PR DESCRIPTION
## Summary

- **Surfaces the existing CDP Onramp flow in the UI.** When a user has insufficient USDC balance, a "Buy USDC with Card" button now appears below the balance display in the GameEntry component. It opens the Coinbase Pay One-Click-Buy page (card or Apple Pay) using the session token and funding URL that were already generated server-side but never exposed to the user.
- **No backend changes.** The session token endpoint (`/api/session-token`), JWT auth (`lib/apis/cdp-onramp.ts`), and funding URL generation (`lib/utils/funding.ts`) were already fully implemented — this PR wires the last mile into the UI.

### Context: Sub Account origin

The sub account address users see (e.g. `0xe9ec...5e2b`) is an **app-specific smart contract wallet** created by the Base Account SDK (`subAccounts: { creation: 'on-connect', defaultAccount: 'sub' }`). It's separate from the user's universal wallet address and won't appear in their regular Base wallet — this is correct post-migration behavior.

## Test plan

- [ ] Connect a Base Account in paid mode with 0 USDC balance
- [ ] Verify the "Buy USDC with Card" button appears below the balance display
- [ ] Verify the button shows "Initializing Onramp..." while the session token is being generated
- [ ] Click the button and confirm it opens the Coinbase Pay page in a new tab with USDC on Base pre-selected
- [ ] Fund the wallet, return to the app, and confirm the button disappears once balance >= 1 USDC

https://claude.ai/code/session_01RycELcxGdaFVSeKpkXvyQc