### PR TITLE
fix: add missing onClick handler to SignInWithBase buttons

### DIFF
--- a/components/game/GameEntry.tsx
+++ b/components/game/GameEntry.tsx
@@ -54,7 +54,7 @@ export default function GameEntry({
 }: GameEntryProps) {
   const isPaidMode = playerModeChoice === 'paid_solo' || playerModeChoice === 'paid_multiplayer';
   console.log('GameEntry received playerModeChoice:', playerModeChoice);
-  const { address, universalAddress, isConnected } = useBaseAccount();
+  const { address, universalAddress, isConnected, connect } = useBaseAccount();
   const { trialStatus, isLoading: trialLoading, incrementTrialGame } = useTrialStatus(address || undefined, entryToken || undefined);
   const { getSessionToken, isLoading: sessionLoading, error: sessionError } = useSessionToken();
   const { balance, hasEnoughForEntry, isLoading: balanceLoading, error: balanceError } = useUSDCBalance();
@@ -549,7 +549,7 @@ export default function GameEntry({
                   <SubAccountDisplay showActions={true} />
                 ) : (
                   <div className="text-center">
-                    <SignInWithBaseButton colorScheme="light" />
+                    <SignInWithBaseButton colorScheme="light" onClick={connect} />
                   </div>
                 )}
               </div>

--- a/components/game/GuestModeEntry.tsx
+++ b/components/game/GuestModeEntry.tsx
@@ -19,7 +19,7 @@ interface GuestModeEntryProps {
 export default function GuestModeEntry({ onGuestStart, onWalletConnect, className = '' }: GuestModeEntryProps) {
   const [guestName, setGuestName] = useState('');
   const [showGuestForm, setShowGuestForm] = useState(false);
-  const { isConnected } = useBaseAccount();
+  const { isConnected, connect } = useBaseAccount();
 
   const handleGuestSubmit = (e: React.FormEvent) => {
     e.preventDefault();
@@ -178,7 +178,7 @@ export default function GuestModeEntry({ onGuestStart, onWalletConnect, classNam
             </Button>
           ) : (
             <div className="space-y-3">
-              <SignInWithBaseButton colorScheme="light" />
+              <SignInWithBaseButton colorScheme="light" onClick={connect} />
               <Button
                 onClick={onWalletConnect}
                 variant="outline"

--- a/components/wallet/WalletWithBalance.tsx
+++ b/components/wallet/WalletWithBalance.tsx
@@ -16,7 +16,7 @@ interface WalletWithBalanceProps {
 }
 
 export default function WalletWithBalance({ onFundingSuccess, className = '' }: WalletWithBalanceProps) {
-  const { address, subAccountAddress, universalAddress, isConnected } = useBaseAccount();
+  const { address, subAccountAddress, universalAddress, isConnected, connect } = useBaseAccount();
   const { balance, hasEnoughForEntry, isLoading, error, refreshBalance } = useUSDCBalance();
   const [fundingSuccess, setFundingSuccess] = useState(false);
   const [paymentLoading, setPaymentLoading] = useState(false);
@@ -173,7 +173,7 @@ export default function WalletWithBalance({ onFundingSuccess, className = '' }: 
             </CardContent>
           </Card>
         ) : (
-          <SignInWithBaseButton colorScheme="light" />
+          <SignInWithBaseButton colorScheme="light" onClick={connect} />
         )}
       </div>
     </div>


### PR DESCRIPTION
The SignInWithBaseButton in GameEntry, GuestModeEntry, and WalletWithBalance
was rendered without an onClick handler, making it non-functional. Users could
not sign in with Base to access paid game modes. Added the connect() handler
from useBaseAccount hook, matching the working pattern in WalletConnect and
BaseAccountButton.

https://claude.ai/code/session_01Xc5pVi7gxRh5sUKwcbU6Mg