### PR TITLE
fix: CRE prize distribution — fix onReport auth and auto-sync scores

### DIFF
--- a/app/api/save-paid-score/route.ts
+++ b/app/api/save-paid-score/route.ts
@@ -1,11 +1,17 @@
 import { NextRequest, NextResponse } from 'next/server';
+import { createPublicClient, createWalletClient, http } from 'viem';
+import { privateKeyToAccount } from 'viem/accounts';
+import { base } from 'viem/chains';
 import { spacetimeClient } from '@/lib/apis/spacetime';
 import { verifyEntryToken } from '@/lib/utils/jwt';
+import { TRIVIA_ABI, TRIVIA_CONTRACT_ADDRESS } from '@/lib/blockchain/contracts';
 
 /** Paid games only. Trial / practice scores must not call this route (TOP EARNERS / Spacetime bestScore). */
 
 // Max possible score: 30 questions × 100 points each
 const MAX_GAME_SCORE = 3000;
+
+const BASE_RPC = process.env.BASE_RPC_URL || 'https://mainnet.base.org';
 
 export async function POST(req: NextRequest) {
   try {
@@ -81,7 +87,40 @@ export async function POST(req: NextRequest) {
       totalEarnings
     );
 
-    return NextResponse.json({ success: true });
+    // Submit score on-chain so CRE distribution sees real scores.
+    // This is fire-and-forget — SpacetimeDB is the source of truth for
+    // the leaderboard; on-chain scores are only needed for prize distribution.
+    let onChainTxHash: string | null = null;
+    const ownerKey = process.env.CONTRACT_OWNER_PRIVATE_KEY || process.env.PRIVATE_KEY;
+    if (ownerKey) {
+      try {
+        const publicClient = createPublicClient({ chain: base, transport: http(BASE_RPC) });
+
+        // Only submit if the session is active on-chain (scores can only be set during active sessions)
+        const isActive = await publicClient.readContract({
+          address: TRIVIA_CONTRACT_ADDRESS as `0x${string}`,
+          abi: TRIVIA_ABI,
+          functionName: 'isSessionActive',
+        });
+
+        if (isActive) {
+          const account = privateKeyToAccount(ownerKey as `0x${string}`);
+          const walletClient = createWalletClient({ account, chain: base, transport: http(BASE_RPC) });
+
+          onChainTxHash = await walletClient.writeContract({
+            address: TRIVIA_CONTRACT_ADDRESS as `0x${string}`,
+            abi: TRIVIA_ABI,
+            functionName: 'submitScores',
+            args: [[walletAddress as `0x${string}`], [BigInt(bestScore)]],
+          });
+        }
+      } catch (onChainError) {
+        // Log but don't fail — SpacetimeDB save already succeeded
+        console.error('Warning: on-chain score submission failed (non-fatal):', onChainError);
+      }
+    }
+
+    return NextResponse.json({ success: true, onChainTxHash });
   } catch (error) {
     console.error('Error saving paid score:', error);
     return NextResponse.json(

--- a/app/api/save-paid-score/route.ts
+++ b/app/api/save-paid-score/route.ts
@@ -1,17 +1,12 @@
 import { NextRequest, NextResponse } from 'next/server';
-import { createPublicClient, createWalletClient, http } from 'viem';
-import { privateKeyToAccount } from 'viem/accounts';
-import { base } from 'viem/chains';
 import { spacetimeClient } from '@/lib/apis/spacetime';
+import { submitScoresOnChainAsync } from '@/lib/blockchain/submitScoresOnChain';
 import { verifyEntryToken } from '@/lib/utils/jwt';
-import { TRIVIA_ABI, TRIVIA_CONTRACT_ADDRESS } from '@/lib/blockchain/contracts';
 
 /** Paid games only. Trial / practice scores must not call this route (TOP EARNERS / Spacetime bestScore). */
 
 // Max possible score: 30 questions × 100 points each
 const MAX_GAME_SCORE = 3000;
-
-const BASE_RPC = process.env.BASE_RPC_URL || 'https://mainnet.base.org';
 
 export async function POST(req: NextRequest) {
   try {
@@ -58,7 +53,7 @@ export async function POST(req: NextRequest) {
       }
     }
 
-    await spacetimeClient.initialize();
+    await spacetimeClient.ensurePlayerDataReady();
 
     if (!spacetimeClient.isConfigured()) {
       return NextResponse.json(
@@ -87,40 +82,13 @@ export async function POST(req: NextRequest) {
       totalEarnings
     );
 
-    // Submit score on-chain so CRE distribution sees real scores.
-    // This is fire-and-forget — SpacetimeDB is the source of truth for
-    // the leaderboard; on-chain scores are only needed for prize distribution.
-    let onChainTxHash: string | null = null;
-    const ownerKey = process.env.CONTRACT_OWNER_PRIVATE_KEY || process.env.PRIVATE_KEY;
-    if (ownerKey) {
-      try {
-        const publicClient = createPublicClient({ chain: base, transport: http(BASE_RPC) });
+    // Fire-and-forget on-chain sync for CRE prize distribution.
+    submitScoresOnChainAsync(
+      [walletAddress as `0x${string}`],
+      [BigInt(bestScore)]
+    );
 
-        // Only submit if the session is active on-chain (scores can only be set during active sessions)
-        const isActive = await publicClient.readContract({
-          address: TRIVIA_CONTRACT_ADDRESS as `0x${string}`,
-          abi: TRIVIA_ABI,
-          functionName: 'isSessionActive',
-        });
-
-        if (isActive) {
-          const account = privateKeyToAccount(ownerKey as `0x${string}`);
-          const walletClient = createWalletClient({ account, chain: base, transport: http(BASE_RPC) });
-
-          onChainTxHash = await walletClient.writeContract({
-            address: TRIVIA_CONTRACT_ADDRESS as `0x${string}`,
-            abi: TRIVIA_ABI,
-            functionName: 'submitScores',
-            args: [[walletAddress as `0x${string}`], [BigInt(bestScore)]],
-          });
-        }
-      } catch (onChainError) {
-        // Log but don't fail — SpacetimeDB save already succeeded
-        console.error('Warning: on-chain score submission failed (non-fatal):', onChainError);
-      }
-    }
-
-    return NextResponse.json({ success: true, onChainTxHash });
+    return NextResponse.json({ success: true });
   } catch (error) {
     console.error('Error saving paid score:', error);
     return NextResponse.json(

--- a/app/api/submit-onchain-scores/route.ts
+++ b/app/api/submit-onchain-scores/route.ts
@@ -1,0 +1,94 @@
+import { NextRequest, NextResponse } from 'next/server';
+import { createPublicClient, createWalletClient, http, encodeFunctionData, type Hash } from 'viem';
+import { privateKeyToAccount } from 'viem/accounts';
+import { base } from 'viem/chains';
+import { checkAdminAuth } from '@/lib/utils/adminAuthMiddleware';
+import { spacetimeClient } from '@/lib/apis/spacetime';
+import { TRIVIA_ABI, TRIVIA_CONTRACT_ADDRESS } from '@/lib/blockchain/contracts';
+
+/**
+ * POST /api/submit-onchain-scores
+ *
+ * Admin-protected endpoint that syncs player scores from SpacetimeDB to on-chain.
+ * Must be called before Chainlink CRE distributes prizes so that _findTopPlayers()
+ * sees real scores instead of all-zero defaults.
+ *
+ * Requires:
+ *   - Authorization: Bearer <ADMIN_API_SECRET>
+ *   - CONTRACT_OWNER_PRIVATE_KEY env var (or PRIVATE_KEY fallback)
+ */
+
+const BASE_RPC = process.env.BASE_RPC_URL || 'https://mainnet.base.org';
+
+export async function POST(req: NextRequest) {
+  // Admin auth
+  const authError = checkAdminAuth(req);
+  if (authError) return authError;
+
+  const ownerKey = process.env.CONTRACT_OWNER_PRIVATE_KEY || process.env.PRIVATE_KEY;
+  if (!ownerKey) {
+    return NextResponse.json(
+      { error: 'CONTRACT_OWNER_PRIVATE_KEY not configured' },
+      { status: 500 }
+    );
+  }
+
+  try {
+    // 1. Read current on-chain players
+    const publicClient = createPublicClient({ chain: base, transport: http(BASE_RPC) });
+
+    const players = (await publicClient.readContract({
+      address: TRIVIA_CONTRACT_ADDRESS as `0x${string}`,
+      abi: TRIVIA_ABI,
+      functionName: 'getCurrentPlayers',
+    })) as `0x${string}`[];
+
+    if (players.length === 0) {
+      return NextResponse.json({ success: true, message: 'No players in current session', submitted: 0 });
+    }
+
+    // 2. Look up each player's bestScore from SpacetimeDB
+    await spacetimeClient.initialize();
+
+    const addresses: `0x${string}`[] = [];
+    const scores: bigint[] = [];
+
+    for (const addr of players) {
+      const profile = spacetimeClient.getPlayerProfile(addr);
+      const score = profile ? BigInt(profile.bestScore) : BigInt(0);
+      addresses.push(addr);
+      scores.push(score);
+    }
+
+    // 3. Submit scores on-chain as the contract owner
+    const account = privateKeyToAccount(ownerKey as `0x${string}`);
+    const walletClient = createWalletClient({ account, chain: base, transport: http(BASE_RPC) });
+
+    const txHash: Hash = await walletClient.writeContract({
+      address: TRIVIA_CONTRACT_ADDRESS as `0x${string}`,
+      abi: TRIVIA_ABI,
+      functionName: 'submitScores',
+      args: [addresses, scores],
+    });
+
+    // 4. Wait for confirmation
+    const receipt = await publicClient.waitForTransactionReceipt({ hash: txHash, confirmations: 1 });
+
+    return NextResponse.json({
+      success: receipt.status === 'success',
+      txHash,
+      blockNumber: Number(receipt.blockNumber),
+      submitted: addresses.length,
+      scores: addresses.map((a, i) => ({ address: a, score: Number(scores[i]) })),
+    });
+  } catch (error) {
+    console.error('Error submitting on-chain scores:', error);
+    return NextResponse.json(
+      {
+        error: 'Failed to submit on-chain scores',
+        details: error instanceof Error ? error.message : String(error),
+      },
+      { status: 500 }
+    );
+  }
+}

--- a/app/api/submit-onchain-scores/route.ts
+++ b/app/api/submit-onchain-scores/route.ts
@@ -1,9 +1,9 @@
 import { NextRequest, NextResponse } from 'next/server';
-import { createPublicClient, createWalletClient, http, encodeFunctionData, type Hash } from 'viem';
-import { privateKeyToAccount } from 'viem/accounts';
+import { createPublicClient, http, type Hash } from 'viem';
 import { base } from 'viem/chains';
 import { checkAdminAuth } from '@/lib/utils/adminAuthMiddleware';
 import { spacetimeClient } from '@/lib/apis/spacetime';
+import { submitScoresOnChain } from '@/lib/blockchain/submitScoresOnChain';
 import { TRIVIA_ABI, TRIVIA_CONTRACT_ADDRESS } from '@/lib/blockchain/contracts';
 
 /**
@@ -21,7 +21,6 @@ import { TRIVIA_ABI, TRIVIA_CONTRACT_ADDRESS } from '@/lib/blockchain/contracts'
 const BASE_RPC = process.env.BASE_RPC_URL || 'https://mainnet.base.org';
 
 export async function POST(req: NextRequest) {
-  // Admin auth
   const authError = checkAdminAuth(req);
   if (authError) return authError;
 
@@ -34,7 +33,6 @@ export async function POST(req: NextRequest) {
   }
 
   try {
-    // 1. Read current on-chain players
     const publicClient = createPublicClient({ chain: base, transport: http(BASE_RPC) });
 
     const players = (await publicClient.readContract({
@@ -47,31 +45,39 @@ export async function POST(req: NextRequest) {
       return NextResponse.json({ success: true, message: 'No players in current session', submitted: 0 });
     }
 
-    // 2. Look up each player's bestScore from SpacetimeDB
-    await spacetimeClient.initialize();
+    await spacetimeClient.ensurePlayerDataReady();
 
     const addresses: `0x${string}`[] = [];
     const scores: bigint[] = [];
+    const missingProfiles: string[] = [];
 
     for (const addr of players) {
       const profile = spacetimeClient.getPlayerProfile(addr);
+      if (!profile) {
+        missingProfiles.push(addr);
+      }
       const score = profile ? BigInt(profile.bestScore) : BigInt(0);
       addresses.push(addr);
       scores.push(score);
     }
 
-    // 3. Submit scores on-chain as the contract owner
-    const account = privateKeyToAccount(ownerKey as `0x${string}`);
-    const walletClient = createWalletClient({ account, chain: base, transport: http(BASE_RPC) });
+    if (missingProfiles.length > 0) {
+      console.warn(
+        `submit-onchain-scores: ${missingProfiles.length} player(s) missing from Spacetime cache; submitting 0 for:`,
+        missingProfiles
+      );
+    }
 
-    const txHash: Hash = await walletClient.writeContract({
-      address: TRIVIA_CONTRACT_ADDRESS as `0x${string}`,
-      abi: TRIVIA_ABI,
-      functionName: 'submitScores',
-      args: [addresses, scores],
-    });
+    const txHash = (await submitScoresOnChain(addresses, scores)) as Hash | null;
 
-    // 4. Wait for confirmation
+    if (!txHash) {
+      return NextResponse.json({
+        success: true,
+        message: 'No active on-chain session — scores not submitted',
+        submitted: 0,
+      });
+    }
+
     const receipt = await publicClient.waitForTransactionReceipt({ hash: txHash, confirmations: 1 });
 
     return NextResponse.json({
@@ -79,6 +85,7 @@ export async function POST(req: NextRequest) {
       txHash,
       blockNumber: Number(receipt.blockNumber),
       submitted: addresses.length,
+      missingProfiles: missingProfiles.length,
       scores: addresses.map((a, i) => ({ address: a, score: Number(scores[i]) })),
     });
   } catch (error) {

--- a/contracts/TriviaBattle.sol
+++ b/contracts/TriviaBattle.sol
@@ -85,7 +85,9 @@ contract TriviaBattle is ReentrancyGuard, Ownable, IReceiver {
     }
 
     function _onlyOwnerOrChainlink() internal view {
-        if (msg.sender != owner() && msg.sender != chainlinkOracle) {
+        // Allow owner, Chainlink oracle, and self-calls (from onReport → distributePrizes flow)
+        // Self-call is safe because onReport() already verifies msg.sender == chainlinkOracle
+        if (msg.sender != owner() && msg.sender != chainlinkOracle && msg.sender != address(this)) {
             revert TriviaBattle__Unauthorized();
         }
     }

--- a/hooks/useTriviaContract.ts
+++ b/hooks/useTriviaContract.ts
@@ -388,35 +388,29 @@ export function useTriviaContract(useGasless: boolean = true) {
     setIsPending(false);
   }, []);
 
-  // Submit score
+  // Submit score — saves off-chain only. On-chain score submission is done
+  // server-side via /api/submit-onchain-scores (owner-only, before distribution).
   const submitScore = useCallback(async (score: number) => {
-    if (!address || !isConnected || !provider) {
-      setState(prev => ({ ...prev, error: 'Wallet not connected or provider not ready' }));
+    if (!address) {
+      setState(prev => ({ ...prev, error: 'Wallet not connected' }));
       return;
     }
 
     setState(prev => ({ ...prev, isSubmitting: true, error: null }));
-    setIsPending(true);
 
     try {
-      const data = encodeFunctionData({
-        abi: TRIVIA_ABI,
-        functionName: 'submitScores',
-        args: [[address as `0x${string}`], [BigInt(score)]],
+      const response = await fetch('/api/save-paid-score', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ walletAddress: address, finalScore: score }),
       });
-      
-      const txHash = await provider.request({
-        method: 'eth_sendTransaction',
-        params: [{
-          from: address,
-          to: TRIVIA_CONTRACT_ADDRESS,
-          data,
-        }]
-      });
-      
-      setHash(txHash as string);
-      setIsPending(false);
-      setIsConfirming(true);
+
+      if (!response.ok) {
+        const data = await response.json().catch(() => ({}));
+        throw new Error(data.error || 'Failed to save score');
+      }
+
+      setState(prev => ({ ...prev, isSubmitting: false }));
     } catch (error) {
       console.error('Error submitting score:', error);
       setState(prev => ({
@@ -424,10 +418,8 @@ export function useTriviaContract(useGasless: boolean = true) {
         isSubmitting: false,
         error: error instanceof Error ? error.message : 'Failed to submit score',
       }));
-      setIsPending(false);
-      setWriteError(error as Error);
     }
-    }, [address, isConnected, provider]);
+  }, [address]);
 
   const submitTrialScore = useCallback(async (_sessionId: string, _score: number) => {
     setState(prev => ({

--- a/lib/apis/spacetime.ts
+++ b/lib/apis/spacetime.ts
@@ -9,6 +9,7 @@ import { Identity } from 'spacetimedb';
 import {
   buildAppSubscriptionQueries,
   buildGameSessionOnlySubscriptionQueries,
+  buildPlayerLookupSubscriptionQueries,
   type AppSubscriptionTables,
 } from '../spacetime/appSubscriptionQueries';
 
@@ -60,6 +61,11 @@ const SPACETIME_CONFIG = {
   module: process.env.SPACETIME_MODULE || 'beat-me',
 };
 
+export interface SpacetimeInitOptions {
+  /** Subscribe to player rows on the server before reading profiles. */
+  syncPlayers?: boolean;
+}
+
 /**
  * SpacetimeDB Client - Singleton wrapper around DbConnection
  */
@@ -67,21 +73,130 @@ class SpacetimeDBClient {
   private connection: DbConnection | null = null;
   private isConnected = false;
   private connectionPromise: Promise<void> | null = null;
+  private initOptions: SpacetimeInitOptions = {};
+  private playersSubscribed = false;
+  private subscriptionSynced = false;
+  private syncPromise: Promise<void> | null = null;
+  private syncResolve: (() => void) | null = null;
+
+  private resetSyncState(): void {
+    this.subscriptionSynced = false;
+    this.syncPromise = null;
+    this.syncResolve = null;
+  }
+
+  private beginSyncWait(): void {
+    if (this.syncPromise) {
+      return;
+    }
+
+    this.syncPromise = new Promise<void>((resolve) => {
+      if (this.subscriptionSynced) {
+        resolve();
+        return;
+      }
+      this.syncResolve = resolve;
+    });
+  }
+
+  private markSubscriptionApplied(): void {
+    console.log('✅ SpacetimeDB subscription applied');
+    this.subscriptionSynced = true;
+    this.syncResolve?.();
+    this.syncResolve = null;
+  }
+
+  /**
+   * Wait until the initial subscription snapshot is applied to the local cache.
+   */
+  async waitForSync(timeoutMs = 15000): Promise<void> {
+    if (this.subscriptionSynced) {
+      return;
+    }
+
+    this.beginSyncWait();
+
+    const timeout = new Promise<void>((_, reject) => {
+      setTimeout(() => reject(new Error('SpacetimeDB subscription sync timeout')), timeoutMs);
+    });
+
+    await Promise.race([this.syncPromise!, timeout]);
+  }
+
+  /**
+   * Connect (if needed), subscribe to players on the server, and wait for cache sync.
+   */
+  async ensurePlayerDataReady(): Promise<void> {
+    await this.initialize({ syncPlayers: true });
+    await this.waitForSync();
+  }
+
+  private async subscribeToPlayers(): Promise<void> {
+    if (!this.connection || this.playersSubscribed) {
+      return;
+    }
+
+    this.resetSyncState();
+    this.beginSyncWait();
+
+    await new Promise<void>((resolve, reject) => {
+      const timeout = setTimeout(() => {
+        reject(new Error('SpacetimeDB player subscription timeout'));
+      }, 15000);
+
+      this.connection!.subscriptionBuilder()
+        .onApplied(() => {
+          clearTimeout(timeout);
+          this.playersSubscribed = true;
+          this.markSubscriptionApplied();
+          resolve();
+        })
+        .onError((errorContext) => {
+          clearTimeout(timeout);
+          const message =
+            typeof errorContext === 'string'
+              ? errorContext
+              : errorContext instanceof Error
+                ? errorContext.message
+                : 'SpacetimeDB player subscription failed';
+          reject(new Error(message));
+        })
+        .subscribe((t) => {
+          const tbl = t as unknown as AppSubscriptionTables;
+          return buildPlayerLookupSubscriptionQueries(tbl);
+        });
+    });
+  }
 
   /**
    * Initialize the SpacetimeDB connection
    */
-  async initialize(): Promise<void> {
+  async initialize(options?: SpacetimeInitOptions): Promise<void> {
+    if (options?.syncPlayers) {
+      this.initOptions.syncPlayers = true;
+    }
+
     if (this.connectionPromise) {
-      return this.connectionPromise;
+      await this.connectionPromise;
+      if (options?.syncPlayers && !this.playersSubscribed) {
+        await this.subscribeToPlayers();
+      }
+      return;
     }
 
     if (this.isConnected && this.connection) {
-      return Promise.resolve();
+      if (options?.syncPlayers && !this.playersSubscribed) {
+        await this.subscribeToPlayers();
+      }
+      return;
     }
 
     this.connectionPromise = this._doInitialize();
-    return this.connectionPromise;
+    await this.connectionPromise;
+
+    if (options?.syncPlayers && !this.playersSubscribed) {
+      await this.subscribeToPlayers();
+    }
   }
 
   private async _doInitialize(): Promise<void> {
@@ -119,24 +234,29 @@ class SpacetimeDBClient {
             console.log(`   Token: ${token ? '***' + token.slice(-8) : 'None'}`);
             this.connection = conn;
             this.isConnected = true;
-            
+            this.beginSyncWait();
+
             conn.subscriptionBuilder()
               .onApplied(() => {
-                console.log('✅ SpacetimeDB subscription applied');
+                this.markSubscriptionApplied();
               })
               .subscribe((t) => {
                 const tbl = t as unknown as AppSubscriptionTables;
-                return typeof window === 'undefined'
-                  ? buildGameSessionOnlySubscriptionQueries(tbl)
-                  : buildAppSubscriptionQueries(tbl);
+                if (typeof window !== 'undefined') {
+                  this.playersSubscribed = true;
+                  return buildAppSubscriptionQueries(tbl);
+                }
+                return buildGameSessionOnlySubscriptionQueries(tbl);
               });
-            
+
             resolve();
           })
           .onDisconnect(() => {
             console.log('🔌 Disconnected from SpacetimeDB');
             this.isConnected = false;
             this.connection = null;
+            this.playersSubscribed = false;
+            this.resetSyncState();
           })
           .onConnectError((error) => {
             if (connectionResolved) return;

--- a/lib/blockchain/ownerTxQueue.ts
+++ b/lib/blockchain/ownerTxQueue.ts
@@ -1,0 +1,40 @@
+import type { Hash } from 'viem';
+
+type TxTask = () => Promise<Hash>;
+
+/** Serializes owner-key writes within this runtime to reduce nonce collisions. */
+let txChain: Promise<unknown> = Promise.resolve();
+
+const NONCE_ERROR_PATTERN =
+  /nonce too low|replacement transaction underpriced|already known|nonce has already been used/i;
+
+const MAX_RETRIES = 3;
+
+const isNonceError = (error: unknown): boolean => {
+  const message = error instanceof Error ? error.message : String(error);
+  return NONCE_ERROR_PATTERN.test(message);
+};
+
+/**
+ * Enqueue a contract write so only one owner-key transaction runs at a time.
+ * Retries on nonce conflicts (common under concurrent serverless invocations).
+ */
+export const enqueueOwnerTx = (task: TxTask): Promise<Hash> => {
+  const run = async (): Promise<Hash> => {
+    for (let attempt = 0; attempt < MAX_RETRIES; attempt++) {
+      try {
+        return await task();
+      } catch (error) {
+        if (!isNonceError(error) || attempt === MAX_RETRIES - 1) {
+          throw error;
+        }
+        await new Promise((resolve) => setTimeout(resolve, 300 * (attempt + 1)));
+      }
+    }
+    throw new Error('enqueueOwnerTx: exhausted retries');
+  };
+
+  const result = txChain.then(run, run);
+  txChain = result.catch(() => undefined);
+  return result;
+};

--- a/lib/blockchain/submitScoresOnChain.ts
+++ b/lib/blockchain/submitScoresOnChain.ts
@@ -1,0 +1,60 @@
+import { createPublicClient, createWalletClient, http } from 'viem';
+import { privateKeyToAccount } from 'viem/accounts';
+import { base } from 'viem/chains';
+import { TRIVIA_ABI, TRIVIA_CONTRACT_ADDRESS } from '@/lib/blockchain/contracts';
+import { enqueueOwnerTx } from '@/lib/blockchain/ownerTxQueue';
+
+const BASE_RPC = process.env.BASE_RPC_URL || 'https://mainnet.base.org';
+
+const getOwnerKey = (): string | undefined =>
+  process.env.CONTRACT_OWNER_PRIVATE_KEY || process.env.PRIVATE_KEY;
+
+export const submitScoresOnChain = async (
+  addresses: `0x${string}`[],
+  scores: bigint[]
+): Promise<string | null> => {
+  const ownerKey = getOwnerKey();
+  if (!ownerKey || addresses.length === 0) {
+    return null;
+  }
+
+  const publicClient = createPublicClient({ chain: base, transport: http(BASE_RPC) });
+
+  const isActive = await publicClient.readContract({
+    address: TRIVIA_CONTRACT_ADDRESS as `0x${string}`,
+    abi: TRIVIA_ABI,
+    functionName: 'isSessionActive',
+  });
+
+  if (!isActive) {
+    return null;
+  }
+
+  const account = privateKeyToAccount(ownerKey as `0x${string}`);
+  const walletClient = createWalletClient({
+    account,
+    chain: base,
+    transport: http(BASE_RPC),
+  });
+
+  const hash = await enqueueOwnerTx(() =>
+    walletClient.writeContract({
+      address: TRIVIA_CONTRACT_ADDRESS as `0x${string}`,
+      abi: TRIVIA_ABI,
+      functionName: 'submitScores',
+      args: [addresses, scores],
+    })
+  );
+
+  return hash;
+};
+
+/** Non-blocking on-chain sync — errors are logged, not thrown. */
+export const submitScoresOnChainAsync = (
+  addresses: `0x${string}`[],
+  scores: bigint[]
+): void => {
+  void submitScoresOnChain(addresses, scores).catch((error) => {
+    console.error('Warning: on-chain score submission failed (non-fatal):', error);
+  });
+};

--- a/lib/spacetime/appSubscriptionQueries.ts
+++ b/lib/spacetime/appSubscriptionQueries.ts
@@ -10,7 +10,8 @@ import { tables } from './index';
 /** Same object shape `subscriptionBuilder().subscribe(fn)` passes at runtime; SDK types it loosely. */
 export type AppSubscriptionTables = typeof tables;
 
-export const buildAppSubscriptionQueries = (t: AppSubscriptionTables) => [
+/** All player rows via three disjoint predicates (safe for server-side profile lookups). */
+export const buildPlayerLookupSubscriptionQueries = (t: AppSubscriptionTables) => [
   t.players.where((row) => row.totalEarnings.gt(0)),
   t.players.where((row) =>
     row.totalEarnings.eq(0).and(row.gamesPlayed.gt(0))
@@ -18,6 +19,10 @@ export const buildAppSubscriptionQueries = (t: AppSubscriptionTables) => [
   t.players.where((row) =>
     row.totalEarnings.eq(0).and(row.gamesPlayed.eq(0))
   ),
+];
+
+export const buildAppSubscriptionQueries = (t: AppSubscriptionTables) => [
+  ...buildPlayerLookupSubscriptionQueries(t),
   t.game_sessions,
   t.player_stats,
   t.active_game_sessions,


### PR DESCRIPTION
## Summary

- **Fixed silent CRE revert**: `onReport()` calls `address(this).call(report)` to execute `distributePrizes()`, but `msg.sender` becomes `address(this)` which the `onlyOwnerOrChainlink` modifier rejected. Added `address(this)` to the modifier — safe because `onReport` already gates on `chainlinkOracle`.
- **Auto-sync scores on-chain**: Player scores were only saved to SpacetimeDB, never on-chain. Now `/api/save-paid-score` auto-submits each score on-chain using the owner key after every paid game, so CRE sees real scores at distribution time.
- **Removed broken client-side `submitScores` call**: The player's wallet can't call `submitScores` (owner-only). Client now saves off-chain only; on-chain submission happens server-side.

## Test plan

- [ ] Run `forge build --force` — contract compiles cleanly
- [ ] Run `npx tsc --noEmit` — no TypeScript errors
- [ ] Redeploy contract to Base Mainnet with the modifier fix
- [ ] Set `chainlinkOracle` to `0xF8344CFd5c43616a4366C34E3EEE75af79a74482` on new contract
- [ ] Update `NEXT_PUBLIC_TRIVIA_CONTRACT_ADDRESS` env var and CRE config
- [ ] Verify paid game completion submits score on-chain (check `getPlayerScore()`)
- [ ] Verify CRE weekly trigger successfully distributes prizes

🤖 Generated with [Claude Code](https://claude.com/claude-code)