### PR TITLE
Remove Trial Games Complete and GamePayment views, persist trial status in localStorage

### DIFF
--- a/app/page.tsx
+++ b/app/page.tsx
@@ -9,7 +9,7 @@ import { formatTimeRemainingText } from '@/lib/utils/timeUtils';
 import GameEntry from '@/components/game/GameEntry';
 import MultiplayerLobby from '@/components/game/MultiplayerLobby';
 import GuestModeEntry from '@/components/game/GuestModeEntry';
-import GamePayment from '@/components/game/GamePayment';
+// GamePayment view removed — no longer needed in the flow
 import AudioPlayer from '@/components/game/AudioPlayer';
 import ActivePlayers from '@/components/game/ActivePlayers';
 import type { TriviaQuestion, PlayerModeChoice, GameStartOptions } from '@/types/game';
@@ -20,12 +20,10 @@ import { useContractUSDCBalance } from '@/hooks/useContractUSDCBalance';
 import GameTitle from '@/components/ui/GameTitle';
 import HighScoreDisplay from '@/components/game/HighScoreDisplay';
 import TopEarners from '@/components/leaderboard/TopEarners';
-import { Trophy } from 'lucide-react';
 // OnchainKit imports removed - using Base Account instead
 import { Card, CardContent } from '@/components/ui/card';
 import { cn } from '@/lib/utils';
 import { isLobbySessionStatus } from '@/lib/utils/gameSessionStatus';
