### PR TITLE
Fix wallet popup, ETH gas checks, and icon contrast for paid entry

### DIFF
--- a/components/base-account/GaslessBadge.tsx
+++ b/components/base-account/GaslessBadge.tsx
@@ -1,28 +1,30 @@
 'use client';
 
 import { Badge } from '@/components/ui/badge';
-import { Zap, CheckCircle } from 'lucide-react';
+import { Zap } from 'lucide-react';
 
 interface GaslessBadgeProps {
+  /** When false, badge is hidden (e.g. paymaster not configured). */
   isGasless?: boolean;
   className?: string;
 }
 
-export default function GaslessBadge({ 
-  isGasless = true, 
-  className = '' 
+export default function GaslessBadge({
+  isGasless = true,
+  className = '',
 }: GaslessBadgeProps) {
   if (!isGasless) {
     return null;
   }
 
   return (
-    <Badge 
+    <Badge
       variant="secondary"
       className={`bg-blue-500/20 text-blue-400 border-blue-500/30 ${className}`}
+      title="Eligible Coinbase One members may get sponsored gas. Others pay a small ETH fee."
     >
       <Zap className="h-3 w-3 mr-1" />
-      Gasless
+      Gasless*
     </Badge>
   );
 }

--- a/components/base-account/SubAccountDisplay.tsx
+++ b/components/base-account/SubAccountDisplay.tsx
@@ -4,19 +4,30 @@ import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card';
 import { Badge } from '@/components/ui/badge';
 import { Button } from '@/components/ui/button';
 import { useBaseAccount } from '@/hooks/useBaseAccount';
-import { Copy, CheckCircle, Shield, ExternalLink } from 'lucide-react';
+import { useETHBalance } from '@/hooks/useETHBalance';
+import { Copy, CheckCircle, Shield, ExternalLink, AlertCircle, Fuel } from 'lucide-react';
 import { useState } from 'react';
 
 interface SubAccountDisplayProps {
   className?: string;
   showActions?: boolean;
+  /** Called when user taps "Add ETH for gas" */
+  onFundEth?: () => void;
+  /** Whether paymaster is configured (gas may still be sponsored for eligible users). */
+  paymasterConfigured?: boolean;
 }
 
-export default function SubAccountDisplay({ 
+const iconButtonClass =
+  'h-6 w-6 p-0 text-white hover:text-white hover:bg-white/10';
+
+export default function SubAccountDisplay({
   className = '',
-  showActions = true 
+  showActions = true,
+  onFundEth,
+  paymasterConfigured = Boolean(process.env.NEXT_PUBLIC_PAYMASTER_AND_BUNDLER_ENDPOINT),
 }: SubAccountDisplayProps) {
   const { address, subAccountAddress, universalAddress, isConnected } = useBaseAccount();
+  const { balance: ethBalance, hasEnoughForGas, isLoading: ethLoading } = useETHBalance();
   const [copied, setCopied] = useState<string | null>(null);
 
   const copyToClipboard = async (text: string | null, type: string) => {
@@ -30,14 +41,16 @@ export default function SubAccountDisplay({
     }
   };
 
-  const openInExplorer = (address: string | null) => {
-    if (!address) return;
-    window.open(`https://basescan.org/address/${address}`, '_blank');
+  const openInExplorer = (addr: string | null) => {
+    if (!addr) return;
+    window.open(`https://basescan.org/address/${addr}`, '_blank', 'noopener,noreferrer');
   };
 
   if (!isConnected || !address) {
     return null;
   }
+
+  const showGasWarning = !ethLoading && !hasEnoughForGas;
 
   return (
     <Card className={`bg-gradient-to-br from-blue-900/20 to-purple-900/20 border-blue-500/30 ${className}`}>
@@ -64,12 +77,13 @@ export default function SubAccountDisplay({
               variant="ghost"
               size="sm"
               onClick={() => copyToClipboard(subAccountAddress, 'sub')}
-              className="h-6 w-6 p-0"
+              className={iconButtonClass}
+              aria-label="Copy sub account address"
             >
               {copied === 'sub' ? (
                 <CheckCircle className="h-3 w-3 text-green-400" />
               ) : (
-                <Copy className="h-3 w-3" />
+                <Copy className="h-3 w-3 text-white" />
               )}
             </Button>
             {showActions && (
@@ -77,9 +91,10 @@ export default function SubAccountDisplay({
                 variant="ghost"
                 size="sm"
                 onClick={() => openInExplorer(subAccountAddress)}
-                className="h-6 w-6 p-0"
+                className={iconButtonClass}
+                aria-label="View sub account on BaseScan"
               >
-                <ExternalLink className="h-3 w-3" />
+                <ExternalLink className="h-3 w-3 text-white" />
               </Button>
             )}
           </div>
@@ -102,12 +117,13 @@ export default function SubAccountDisplay({
                 variant="ghost"
                 size="sm"
                 onClick={() => copyToClipboard(universalAddress, 'universal')}
-                className="h-6 w-6 p-0"
+                className={iconButtonClass}
+                aria-label="Copy universal account address"
               >
                 {copied === 'universal' ? (
                   <CheckCircle className="h-3 w-3 text-green-400" />
                 ) : (
-                  <Copy className="h-3 w-3" />
+                  <Copy className="h-3 w-3 text-white" />
                 )}
               </Button>
               {showActions && (
@@ -115,14 +131,58 @@ export default function SubAccountDisplay({
                   variant="ghost"
                   size="sm"
                   onClick={() => openInExplorer(universalAddress)}
-                  className="h-6 w-6 p-0"
+                  className={iconButtonClass}
+                  aria-label="View universal account on BaseScan"
                 >
-                  <ExternalLink className="h-3 w-3" />
+                  <ExternalLink className="h-3 w-3 text-white" />
                 </Button>
               )}
             </div>
           </div>
         )}
+
+        {/* ETH balance for gas */}
+        <div className="space-y-2 pt-2 border-t border-white/10">
+          <div className="flex items-center justify-between">
+            <div className="flex items-center gap-2">
+              <Fuel className="h-3.5 w-3.5 text-gray-400" />
+              <span className="text-sm text-gray-300">ETH (gas)</span>
+            </div>
+            {!ethLoading && hasEnoughForGas && (
+              <CheckCircle className="h-4 w-4 text-green-400" aria-hidden />
+            )}
+            {showGasWarning && (
+              <AlertCircle className="h-4 w-4 text-amber-400" aria-hidden />
+            )}
+          </div>
+          <div className="text-sm font-medium text-white">
+            {ethLoading ? '...' : `${ethBalance.toFixed(6)} ETH`}
+          </div>
+          {showGasWarning && (
+            <div className="rounded-lg border border-amber-500/30 bg-amber-950/20 px-3 py-2 space-y-2">
+              <p className="text-xs text-amber-200">
+                {paymasterConfigured
+                  ? 'Gas sponsorship may not apply to your account. Add a small amount of ETH to cover network fees (~$0.02).'
+                  : 'Add a small amount of ETH to your wallet to cover network fees (~$0.02 per transaction).'}
+              </p>
+              {onFundEth && (
+                <Button
+                  type="button"
+                  size="sm"
+                  onClick={onFundEth}
+                  className="w-full bg-amber-600 hover:bg-amber-500 text-white text-xs"
+                >
+                  Add ETH for gas
+                </Button>
+              )}
+            </div>
+          )}
+          {!showGasWarning && !ethLoading && paymasterConfigured && (
+            <p className="text-[10px] text-gray-400">
+              Coinbase One members may get sponsored gas. Others use ETH above.
+            </p>
+          )}
+        </div>
 
         {/* Network Status */}
         <div className="flex items-center justify-between pt-2 border-t border-white/10">

--- a/components/game/GameEntry.tsx
+++ b/components/game/GameEntry.tsx
@@ -10,13 +10,13 @@ import { useUSDCBalance } from '@/hooks/useUSDCBalance';
 import { useTriviaContract } from '@/hooks/useTriviaContract';
 import { useBaseAccount } from '@/hooks/useBaseAccount';
 import { SignInWithBaseButton } from '@base-org/account-ui/react';
-import { generateFundingUrl, clearBrowserCache } from '@/lib/utils/funding';
+import { generateFundingUrl, generateAssetFundingUrl, clearBrowserCache } from '@/lib/utils/funding';
 import TrialStatusDisplay from './TrialStatusDisplay';
 import GamePayment from './GamePayment';
 import WalletWithBalance from '@/components/wallet/WalletWithBalance';
 import SubAccountDisplay from '@/components/base-account/SubAccountDisplay';
 import GaslessBadge from '@/components/base-account/GaslessBadge';
-import { Gamepad2, Crown, Coins, Play, DollarSign, AlertCircle, CheckCircle, Loader2 } from 'lucide-react';
+import { Gamepad2, Crown, Coins, Play, DollarSign, AlertCircle, CheckCircle, Loader2, Wallet } from 'lucide-react';
 // Removed OnchainKit transaction imports - using Base Account native methods instead
 import { createBaseAccountPaidGameCalls } from '@/lib/transaction/baseAccountCalls';
 import BaseAccountTransaction, {
@@ -63,13 +63,16 @@ export default function GameEntry({
   const [error, setError] = useState<string | null>(null);
   const [transactionError, setTransactionError] = useState<TransactionError | null>(null);
   const [fundingUrl, setFundingUrl] = useState<string | null>(null);
+  const [ethFundingUrl, setEthFundingUrl] = useState<string | null>(null);
   const [fundingSuccess, setFundingSuccess] = useState(false);
   const [isProcessingPayment, setIsProcessingPayment] = useState(false);
+  const [awaitingWalletOpen, setAwaitingWalletOpen] = useState(false);
   const [isStartingGame, setIsStartingGame] = useState(false);
   const [paymentFlowId, setPaymentFlowId] = useState(0);
   const [isFundingUrlGenerating, setIsFundingUrlGenerating] = useState(false);
   const paidGameCalls = useMemo(() => createBaseAccountPaidGameCalls(), []);
   const paidTxRef = useRef<BaseAccountTransactionHandle>(null);
+  const paymasterConfigured = Boolean(process.env.NEXT_PUBLIC_PAYMASTER_AND_BUNDLER_ENDPOINT);
 
   // Local countdown timer that ticks every second from the server-provided value
   const [localCountdown, setLocalCountdown] = useState(sessionTimeRemaining);
@@ -87,45 +90,37 @@ export default function GameEntry({
   const countdownSecs = localCountdown % 60;
   const countdownText = `${countdownMins}:${countdownSecs.toString().padStart(2, '0')}`;
 
-  useEffect(() => {
-    if (!isProcessingPayment) return;
-    const t = window.setTimeout(() => {
-      paidTxRef.current?.submit();
-    }, 0);
-    return () => window.clearTimeout(t);
-  }, [isProcessingPayment, paymentFlowId]);
 
-  // Reset funding URL when wallet address changes to prevent funding the wrong account
+  // Reset funding URLs when wallet address changes
   useEffect(() => {
     setFundingUrl(null);
+    setEthFundingUrl(null);
   }, [address]);
 
-  // Auto-generate funding URL with CDP session token when address is available
+  // Auto-generate USDC + ETH onramp URLs when address is available
   useEffect(() => {
-    const generateInitialFundingUrl = async () => {
-      if (!address || fundingUrl || isFundingUrlGenerating) return;
-      
+    const generateOnrampUrls = async () => {
+      if (!address || (fundingUrl && ethFundingUrl) || isFundingUrlGenerating) return;
+
       try {
         setIsFundingUrlGenerating(true);
-        console.log('🔄 Auto-generating CDP funding URL with session token for:', address);
-        
-        // Clear browser cache for fresh token
         await clearBrowserCache();
-        
-        // Generate fresh session token
         const sessionToken = await getSessionToken(address);
 
-        // Generate funding URL with session token
-        const url = generateFundingUrl({
-          walletAddress: address,
-          sessionToken: sessionToken
-        });
-        
-        console.log('✅ CDP funding URL ready for onramp');
-        setFundingUrl(url);
+        setFundingUrl(
+          generateFundingUrl({ walletAddress: address, sessionToken })
+        );
+        setEthFundingUrl(
+          generateAssetFundingUrl({
+            walletAddress: address,
+            sessionToken,
+            asset: 'ETH',
+            presetFiatAmount: '5',
+          })
+        );
         setError(null);
       } catch (err) {
-        console.error('❌ Failed to generate CDP funding URL:', err);
+        console.error('Failed to generate onramp URLs:', err);
         const errorMessage = err instanceof Error ? err.message : 'Unknown error occurred';
         setError(`Failed to initialize onramp: ${errorMessage}`);
       } finally {
@@ -133,8 +128,8 @@ export default function GameEntry({
       }
     };
 
-    generateInitialFundingUrl();
-  }, [address, fundingUrl, isFundingUrlGenerating, getSessionToken]);
+    generateOnrampUrls();
+  }, [address, fundingUrl, ethFundingUrl, isFundingUrlGenerating, getSessionToken]);
 
   // Handle transaction status updates
   const handleTransactionStatus = useCallback((
@@ -147,6 +142,7 @@ export default function GameEntry({
     if (status === 'success') {
       console.log('Paid game transaction successful!');
       setIsProcessingPayment(false);
+      setAwaitingWalletOpen(false);
       setIsStartingGame(false);
       setTransactionError(null);
       setError(null);
@@ -158,6 +154,7 @@ export default function GameEntry({
       });
     } else if (status === 'error') {
       setIsProcessingPayment(false);
+      setAwaitingWalletOpen(true);
       setIsStartingGame(false);
       
       // Check if user cancelled/rejected the transaction
@@ -213,6 +210,26 @@ export default function GameEntry({
           },
           { message: safeMessage }
         );
+        return;
+      }
+
+      const isInsufficientGas =
+        safeMessage.toLowerCase().includes('insufficient') &&
+        (safeMessage.toLowerCase().includes('eth') ||
+          safeMessage.toLowerCase().includes('gas') ||
+          safeMessage.toLowerCase().includes('fee'));
+
+      if (isInsufficientGas) {
+        const gasError: TransactionError = {
+          code: 'INSUFFICIENT_ETH_FOR_GAS',
+          message: 'Insufficient ETH for gas fees',
+          userMessage:
+            'You need a small amount of ETH in your wallet for network fees (~$0.02). Add ETH using the button on your wallet card, then open the wallet again.',
+          recoverable: true,
+          retryable: true,
+        };
+        setTransactionError(gasError);
+        setError(gasError.userMessage);
         return;
       }
 
@@ -343,18 +360,22 @@ export default function GameEntry({
     console.log('USDC Balance:', balance, 'Has enough:', hasEnoughForEntry);
     setPaymentFlowId((n) => n + 1);
     setIsProcessingPayment(true);
+    setAwaitingWalletOpen(true);
+    setIsStartingGame(false);
     setError(null);
+  };
 
-    try {
-      console.log('Paid entry: approve USDC then joinBattle (opens session on-chain if needed).');
-      
-      // The actual game start will be handled by the transaction success callback
-      console.log('Proceeding with paid game entry...');
-      
-    } catch (error) {
-      console.error('Error in paid game entry:', error);
-      setError(error instanceof Error ? error.message : 'Failed to start game session');
-      setIsProcessingPayment(false);
+  /** Must run synchronously from a user click so the wallet window is not blocked. */
+  const handleOpenWallet = () => {
+    setAwaitingWalletOpen(false);
+    setTransactionError(null);
+    setError(null);
+    paidTxRef.current?.submit();
+  };
+
+  const handleFundEth = () => {
+    if (ethFundingUrl) {
+      window.open(ethFundingUrl, '_blank', 'noopener,noreferrer');
     }
   };
 
@@ -376,15 +397,16 @@ export default function GameEntry({
   const handleRetryTransaction = () => {
     setTransactionError(null);
     setError(null);
-    setIsStartingGame(true);
     setPaymentFlowId((n) => n + 1);
     setIsProcessingPayment(true);
+    setAwaitingWalletOpen(true);
   };
 
   const handleDismissError = () => {
     setTransactionError(null);
     setError(null);
     setIsProcessingPayment(false);
+    setAwaitingWalletOpen(false);
     setIsStartingGame(false);
   };
 
@@ -403,20 +425,21 @@ export default function GameEntry({
       
       // Clear existing URL and cache
       setFundingUrl(null);
+      setEthFundingUrl(null);
       setError(null);
       await clearBrowserCache();
       
-      // Generate fresh session token
       const sessionToken = await getSessionToken(address);
 
-      // Generate new funding URL
-      const url = generateFundingUrl({
-        walletAddress: address,
-        sessionToken: sessionToken
-      });
-      
-      console.log('✅ New CDP funding URL generated');
-      setFundingUrl(url);
+      setFundingUrl(generateFundingUrl({ walletAddress: address, sessionToken }));
+      setEthFundingUrl(
+        generateAssetFundingUrl({
+          walletAddress: address,
+          sessionToken,
+          asset: 'ETH',
+          presetFiatAmount: '5',
+        })
+      );
       setFundingSuccess(true);
       setTimeout(() => setFundingSuccess(false), 2000);
     } catch (err) {
@@ -546,7 +569,11 @@ export default function GameEntry({
               {/* Base Account Display */}
               <div className="mb-4">
                 {isConnected ? (
-                  <SubAccountDisplay showActions={true} />
+                  <SubAccountDisplay
+                    showActions={true}
+                    onFundEth={handleFundEth}
+                    paymasterConfigured={paymasterConfigured}
+                  />
                 ) : (
                   <div className="text-center">
                     <SignInWithBaseButton colorScheme="light" onClick={connect} />
@@ -590,8 +617,13 @@ export default function GameEntry({
               <div className="flex items-center justify-center gap-2 text-sm mb-4">
                 <Coins className="h-4 w-4 text-yellow-400" />
                 <span className="text-gray-300">Entry Fee: 1 USDC</span>
-                <GaslessBadge isGasless={true} />
+                <GaslessBadge isGasless={paymasterConfigured} />
               </div>
+              {paymasterConfigured && (
+                <p className="text-[10px] text-gray-500 text-center -mt-2 mb-2">
+                  *Gasless for eligible Coinbase One members; others need a small ETH balance
+                </p>
+              )}
 
               {!isConnected || !address ? (
                 <div className="text-center">
@@ -691,18 +723,6 @@ export default function GameEntry({
 
                   {isProcessingPayment ? (
                     <div className="space-y-4">
-                      <div
-                        className="rounded-lg border border-amber-500/30 bg-amber-950/20 px-4 py-5 text-center"
-                        role="status"
-                        aria-live="polite"
-                      >
-                        <p className="text-sm font-medium text-amber-200">Processing entry</p>
-                        <p className="mt-2 text-sm text-zinc-200">
-                          {playerModeChoice === 'paid_multiplayer'
-                            ? 'Approve USDC in your wallet, then confirm join. When both transactions confirm, you’ll enter the multiplayer lobby automatically.'
-                            : 'Approve USDC in your wallet, then confirm join. When both transactions confirm, your paid game will start automatically.'}
-                        </p>
-                      </div>
                       <BaseAccountTransaction
                         ref={paidTxRef}
                         calls={paidGameCalls}
@@ -711,9 +731,44 @@ export default function GameEntry({
                         showSubmitButton={false}
                         connectedAddress={address}
                       />
+                      {awaitingWalletOpen ? (
+                        <div
+                          className="rounded-lg border border-blue-500/30 bg-blue-950/20 px-4 py-5 text-center space-y-4"
+                          role="status"
+                          aria-live="polite"
+                        >
+                          <p className="text-sm font-medium text-blue-200">Ready to sign</p>
+                          <p className="text-sm text-zinc-200">
+                            Tap below to open your Base wallet and approve USDC, then confirm join.
+                          </p>
+                          <Button
+                            type="button"
+                            onClick={handleOpenWallet}
+                            className="w-full bg-white text-black hover:bg-gray-100 font-semibold"
+                          >
+                            <Wallet className="h-4 w-4 mr-2" />
+                            Open wallet
+                          </Button>
+                        </div>
+                      ) : (
+                        <div
+                          className="rounded-lg border border-amber-500/30 bg-amber-950/20 px-4 py-5 text-center"
+                          role="status"
+                          aria-live="polite"
+                        >
+                          <p className="text-sm font-medium text-amber-200">Processing entry</p>
+                          <p className="mt-2 text-sm text-zinc-200">
+                            Confirm in your wallet, then wait for on-chain confirmation…
+                          </p>
+                        </div>
+                      )}
                       <Button
                         type="button"
-                        onClick={() => { setIsProcessingPayment(false); setIsStartingGame(false); }}
+                        onClick={() => {
+                          setIsProcessingPayment(false);
+                          setAwaitingWalletOpen(false);
+                          setIsStartingGame(false);
+                        }}
                         variant="outline"
                         className="w-full border-white text-red-400 hover:text-red-500 hover:bg-red-500/20 hover:cursor-pointer"
                       >

--- a/components/game/GameEntry.tsx
+++ b/components/game/GameEntry.tsx
@@ -99,6 +99,8 @@ export default function GameEntry({
 
   // Auto-generate USDC + ETH onramp URLs when address is available
   useEffect(() => {
+    let active = true;
+
     const generateOnrampUrls = async () => {
       if (!address || (fundingUrl && ethFundingUrl) || isFundingUrlGenerating) return;
 
@@ -106,6 +108,8 @@ export default function GameEntry({
         setIsFundingUrlGenerating(true);
         await clearBrowserCache();
         const sessionToken = await getSessionToken(address);
+
+        if (!active) return;
 
         setFundingUrl(
           generateFundingUrl({ walletAddress: address, sessionToken })
@@ -120,15 +124,22 @@ export default function GameEntry({
         );
         setError(null);
       } catch (err) {
+        if (!active) return;
         console.error('Failed to generate onramp URLs:', err);
         const errorMessage = err instanceof Error ? err.message : 'Unknown error occurred';
         setError(`Failed to initialize onramp: ${errorMessage}`);
       } finally {
-        setIsFundingUrlGenerating(false);
+        if (active) {
+          setIsFundingUrlGenerating(false);
+        }
       }
     };
 
     generateOnrampUrls();
+
+    return () => {
+      active = false;
+    };
   }, [address, fundingUrl, ethFundingUrl, isFundingUrlGenerating, getSessionToken]);
 
   // Handle transaction status updates

--- a/components/ui/TransactionErrorDisplay.tsx
+++ b/components/ui/TransactionErrorDisplay.tsx
@@ -126,7 +126,7 @@ export default function TransactionErrorDisplay({
               ) : (
                 <>
                   <RefreshCw className="h-3 w-3 mr-1" />
-                  Try Again
+                  {error.code === 'INSUFFICIENT_ETH_FOR_GAS' ? 'Open wallet' : 'Try again'}
                 </>
               )}
             </Button>

--- a/hooks/useETHBalance.ts
+++ b/hooks/useETHBalance.ts
@@ -8,6 +8,15 @@ import { base } from 'viem/chains';
 /** Minimum ETH needed to cover gas when paymaster sponsorship is unavailable (~$0.05 buffer). */
 const MIN_ETH_FOR_GAS = 0.00005;
 
+const initialState = {
+  balance: 0,
+  balanceWei: BigInt(0),
+  isLoading: false,
+  error: null as string | null,
+  hasEnoughForGas: false,
+  minRequired: MIN_ETH_FOR_GAS,
+};
+
 const publicClient = createPublicClient({
   chain: base,
   transport: http(process.env.NEXT_PUBLIC_BASE_RPC_URL ?? 'https://mainnet.base.org'),
@@ -26,16 +35,11 @@ export function useETHBalance() {
   const { address, subAccountAddress, isConnected } = useBaseAccount();
   const checkAddress = subAccountAddress || address;
 
-  const [state, setState] = useState<ETHBalanceState>({
-    balance: 0,
-    balanceWei: BigInt(0),
-    isLoading: false,
-    error: null,
-    hasEnoughForGas: false,
-    minRequired: MIN_ETH_FOR_GAS,
-  });
+  const [state, setState] = useState<ETHBalanceState>(initialState);
 
   const hasFetchedOnce = useRef(false);
+  const checkAddressRef = useRef(checkAddress);
+  checkAddressRef.current = checkAddress;
 
   const fetchETHBalance = useCallback(async () => {
     if (!checkAddress || !isConnected) {
@@ -58,6 +62,9 @@ export function useETHBalance() {
       const balanceWei = await publicClient.getBalance({
         address: checkAddress as `0x${string}`,
       });
+
+      if (checkAddress !== checkAddressRef.current) return;
+
       const balance = Number(formatEther(balanceWei));
       const hasEnough = balance >= MIN_ETH_FOR_GAS;
 
@@ -72,6 +79,8 @@ export function useETHBalance() {
         error: null,
       }));
     } catch (error) {
+      if (checkAddress !== checkAddressRef.current) return;
+
       console.error('Error fetching ETH balance:', error);
       hasFetchedOnce.current = true;
       setState((prev) => ({
@@ -88,7 +97,11 @@ export function useETHBalance() {
   }, [checkAddress, isConnected]);
 
   useEffect(() => {
-    if (!isConnected || !checkAddress) return;
+    if (!isConnected || !checkAddress) {
+      setState(initialState);
+      hasFetchedOnce.current = false;
+      return;
+    }
 
     fetchETHBalance();
     const interval = setInterval(fetchETHBalance, 30_000);

--- a/hooks/useETHBalance.ts
+++ b/hooks/useETHBalance.ts
@@ -1,0 +1,108 @@
+'use client';
+
+import { useState, useEffect, useCallback, useRef } from 'react';
+import { useBaseAccount } from './useBaseAccount';
+import { createPublicClient, http, formatEther } from 'viem';
+import { base } from 'viem/chains';
+
+/** Minimum ETH needed to cover gas when paymaster sponsorship is unavailable (~$0.05 buffer). */
+const MIN_ETH_FOR_GAS = 0.00005;
+
+const publicClient = createPublicClient({
+  chain: base,
+  transport: http(process.env.NEXT_PUBLIC_BASE_RPC_URL ?? 'https://mainnet.base.org'),
+});
+
+export interface ETHBalanceState {
+  balance: number;
+  balanceWei: bigint;
+  isLoading: boolean;
+  error: string | null;
+  hasEnoughForGas: boolean;
+  minRequired: number;
+}
+
+export function useETHBalance() {
+  const { address, subAccountAddress, isConnected } = useBaseAccount();
+  const checkAddress = subAccountAddress || address;
+
+  const [state, setState] = useState<ETHBalanceState>({
+    balance: 0,
+    balanceWei: BigInt(0),
+    isLoading: false,
+    error: null,
+    hasEnoughForGas: false,
+    minRequired: MIN_ETH_FOR_GAS,
+  });
+
+  const hasFetchedOnce = useRef(false);
+
+  const fetchETHBalance = useCallback(async () => {
+    if (!checkAddress || !isConnected) {
+      setState((prev) => ({
+        ...prev,
+        balance: 0,
+        balanceWei: BigInt(0),
+        hasEnoughForGas: false,
+        isLoading: false,
+        error: null,
+      }));
+      return;
+    }
+
+    if (!hasFetchedOnce.current) {
+      setState((prev) => ({ ...prev, isLoading: true, error: null }));
+    }
+
+    try {
+      const balanceWei = await publicClient.getBalance({
+        address: checkAddress as `0x${string}`,
+      });
+      const balance = Number(formatEther(balanceWei));
+      const hasEnough = balance >= MIN_ETH_FOR_GAS;
+
+      hasFetchedOnce.current = true;
+
+      setState((prev) => ({
+        ...prev,
+        balance,
+        balanceWei,
+        hasEnoughForGas: hasEnough,
+        isLoading: false,
+        error: null,
+      }));
+    } catch (error) {
+      console.error('Error fetching ETH balance:', error);
+      hasFetchedOnce.current = true;
+      setState((prev) => ({
+        ...prev,
+        isLoading: false,
+        error:
+          prev.balance > 0
+            ? null
+            : error instanceof Error
+              ? error.message
+              : 'Failed to fetch ETH balance',
+      }));
+    }
+  }, [checkAddress, isConnected]);
+
+  useEffect(() => {
+    if (!isConnected || !checkAddress) return;
+
+    fetchETHBalance();
+    const interval = setInterval(fetchETHBalance, 30_000);
+    return () => clearInterval(interval);
+  }, [fetchETHBalance, isConnected, checkAddress]);
+
+  const refreshBalance = useCallback(() => {
+    fetchETHBalance();
+  }, [fetchETHBalance]);
+
+  return {
+    ...state,
+    refreshBalance,
+    isConnected,
+    address: checkAddress,
+  };
+}

--- a/lib/utils/funding.ts
+++ b/lib/utils/funding.ts
@@ -27,21 +27,40 @@ export function generateFundingUrl({
   appId = process.env.NEXT_PUBLIC_CDP_PROJECT_ID || '5b09d242-5390-4db3-866f-bfc2ce575821',
   chains = ['base']
 }: FundingUrlParams): string {
-  // Use the correct One-Click-Buy URL path
-  const baseUrl = 'https://pay.coinbase.com/buy';
-  
-  // Build query parameters according to Coinbase One-Click-Buy requirements
-  // Note: addresses are already in the session token (from server-side API call)
-  // They should NOT be passed in the URL query parameters
-  const params = new URLSearchParams({
-    sessionToken: sessionToken,
-    defaultAsset: 'USDC',              // Required: specific asset to buy
-    fiatCurrency: 'USD',               // Required when using presetFiatAmount
-    presetFiatAmount: '2',            // Amount in USD (includes fees)
-    defaultPaymentMethod: 'CARD',      // CARD auto-upgrades to Apple Pay when available
-    defaultNetwork: 'base'             // Ensure it uses Base network
+  return generateAssetFundingUrl({
+    walletAddress,
+    sessionToken,
+    appId,
+    chains,
+    asset: 'USDC',
+    presetFiatAmount: '2',
   });
-  
+}
+
+export interface AssetFundingUrlParams extends FundingUrlParams {
+  asset: 'USDC' | 'ETH';
+  presetFiatAmount?: string;
+}
+
+/**
+ * Generates a Coinbase Pay One-Click-Buy URL for a specific asset (USDC or ETH).
+ */
+export function generateAssetFundingUrl({
+  sessionToken,
+  asset,
+  presetFiatAmount = asset === 'ETH' ? '5' : '2',
+}: AssetFundingUrlParams): string {
+  const baseUrl = 'https://pay.coinbase.com/buy';
+
+  const params = new URLSearchParams({
+    sessionToken,
+    defaultAsset: asset,
+    fiatCurrency: 'USD',
+    presetFiatAmount,
+    defaultPaymentMethod: 'CARD',
+    defaultNetwork: 'base',
+  });
+
   return `${baseUrl}?${params.toString()}`;
 }
 


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Fixes three issues reported during paid game entry on mobile:

1. **Base Account "Try again" modal** — Paid entry now uses an explicit **Open wallet** button so the popup opens from a direct user tap (fixes blocked popup / permission modal).

2. **Gas / paymaster fallback** — Wallet card shows **ETH balance**, low-gas warning, and **Add ETH for gas** onramp. Gasless badge clarifies Coinbase One eligibility.

3. **Icon contrast** — Copy and external-link icons are white on the dark wallet card.

## PR review follow-up

- Onramp URL generation uses an `active` flag to avoid applying stale session tokens after account switch/disconnect
- `useETHBalance` resets state on disconnect and ignores stale `getBalance` responses after address change

## Test plan

- [ ] Connect Base Account on paid multiplayer entry screen
- [ ] Verify copy / explorer icons are visible (white)
- [ ] Verify ETH balance shows on wallet card
- [ ] Tap "Enter Multiplayer Lobby" → see **Open wallet** button
- [ ] Tap **Open wallet** → Base wallet opens for USDC approve + join
- [ ] With zero ETH, confirm warning and **Add ETH for gas** opens onramp
- [ ] Switch/disconnect wallet quickly — no stale balance or wrong onramp URLs

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-e1a22355-37a7-4274-af02-ea7bd86a6b78"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-e1a22355-37a7-4274-af02-ea7bd86a6b78"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

