### PR TITLE
Address PR #81 review: ETH funding popup + fresh buy quote

### DIFF
--- a/lib/utils/funding.ts
+++ b/lib/utils/funding.ts
@@ -4,7 +4,7 @@
  */
 
 import type { OneClickBuyOptions, OneClickBuyResult } from '@/types/onramp';
-import { openFundingUrl } from '@/lib/utils/openFundingUrl';
+import { openFundingUrl, openBlankFundingPopup, navigateFundingTarget, closeFundingPopup } from '@/lib/utils/openFundingUrl';
 
 export interface FundingUrlParams {
   walletAddress: string;
@@ -80,7 +80,7 @@ export async function generateEthBuyQuoteUrl(
   });
 }
 
-/** Open ETH onramp: buy-quote first, then session-token URL fallback. */
+/** Open ETH onramp: fresh buy-quote first, then session-token fallbacks (blank popup pattern). */
 export async function openEthGasFunding(options: {
   walletAddress: string;
   getSessionToken: (address: string) => Promise<string>;
@@ -88,19 +88,25 @@ export async function openEthGasFunding(options: {
 }): Promise<{ opened: boolean; error?: string }> {
   const { walletAddress, getSessionToken, cachedUrl } = options;
 
-  if (cachedUrl && openFundingUrl(cachedUrl)) {
-    return { opened: true };
-  }
+  // Preserve user-gesture context for async quote fetch (avoids popup blockers on desktop)
+  const popup = openBlankFundingPopup();
 
+  // 1. Fresh buy quote (preferred — new quote every tap)
   try {
     const quote = await generateEthBuyQuoteUrl(walletAddress);
-    if (quote.url && openFundingUrl(quote.url)) {
+    if (quote.url && navigateFundingTarget(popup, quote.url)) {
       return { opened: true };
     }
   } catch (quoteErr) {
-    console.warn('ETH buy-quote failed, trying session token:', quoteErr);
+    console.warn('ETH buy-quote failed, trying session token fallback:', quoteErr);
   }
 
+  // 2. Cached session-token URL from page load
+  if (cachedUrl && navigateFundingTarget(popup, cachedUrl)) {
+    return { opened: true };
+  }
+
+  // 3. Fresh session token
   try {
     await clearBrowserCache();
     const sessionToken = await getSessionToken(walletAddress);
@@ -110,11 +116,13 @@ export async function openEthGasFunding(options: {
       asset: 'ETH',
       presetFiatAmount: '5',
     });
-    if (openFundingUrl(url)) {
+    if (navigateFundingTarget(popup, url)) {
       return { opened: true };
     }
+    closeFundingPopup(popup);
     return { opened: false, error: 'Could not open the funding page. Try the Base Account link below.' };
   } catch (err) {
+    closeFundingPopup(popup);
     const message = err instanceof Error ? err.message : 'Failed to start ETH purchase';
     return { opened: false, error: message };
   }

--- a/lib/utils/openFundingUrl.ts
+++ b/lib/utils/openFundingUrl.ts
@@ -22,3 +22,54 @@ export function openFundingUrl(url: string): boolean {
     return false;
   }
 }
+
+/**
+ * Open a blank popup synchronously during a user click to preserve gesture context.
+ * The caller sets popup.location.href once the async funding URL is ready.
+ */
+export function openBlankFundingPopup(): Window | null {
+  try {
+    const popup = window.open('about:blank', '_blank', 'noopener,noreferrer');
+    if (popup) {
+      popup.opener = null;
+      return popup;
+    }
+  } catch {
+    // fall through — caller will use same-tab navigation
+  }
+  return null;
+}
+
+/** Navigate a pre-opened popup or fall back to same-tab navigation. */
+export function navigateFundingTarget(popup: Window | null, url: string): boolean {
+  if (!url) return false;
+
+  if (popup) {
+    try {
+      if (!popup.closed) {
+        popup.location.href = url;
+        return true;
+      }
+    } catch {
+      // fall through
+    }
+  }
+
+  try {
+    window.location.assign(url);
+    return true;
+  } catch {
+    return false;
+  }
+}
+
+export function closeFundingPopup(popup: Window | null): void {
+  if (!popup) return;
+  try {
+    if (!popup.closed) {
+      popup.close();
+    }
+  } catch {
+    // ignore
+  }
+}


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
Addresses Gemini Code Assist review on the ETH gas funding flow.

## Changes

- **Blank popup pattern**: Opens `about:blank` synchronously on user click, then navigates the pre-opened window once the async funding URL is ready — avoids desktop popup blockers after `await`.
- **Fresh buy quote first**: Removed early `cachedUrl` short-circuit so every tap tries a new ETH buy-quote before falling back to cached or fresh session-token URLs.
- **Cleanup on failure**: Closes the blank popup when all funding paths fail.

## Files

- `lib/utils/openFundingUrl.ts` — `openBlankFundingPopup`, `navigateFundingTarget`, `closeFundingPopup`
- `lib/utils/funding.ts` — `openEthGasFunding` reorder + popup navigation

Note: Core ETH funding shipped in #80; this PR is the review follow-up only.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-e1a22355-37a7-4274-af02-ea7bd86a6b78"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-e1a22355-37a7-4274-af02-ea7bd86a6b78"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