-import BaseAccountButton from '@/components/base-account/BaseAccountButton';
 import { ENTRY_FEE_USDC } from '@/lib/blockchain/contracts';
 
 function HomePage() {
@@ -47,7 +45,6 @@ function HomePage() {
   } = useGameSession();
   const [showGameEntry, setShowGameEntry] = useState(false);
   const [showGuestMode, setShowGuestMode] = useState(false);
-  const [showPayment, setShowPayment] = useState(false);
   const [playerModeChoice, setPlayerModeChoice] = useState<PlayerModeChoice>('trial');
   const [gameStarted, setGameStarted] = useState(false);
   const [isGuestMode, setIsGuestMode] = useState(false);
@@ -242,19 +239,7 @@ function HomePage() {
   };
 
   const handleWalletConnect = () => {
-    setShowGameEntry(false);
-    setShowPayment(true);
-  };
-
-  const handlePaymentComplete = () => {
-    setShowPayment(false);
-    setIsTrialGame(false);
-    setGameStarted(true);
-    loadRandomQuestion();
-  };
-
-  const handlePaymentBack = () => {
-    setShowPayment(false);
+    // Payment view removed — go straight to game entry with paid modes
     setShowGameEntry(true);
   };
 
@@ -306,7 +291,6 @@ function HomePage() {
       setJoinGameStartError(null);
       setShowGameEntry(false);
       setShowGuestMode(false);
-      setShowPayment(false);
       setGameStarted(false);
       setIsGuestMode(false);
       setGameCompleted(false);
@@ -487,16 +471,6 @@ function HomePage() {
     return `${totalPlayers} PLAYERS ARE PLAYING`;
   };
 
-  // Show payment screen
-  if (showPayment) {
-    return (
-      <GamePayment 
-        onPaymentComplete={handlePaymentComplete}
-        onBack={handlePaymentBack}
-      />
-    );
-  }
-
   // Show guest mode entry
   if (showGuestMode) {
     return (
@@ -511,36 +485,13 @@ function HomePage() {
     );
   }
 
-  // Show trial completion screen if user has used all free games (but not if a game just finished)
-  if (trialStatus.requiresWallet && !gameCompleted) {
-    return (
-      <div className="bg-[#000000] min-h-screen w-full flex items-center justify-center px-4">
-        <div className="w-full max-w-[390px] md:max-w-[428px]">
-          <div className="bg-gradient-to-br from-white to-gray-50 rounded-lg shadow-lg border-0 p-8 text-center">
-            <div className="mx-auto w-16 h-16 bg-gradient-to-r from-purple-500 to-pink-500 rounded-full flex items-center justify-center mb-4">
-              <Trophy className="w-8 h-8 text-white" />
-            </div>
-            <h1 className="text-2xl font-bold text-gray-800 mb-2">
-              Trial Games Complete!
-            </h1>
-            <p className="text-gray-600 text-lg mb-4">
-              {`You've played ${trialStatus.gamesPlayed} free games. Connect your wallet to continue playing and earn rewards!`}
-            </p>
-            {/* Base Account Wallet Component */}
-            <div className="flex justify-center">
-              <BaseAccountButton
-                className="!bg-gradient-to-r !from-purple-500 !to-pink-500 hover:!from-purple-600 hover:!to-pink-600 !text-white !px-8 !py-3 !rounded-lg !text-lg !font-semibold"
-                onConnect={() => setShowPayment(true)}
-              />
-            </div>
-            <p className="text-sm text-gray-500 mt-4">
-              Connect your wallet to continue playing and earn rewards!
-            </p>
-          </div>
-        </div>
-      </div>
-    );
-  }
+  // When trial is exhausted, automatically show game entry with paid modes
+  // (Trial Games Complete screen has been removed — users go straight to game entry)
+  useEffect(() => {
+    if (trialStatus.requiresWallet && !gameCompleted && !gameStarted && !showGameEntry && !showGuestMode && !inMultiplayerLobby) {
+      setShowGameEntry(true);
+    }
+  }, [trialStatus.requiresWallet, gameCompleted, gameStarted, showGameEntry, showGuestMode, inMultiplayerLobby]);
 
   // Paid multiplayer lobby (memory session)
   if (inMultiplayerLobby) {

--- a/components/game/SpacetimeTriviaGame.tsx
+++ b/components/game/SpacetimeTriviaGame.tsx
@@ -9,7 +9,7 @@ import TriviaQuestion from '@/components/game/TriviaQuestion';
 import GameStats from '@/components/game/GameStats';
 import Timer from '@/components/game/Timer';
 import type { GameState, DifficultyLevel, QuestionType, TriviaQuestion as TQ } from '@/types/game';
-import { Music, Trophy, Clock, Target, Play, ArrowLeft } from 'lucide-react';
+import { Music, Trophy, Clock, Target, Play } from 'lucide-react';
 import { ScoringSystem } from '@/lib/game/scoring';
 import { useTrialStatus } from '@/hooks/useTrialStatus';
 import { SessionManager } from '@/lib/utils/sessionManager';
@@ -304,59 +304,12 @@ export default function SpacetimeTriviaGame({ className = '', onWalletConnect, o
     };
   };
 
-  // Show trial completion screen if user has used all free games
+  // When trial is exhausted, navigate back to game entry instead of showing a blocking screen
   if (trialStatus.requiresWallet && gameState.gameStatus === 'waiting') {
-    return (
-      <div className={`max-w-4xl mx-auto ${className}`}>
-        <Card className="shadow-lg border-0 bg-gradient-to-br from-white to-gray-50">
-          <CardHeader className="text-center">
-            <div className="mx-auto w-16 h-16 bg-gradient-to-r from-purple-500 to-pink-500 rounded-full flex items-center justify-center mb-4">
-              <Trophy className="w-8 h-8 text-white" />
-            </div>
-            <CardTitle className="text-2xl font-bold text-gray-800 mb-2">
-              Trial Games Complete!
-            </CardTitle>
-            <p className="text-gray-600 text-lg mb-4">
-              You&apos;ve played {trialStatus.gamesPlayed} free {trialStatus.gamesPlayed === 1 ? 'game' : 'games'}. Connect your wallet to continue playing and earn rewards!
-            </p>
-          </CardHeader>
-          <CardContent className="text-center space-y-4">
-            <Button
-              onClick={() => {
-                if (onWalletConnect) {
-                  onWalletConnect();
-                } else {
-                  // Fallback: redirect to main page to trigger wallet connection
-                  window.location.href = '/';
-                }
-              }}
-              size="lg"
-              className="bg-gradient-to-r from-purple-500 to-pink-500 hover:from-purple-600 hover:to-pink-600 text-white px-8 py-3"
-              disabled={isConnected && !!address}
-            >
-              {isConnected && address ? 'Wallet Connected' : 'Connect Wallet to Continue'}
-            </Button>
-            
-            {/* Back button */}
-            {onBack && (
-              <Button
-                onClick={onBack}
-                variant="ghost"
-                size="sm"
-                className="text-gray-600 hover:text-gray-800"
-              >
-                <ArrowLeft className="w-4 h-4 mr-2" />
-                Back to Game Entry
-              </Button>
-            )}
-            
-            <p className="text-sm text-gray-500">
-              Connect your wallet to continue playing and earn rewards!
-            </p>
-          </CardContent>
-        </Card>
-      </div>
-    );
+    if (onBack) {
+      onBack();
+    }
+    return null;
   }
 
   if (gameState.gameStatus === 'waiting') {

--- a/components/game/SpacetimeTriviaGame.tsx
+++ b/components/game/SpacetimeTriviaGame.tsx
@@ -305,10 +305,13 @@ export default function SpacetimeTriviaGame({ className = '', onWalletConnect, o
   };
 
   // When trial is exhausted, navigate back to game entry instead of showing a blocking screen
-  if (trialStatus.requiresWallet && gameState.gameStatus === 'waiting') {
-    if (onBack) {
+  useEffect(() => {
+    if (trialStatus.requiresWallet && gameState.gameStatus === 'waiting' && onBack) {
       onBack();
     }
+  }, [trialStatus.requiresWallet, gameState.gameStatus, onBack]);
+
+  if (trialStatus.requiresWallet && gameState.gameStatus === 'waiting') {
     return null;
   }
 

--- a/hooks/useTrialStatus.ts
+++ b/hooks/useTrialStatus.ts
@@ -298,10 +298,6 @@ export const useTrialStatus = (walletAddress?: string, entryToken?: string | nul
           const updatedGamesPlayed = prev.gamesPlayed + 1;
           const updatedGamesRemaining = Math.max(0, prev.gamesRemaining - 1);
           const isTrialActive = updatedGamesRemaining > 0;
-          // Persist trial completion to localStorage
-          if (!isTrialActive) {
-            SessionManager.setTrialCompleted();
-          }
           return {
             ...prev,
             gamesPlayed: updatedGamesPlayed,
@@ -345,6 +341,13 @@ export const useTrialStatus = (walletAddress?: string, entryToken?: string | nul
       });
     }
   };
+
+  // Persist trial completion to localStorage as a side effect (outside state updaters)
+  useEffect(() => {
+    if (!trialStatus.isTrialActive && trialStatus.gamesPlayed > 0) {
+      SessionManager.setTrialCompleted();
+    }
+  }, [trialStatus.isTrialActive, trialStatus.gamesPlayed]);
 
   return { trialStatus, isLoading, incrementTrialGame };
 };

--- a/hooks/useTrialStatus.ts
+++ b/hooks/useTrialStatus.ts
@@ -133,6 +133,20 @@ export const useTrialStatus = (walletAddress?: string, entryToken?: string | nul
               throw new Error('Token validation failed');
             }
           } else {
+            // Check localStorage first for persisted trial completion
+            if (SessionManager.isTrialCompleted()) {
+              const gamesPlayed = SessionManager.getTrialGamesPlayed();
+              setTrialStatus({
+                gamesPlayed: Math.max(gamesPlayed, 1),
+                gamesRemaining: 0,
+                isTrialActive: false,
+                requiresWallet: true,
+                canJoinPrizePool: true,
+                playerType: 'trial'
+              });
+              setIsLoading(false);
+              return;
+            }
             // Check anonymous session trial status
             const sessionId = SessionManager.getSessionId();
             const response = await fetch(`/api/trial-status?session=${sessionId}`);
@@ -284,6 +298,10 @@ export const useTrialStatus = (walletAddress?: string, entryToken?: string | nul
           const updatedGamesPlayed = prev.gamesPlayed + 1;
           const updatedGamesRemaining = Math.max(0, prev.gamesRemaining - 1);
           const isTrialActive = updatedGamesRemaining > 0;
+          // Persist trial completion to localStorage
+          if (!isTrialActive) {
+            SessionManager.setTrialCompleted();
+          }
           return {
             ...prev,
             gamesPlayed: updatedGamesPlayed,

--- a/lib/utils/sessionManager.ts
+++ b/lib/utils/sessionManager.ts
@@ -1,6 +1,7 @@
 export class SessionManager {
   private static readonly SESSION_KEY = 'beatme_session_id';
   private static readonly TRIAL_GAMES_KEY = 'beatme_trial_games';
+  private static readonly TRIAL_COMPLETED_KEY = 'beatme_trial_completed';
   private static readonly LAST_SYNC_KEY = 'beatme_last_sync';
 
   private static generateUUID(): string {
@@ -64,9 +65,20 @@ export class SessionManager {
     return (now - lastSync) > 5 * 60 * 1000;
   }
 
+  static isTrialCompleted(): boolean {
+    if (typeof window === 'undefined') return false;
+    return localStorage.getItem(this.TRIAL_COMPLETED_KEY) === 'true';
+  }
+
+  static setTrialCompleted(): void {
+    if (typeof window === 'undefined') return;
+    localStorage.setItem(this.TRIAL_COMPLETED_KEY, 'true');
+  }
+
   static resetTrialGames(): void {
     if (typeof window === 'undefined') return;
     localStorage.removeItem(this.TRIAL_GAMES_KEY);
+    localStorage.removeItem(this.TRIAL_COMPLETED_KEY);
     localStorage.removeItem(this.LAST_SYNC_KEY);
   }
 
@@ -74,6 +86,7 @@ export class SessionManager {
     if (typeof window === 'undefined') return;
     localStorage.removeItem(this.SESSION_KEY);
     localStorage.removeItem(this.TRIAL_GAMES_KEY);
+    localStorage.removeItem(this.TRIAL_COMPLETED_KEY);
     localStorage.removeItem(this.LAST_SYNC_KEY);
   }
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -9208,9 +9208,6 @@
       "cpu": [
         "arm"
       ],
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -9223,9 +9220,6 @@
       "integrity": "sha512-n83O8rt4v34hgFzlkb1ycniJh7IR5RCIqt6mz1VRJD6pmhRi0CXdmfnLu9dIUS6buzh60IvACM842Ffb3xd6Gg==",
       "cpu": [
         "arm"
-      ],
-      "libc": [
-        "musl"
       ],
       "license": "MIT",
       "optional": true,
@@ -9240,9 +9234,6 @@
       "cpu": [
         "arm64"
       ],
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -9255,9 +9246,6 @@
       "integrity": "sha512-+pUymDhd0ys9GcKZPPWlFiZ67sTWV5UU6zOJat02M1+PiuSGDziyRuI/pPue3hoUwm2uGfxdL+trT6Z9rxnlMA==",
       "cpu": [
         "arm64"
-      ],
-      "libc": [
-        "musl"
       ],
       "license": "MIT",
       "optional": true,
@@ -9272,9 +9260,6 @@
       "cpu": [
         "loong64"
       ],
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -9287,9 +9272,6 @@
       "integrity": "sha512-4LqhUomJqwe641gsPp6xLfhqWMbQV04KtPp7/dIp0nzPxAkNY1AbwL5W0MQpcalLYk07vaW9Kp1PBhdpZYYcEw==",
       "cpu": [
         "loong64"
-      ],
-      "libc": [
-        "musl"
       ],
       "license": "MIT",
       "optional": true,
@@ -9304,9 +9286,6 @@
       "cpu": [
         "ppc64"
       ],
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -9319,9 +9298,6 @@
       "integrity": "sha512-RMxFhJwc9fSXP6PqmAz4cbv3kAyvD1etJFjTx4ONqFP9DkTkXsAMU4v3Vyc5BgzC+anz7nS/9tp4obsKfqkDHg==",
       "cpu": [
         "ppc64"
-      ],
-      "libc": [
-        "musl"
       ],
       "license": "MIT",
       "optional": true,
@@ -9336,9 +9312,6 @@
       "cpu": [
         "riscv64"
       ],
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -9351,9 +9324,6 @@
       "integrity": "sha512-RAjXjP/8c6ZtzatZcA1RaQr6O1TRhzC+adn8YZDnChliZHviqIjmvFwHcxi4JKPSDAt6Uhf/7vqcBzQJy0PDJg==",
       "cpu": [
         "riscv64"
-      ],
-      "libc": [
-        "musl"
       ],
       "license": "MIT",
       "optional": true,
@@ -9368,9 +9338,6 @@
       "cpu": [
         "s390x"
       ],
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -9384,9 +9351,6 @@
       "cpu": [
         "x64"
       ],
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -9399,9 +9363,6 @@
       "integrity": "sha512-5cIATbk5vynAjqqmyBjlciMJl1+R/CwX9oLk/EyiFXDWd95KpHdrOJT//rnUl4cUcskrd0jCCw3wpZnhIHdD9w==",
       "cpu": [
         "x64"
-      ],
-      "libc": [
-        "musl"
       ],
       "license": "MIT",
       "optional": true,


### PR DESCRIPTION
After a trial game completes, users now go straight to the game entry screen
(with paid modes available) instead of seeing intermediate "Trial Games Complete"
and "Base Account Payment" screens. Trial completion is persisted in localStorage
via SessionManager.setTrialCompleted() so it survives page reloads.

https://claude.ai/code/session_019stPQ25Cc8qSfgGnDWboGB