### PR TITLE
Fix Sentry 403 source map upload on Vercel builds

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -83,6 +83,17 @@ Generate `ADMIN_API_SECRET` or `ENTRY_TOKEN_SECRET`:
 node -e "console.log(require('crypto').randomBytes(32).toString('hex'))"
 ```
 
+############################################
+# SENTRY (via Vercel integration)
+############################################
+
+# Runtime error reporting (set automatically by Vercel Sentry integration)
+NEXT_PUBLIC_SENTRY_DSN=
+
+# Build-time source map upload (set in Vercel; use .env.sentry-build-plugin locally)
+# Token needs org:read, project:releases, project:write for org g2entgroup / project g2entgroup
+SENTRY_AUTH_TOKEN=
+
 ## Vercel Deployment
 
 Set all required variables in your Vercel dashboard:

--- a/instrumentation-client.ts
+++ b/instrumentation-client.ts
@@ -5,7 +5,7 @@
 import * as Sentry from "@sentry/nextjs";
 
 Sentry.init({
-  dsn: "https://db23290b61784ca5b24c106ae1b66d8f@o1058750.ingest.us.sentry.io/6046586",
+  dsn: process.env.NEXT_PUBLIC_SENTRY_DSN,
 
   // Add optional integrations for additional features
   integrations: [Sentry.replayIntegration()],

--- a/next.config.ts
+++ b/next.config.ts
@@ -60,9 +60,17 @@ export default withSentryConfig(nextConfig, {
   // For all available options, see:
   // https://www.npmjs.com/package/@sentry/webpack-plugin#options
 
+  // Use Sentry slugs directly — Vercel integration env vars (SENTRY_ORG/SENTRY_PROJECT)
+  // may point at the Vercel resource name, not the Sentry project slug.
   org: "g2entgroup",
 
   project: "g2entgroup",
+
+  authToken: process.env.SENTRY_AUTH_TOKEN,
+
+  sourcemaps: {
+    disable: !process.env.SENTRY_AUTH_TOKEN,
+  },
 
   // Only print logs for uploading source maps in CI
   silent: !process.env.CI,

--- a/next.config.ts
+++ b/next.config.ts
@@ -66,7 +66,7 @@ export default withSentryConfig(nextConfig, {
 
   project: "g2entgroup",
 
-  authToken: process.env.SENTRY_AUTH_TOKEN,
+  authToken: process.env.SENTRY_AUTH_TOKEN || undefined,
 
   sourcemaps: {
     disable: !process.env.SENTRY_AUTH_TOKEN,

--- a/sentry.edge.config.ts
+++ b/sentry.edge.config.ts
@@ -6,7 +6,7 @@
 import * as Sentry from "@sentry/nextjs";
 
 Sentry.init({
-  dsn: "https://db23290b61784ca5b24c106ae1b66d8f@o1058750.ingest.us.sentry.io/6046586",
+  dsn: process.env.NEXT_PUBLIC_SENTRY_DSN,
 
   // Define how likely traces are sampled. Adjust this value in production, or use tracesSampler for greater control.
   tracesSampleRate: 1,

--- a/sentry.server.config.ts
+++ b/sentry.server.config.ts
@@ -5,7 +5,7 @@
 import * as Sentry from "@sentry/nextjs";
 
 Sentry.init({
-  dsn: "https://db23290b61784ca5b24c106ae1b66d8f@o1058750.ingest.us.sentry.io/6046586",
+  dsn: process.env.NEXT_PUBLIC_SENTRY_DSN,
 
   // Define how likely traces are sampled. Adjust this value in production, or use tracesSampler for greater control.
   tracesSampleRate: 1,


### PR DESCRIPTION
## Summary

- Wire `authToken` explicitly in `withSentryConfig` and skip source map uploads when `SENTRY_AUTH_TOKEN` is missing
- Read DSN from `NEXT_PUBLIC_SENTRY_DSN` instead of hardcoding it in sentry config files
- Keep Sentry org/project slugs as `g2entgroup` (Vercel integration env vars can point at the wrong resource names)
- Document Sentry env vars in `.env.example`

The Vercel build 403 was caused by a stale/invalid `SENTRY_AUTH_TOKEN` and mismatched `SENTRY_ORG` / `SENTRY_PROJECT` values on the platform. Those env vars were updated separately in the Vercel dashboard; this PR lands the code-side changes.

## Test plan

- [ ] Merge and deploy to Vercel preview/production
- [ ] Confirm build logs show `Successfully uploaded source maps to Sentry` (no 403)
- [ ] Confirm a new release appears in Sentry for the deployment commit SHA
- [ ] Trigger a test error and verify readable stack traces in Sentry


Made with [Cursor](https://cursor.com)