### PR TITLE
Modernize Base Account SDK integration

### DIFF
--- a/app/rootProvider.tsx
+++ b/app/rootProvider.tsx
@@ -1,58 +1,22 @@
 "use client";
-import { ReactNode, useEffect, useState } from "react";
-import { base } from "viem/chains";
-import { createBaseAccountSDK } from "@base-org/account";
+
+import { ReactNode, useEffect } from "react";
 import { WagmiProvider } from "wagmi";
 import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
 import { SpacetimeProvider } from "@/components/providers/SpacetimeProvider";
+import { BaseAccountProvider } from "@/components/providers/BaseAccountProvider";
 import { wagmiConfig } from "@/lib/wagmi";
 
-// Create query client
 const queryClient = new QueryClient();
 
-// Base Account provider component
-function BaseAccountProviderWrapper({ children }: { children: ReactNode }) {
-  const [baseAccountSDK, setBaseAccountSDK] = useState<any>(null);
-
-  // Initialize Base Account SDK client-side only
+function FarcasterReadyEffect() {
   useEffect(() => {
-    if (typeof window !== "undefined") {
-      try {
-        const sdk = createBaseAccountSDK({
-          appName: 'BEAT ME',
-          appLogoUrl: 'https://base.org/logo.png',
-          appChainIds: [base.id],
-          subAccounts: {
-            creation: 'on-connect',
-            defaultAccount: 'sub',
-          },
-          paymasterUrls: process.env.NEXT_PUBLIC_PAYMASTER_AND_BUNDLER_ENDPOINT ? [process.env.NEXT_PUBLIC_PAYMASTER_AND_BUNDLER_ENDPOINT] : undefined,
-        });
-        setBaseAccountSDK(sdk);
-      } catch (error) {
-        console.error('Failed to initialize Base Account SDK:', error);
-      }
-    }
-  }, []);
-
-  // Call ready() as early as possible to prevent jitter and content reflows
-  useEffect(() => {
-    // Safely check if Farcaster miniapp SDK is available
     if (typeof window !== "undefined" && window.sdk?.actions?.ready) {
-      console.log('[Farcaster] SDK detected, calling ready()');
       window.sdk.actions.ready();
-      console.log('[Farcaster] ready() called successfully');
-    } else {
-      console.log('[Farcaster] SDK not available:', {
-        hasWindow: typeof window !== "undefined",
-        hasSdk: typeof window !== "undefined" && !!window.sdk,
-        hasActions: typeof window !== "undefined" && !!window.sdk?.actions,
-        hasReady: typeof window !== "undefined" && typeof window.sdk?.actions?.ready === 'function'
-      });
     }
   }, []);
 
-  return <>{children}</>;
+  return null;
 }
 
 export function RootProvider({ children }: { children: ReactNode }) {
@@ -60,9 +24,10 @@ export function RootProvider({ children }: { children: ReactNode }) {
     <WagmiProvider config={wagmiConfig}>
       <QueryClientProvider client={queryClient}>
         <SpacetimeProvider>
-          <BaseAccountProviderWrapper>
+          <BaseAccountProvider>
+            <FarcasterReadyEffect />
             {children}
-          </BaseAccountProviderWrapper>
+          </BaseAccountProvider>
         </SpacetimeProvider>
       </QueryClientProvider>
     </WagmiProvider>

--- a/components/base-account/AutoSpendManager.tsx
+++ b/components/base-account/AutoSpendManager.tsx
@@ -1,258 +1,32 @@
 'use client';
 
-import { useState, useEffect } from 'react';
 import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card';
-import { Button } from '@/components/ui/button';
-import { Badge } from '@/components/ui/badge';
-import { Loader2, CheckCircle, AlertCircle, Zap, Shield, Settings } from 'lucide-react';
-import { useBaseAccount } from '@/hooks/useBaseAccount';
-import {
-  configureAutoSpend,
-  checkAutoSpendStatus,
-  revokeAutoSpend,
-  getAutoSpendConfig
-} from '@/lib/base-account/autoSpend';
+import { Zap } from 'lucide-react';
 
+/**
+ * @deprecated Manual auto-spend configuration is no longer required.
+ * Sub-account funding is handled by the Base Account SDK on the first transaction.
+ */
 export default function AutoSpendManager() {
-  const { isConnected } = useBaseAccount();
-  const [isLoading, setIsLoading] = useState(true);
-  const [isConfiguring, setIsConfiguring] = useState(false);
-  const [isRevoking, setIsRevoking] = useState(false);
-  const [autoSpendStatus, setAutoSpendStatus] = useState<{
-    isConfigured: boolean;
-    allowance?: string;
-    spender?: string;
-    error?: string;
-  } | null>(null);
-  const [config, setConfig] = useState<{
-    universalAddress?: string;
-    subAccountAddress?: string;
-    tokenAddress?: string;
-    amount?: string;
-    duration?: number;
-    isActive?: boolean;
-    error?: string;
-  } | null>(null);
-  const [error, setError] = useState<string | null>(null);
-  const [successMessage, setSuccessMessage] = useState<string | null>(null);
-
-  const fetchStatus = async () => {
-    if (!isConnected) {
-      setAutoSpendStatus(null);
-      setConfig(null);
-      setIsLoading(false);
-      return;
-    }
-
-    setIsLoading(true);
-    setError(null);
-
-    try {
-      const [status, configData] = await Promise.all([
-        checkAutoSpendStatus(),
-        getAutoSpendConfig()
-      ]);
-
-      setAutoSpendStatus(status);
-      setConfig(configData);
-    } catch (err: any) {
-      console.error('Error fetching Auto Spend status:', err);
-      setError(err.message || 'Failed to fetch Auto Spend status');
-    } finally {
-      setIsLoading(false);
-    }
-  };
-
-  useEffect(() => {
-    if (!isConnected) return;
-    fetchStatus();
-    const interval = setInterval(fetchStatus, 15000); // Refresh every 15 seconds
-    return () => clearInterval(interval);
-  }, [isConnected]);
-
-  const handleConfigure = async () => {
-    setIsConfiguring(true);
-    setError(null);
-    setSuccessMessage(null);
-
-    try {
-      const result = await configureAutoSpend();
-      
-      if (result.success) {
-        setSuccessMessage('Auto Spend Permissions configured successfully!');
-        await fetchStatus(); // Refresh status
-      } else {
-        setError(result.error || 'Failed to configure Auto Spend Permissions');
-      }
-    } catch (err: any) {
-      console.error('Error configuring Auto Spend:', err);
-      setError(err.message || 'Failed to configure Auto Spend Permissions');
-    } finally {
-      setIsConfiguring(false);
-    }
-  };
-
-  const handleRevoke = async () => {
-    setIsRevoking(true);
-    setError(null);
-    setSuccessMessage(null);
-
-    try {
-      const result = await revokeAutoSpend();
-      
-      if (result.success) {
-        setSuccessMessage('Auto Spend Permissions revoked successfully!');
-        await fetchStatus(); // Refresh status
-      } else {
-        setError(result.error || 'Failed to revoke Auto Spend Permissions');
-      }
-    } catch (err: any) {
-      console.error('Error revoking Auto Spend:', err);
-      setError(err.message || 'Failed to revoke Auto Spend Permissions');
-    } finally {
-      setIsRevoking(false);
-    }
-  };
-
-  if (!isConnected) {
-    return null; // Only show if connected
-  }
-
-  const formatDuration = (seconds: number) => {
-    const days = Math.floor(seconds / (24 * 60 * 60));
-    return `${days} days`;
-  };
-
   return (
     <Card className="bg-gradient-to-br from-blue-900/20 to-purple-900/20 border-blue-500/30">
       <CardHeader className="pb-3">
         <CardTitle className="flex items-center gap-2 text-lg text-white">
           <Zap className="h-5 w-5 text-blue-400" />
-          Auto Spend Permissions
+          Sub-Account Auto Spend
         </CardTitle>
       </CardHeader>
-      <CardContent className="space-y-4">
-        {/* Status Display */}
-        <div className="space-y-3">
-          <div className="flex items-center justify-between text-sm">
-            <span className="text-gray-300">Status:</span>
-            {isLoading ? (
-              <Loader2 className="h-4 w-4 animate-spin text-gray-400" />
-            ) : autoSpendStatus?.isConfigured ? (
-              <Badge className="bg-green-500/20 text-green-400 border-green-500/30">
-                <CheckCircle className="h-3 w-3 mr-1" />
-                Active
-              </Badge>
-            ) : (
-              <Badge variant="destructive" className="bg-red-500/20 text-red-400 border-red-500/30">
-                <AlertCircle className="h-3 w-3 mr-1" />
-                Not Configured
-              </Badge>
-            )}
-          </div>
-
-          {config && (
-            <>
-              <div className="flex items-center justify-between text-sm">
-                <span className="text-gray-300">Amount:</span>
-                <span className="font-medium text-white">{config.amount} USDC</span>
-              </div>
-              <div className="flex items-center justify-between text-sm">
-                <span className="text-gray-300">Duration:</span>
-                <span className="font-medium text-white">
-                  {config.duration ? formatDuration(config.duration) : 'N/A'}
-                </span>
-              </div>
-            </>
-          )}
-
-          {autoSpendStatus?.allowance && (
-            <div className="flex items-center justify-between text-sm">
-              <span className="text-gray-300">Current Allowance:</span>
-              <span className="font-medium text-white">
-                {parseFloat(autoSpendStatus.allowance).toFixed(2)} USDC
-              </span>
-            </div>
-          )}
-        </div>
-
-        {/* Benefits Info */}
-        <div className="bg-blue-500/10 border border-blue-500/20 rounded-lg p-3">
-          <div className="text-xs text-blue-300">
-            <p className="font-medium mb-1">Auto Spend Benefits:</p>
-            <ul className="space-y-1 text-blue-200/80">
-              <li>• Automatic funding from universal account</li>
-              <li>• Seamless gameplay without manual approvals</li>
-              <li>• Enhanced security with sub-account isolation</li>
-              <li>• Gasless transactions via paymaster</li>
-            </ul>
-          </div>
-        </div>
-
-        {/* Error Display */}
-        {error && (
-          <div className="text-xs text-red-400 flex items-center gap-1">
-            <AlertCircle className="h-3 w-3" />
-            {error}
-          </div>
-        )}
-
-        {/* Success Message */}
-        {successMessage && (
-          <div className="text-xs text-green-400 flex items-center gap-1">
-            <CheckCircle className="h-3 w-3" />
-            {successMessage}
-          </div>
-        )}
-
-        {/* Action Buttons */}
-        <div className="flex gap-2">
-          <Button
-            onClick={handleConfigure}
-            disabled={isConfiguring || isLoading || autoSpendStatus?.isConfigured}
-            className="flex-1 bg-gradient-to-r from-blue-500 to-purple-500 hover:from-blue-400 hover:to-purple-400 text-white"
-          >
-            {isConfiguring ? (
-              <Loader2 className="h-4 w-4 mr-2 animate-spin" />
-            ) : (
-              <Zap className="h-4 w-4 mr-2" />
-            )}
-            {autoSpendStatus?.isConfigured ? 'Already Configured' : 'Enable Auto Spend'}
-          </Button>
-          
-          <Button
-            onClick={handleRevoke}
-            disabled={isRevoking || isLoading || !autoSpendStatus?.isConfigured}
-            variant="outline"
-            className="bg-white/10 border-white/20 text-white hover:bg-white/20"
-          >
-            {isRevoking ? (
-              <Loader2 className="h-4 w-4 animate-spin" />
-            ) : (
-              <Shield className="h-4 w-4" />
-            )}
-          </Button>
-        </div>
-
-        {/* Configuration Details */}
-        {config && (config.universalAddress || config.subAccountAddress) && (
-          <div className="bg-black/30 rounded-lg p-3">
-            <div className="text-xs text-gray-400 space-y-1">
-              <div className="flex justify-between">
-                <span>Universal Account:</span>
-                <span className="font-mono text-white">
-                  {config.universalAddress?.slice(0, 6)}...{config.universalAddress?.slice(-4)}
-                </span>
-              </div>
-              <div className="flex justify-between">
-                <span>Sub Account:</span>
-                <span className="font-mono text-white">
-                  {config.subAccountAddress?.slice(0, 6)}...{config.subAccountAddress?.slice(-4)}
-                </span>
-              </div>
-            </div>
-          </div>
-        )}
+      <CardContent className="space-y-3">
+        <p className="text-sm text-gray-300">
+          Sub-account funding is managed automatically by the Base Account SDK. On your first
+          game transaction, you will be prompted to transfer tokens from your universal account
+          and optionally grant ongoing spend permissions.
+        </p>
+        <p className="text-xs text-gray-400">
+          No manual configuration is needed. To disable auto-funding, set{' '}
+          <code className="text-xs">subAccounts.funding: &apos;manual&apos;</code> in the SDK
+          config (not recommended for this app).
+        </p>
       </CardContent>
     </Card>
   );

--- a/components/base-account/BaseAccountButton.tsx
+++ b/components/base-account/BaseAccountButton.tsx
@@ -3,7 +3,7 @@
 import { Button } from '@/components/ui/button';
 import { SignInWithBaseButton } from '@base-org/account-ui/react';
 import { useBaseAccount } from '@/hooks/useBaseAccount';
-import { Shield, LogOut, CheckCircle } from 'lucide-react';
+import { LogOut, CheckCircle } from 'lucide-react';
 
 interface BaseAccountButtonProps {
   onConnect?: () => void;
@@ -13,21 +13,25 @@ interface BaseAccountButtonProps {
   size?: 'sm' | 'default' | 'lg';
 }
 
-export default function BaseAccountButton({ 
-  onConnect, 
-  onDisconnect, 
+export default function BaseAccountButton({
+  onConnect,
+  onDisconnect,
   className = '',
   variant = 'default',
-  size = 'default'
+  size = 'default',
 }: BaseAccountButtonProps) {
-  const { isConnected, connect, disconnect } = useBaseAccount();
+  const { isConnected, isConnecting, connect, disconnect } = useBaseAccount();
 
   const handleConnect = async () => {
+    if (isConnecting) {
+      return;
+    }
+
     try {
       await connect();
       onConnect?.();
     } catch (error) {
-      console.error('❌ Base Account connection failed:', error);
+      console.error('Base Account connection failed:', error);
     }
   };
 
@@ -53,8 +57,10 @@ export default function BaseAccountButton({
 
   return (
     <SignInWithBaseButton
+      align="center"
+      variant="solid"
       colorScheme="light"
-      onClick={handleConnect}
+      onClick={isConnecting ? undefined : handleConnect}
     />
   );
 }

--- a/components/base-account/BaseAccountTestSuite.tsx
+++ b/components/base-account/BaseAccountTestSuite.tsx
@@ -36,7 +36,7 @@ interface TestResult {
 }
 
 export default function BaseAccountTestSuite() {
-  const { address, universalAddress, subAccountAddress, isConnected, isConnecting, error } = useBaseAccount();
+  const { address, universalAddress, subAccountAddress, isConnected, isConnecting, connect, error } = useBaseAccount();
   const { balance, hasEnoughForEntry, isLoading: balanceLoading } = useUSDCBalance();
   const [testResults, setTestResults] = useState<TestResult[]>([]);
   const [isRunningTests, setIsRunningTests] = useState(false);
@@ -243,7 +243,12 @@ export default function BaseAccountTestSuite() {
               <div className="text-gray-400 text-sm">
                 {isConnecting ? 'Connecting...' : 'Not connected to Base Account'}
               </div>
-              <SignInWithBaseButton colorScheme="light" />
+              <SignInWithBaseButton
+                align="center"
+                variant="solid"
+                colorScheme="light"
+                onClick={isConnecting ? undefined : connect}
+              />
             </div>
           )}
         </CardContent>

--- a/components/base-account/BaseAccountTransaction.tsx
+++ b/components/base-account/BaseAccountTransaction.tsx
@@ -3,7 +3,8 @@
 import { useState, useCallback, useImperativeHandle, forwardRef, useRef } from 'react';
 import { Button } from '@/components/ui/button';
 import { useBaseAccount } from '@/hooks/useBaseAccount';
-import { createBaseAccountSDK } from '@base-org/account';
+import { useBaseAccountContext } from '@/components/providers/BaseAccountProvider';
+import { getBaseAccountProvider } from '@/lib/base-account/sdk';
 import { base } from 'viem/chains';
 import { createPublicClient, http, numberToHex, type Hex } from 'viem';
 import { Loader2, CheckCircle, XCircle } from 'lucide-react';
@@ -47,6 +48,7 @@ const BaseAccountTransaction = forwardRef<BaseAccountTransactionHandle, BaseAcco
     ref
   ) {
   const { isConnected: hookConnected, address: hookAddress } = useBaseAccount();
+  const { provider: contextProvider } = useBaseAccountContext();
   // Prefer parent-provided address to avoid race condition where hook hasn't resolved yet
   const address = connectedAddress || hookAddress;
   const isConnected = Boolean(address) || hookConnected;
@@ -68,19 +70,7 @@ const BaseAccountTransaction = forwardRef<BaseAccountTransactionHandle, BaseAcco
     onStatus?.('pending', 'Transaction pending...');
 
     try {
-      // Initialize Base Account SDK
-      const sdk = createBaseAccountSDK({
-        appName: 'BEAT ME',
-        appLogoUrl: 'https://base.org/logo.png',
-        appChainIds: [base.id],
-        subAccounts: {
-          creation: 'on-connect',
-          defaultAccount: 'sub',
-        },
-        paymasterUrls: process.env.NEXT_PUBLIC_PAYMASTER_AND_BUNDLER_ENDPOINT ? [process.env.NEXT_PUBLIC_PAYMASTER_AND_BUNDLER_ENDPOINT] : undefined,
-      });
-
-      const provider = sdk.getProvider();
+      const provider = contextProvider ?? getBaseAccountProvider();
 
       // Smart accounts (4337): each user op bumps the account nonce on-chain only after
       // inclusion. Sending approve + joinBattle back-to-back causes AA25 invalid account nonce

--- a/components/base-account/SpendPermissionBadge.tsx
+++ b/components/base-account/SpendPermissionBadge.tsx
@@ -2,7 +2,12 @@
 
 import { Badge } from '@/components/ui/badge';
 import { useBaseAccount } from '@/hooks/useBaseAccount';
-import { checkSpendPermission, getSpendPermissionDetails } from '@/lib/base-account/spendPermissions';
+import {
+  checkSpendPermission,
+  getSpendPermissionDetails,
+  isGameSpendPermissionsEnabled,
+  type SpendPermissionDetails,
+} from '@/lib/base-account/spendPermissions';
 import { Shield, AlertTriangle, Clock, CheckCircle } from 'lucide-react';
 import { useEffect, useState } from 'react';
 
@@ -11,37 +16,64 @@ interface SpendPermissionBadgeProps {
   showDetails?: boolean;
 }
 
-export default function SpendPermissionBadge({ 
+export default function SpendPermissionBadge({
   className = '',
-  showDetails = false 
+  showDetails = false,
 }: SpendPermissionBadgeProps) {
   const { address, isConnected } = useBaseAccount();
   const [hasPermission, setHasPermission] = useState(false);
-  const [permissionDetails, setPermissionDetails] = useState<any>(null);
+  const [permissionDetails, setPermissionDetails] = useState<SpendPermissionDetails | null>(null);
 
   useEffect(() => {
-    if (address && isConnected) {
-      const hasSpendPermission = checkSpendPermission(address);
-      setHasPermission(hasSpendPermission);
-      
-      if (hasSpendPermission) {
-        const details = getSpendPermissionDetails(address);
-        setPermissionDetails(details);
+    let cancelled = false;
+
+    const load = async () => {
+      if (!address || !isConnected || !isGameSpendPermissionsEnabled()) {
+        if (!cancelled) {
+          setHasPermission(false);
+          setPermissionDetails(null);
+        }
+        return;
       }
-    } else {
-      setHasPermission(false);
-      setPermissionDetails(null);
-    }
+
+      const active = await checkSpendPermission(address);
+      if (cancelled) {
+        return;
+      }
+
+      setHasPermission(active);
+
+      if (active) {
+        const details = await getSpendPermissionDetails(address);
+        if (!cancelled) {
+          setPermissionDetails(details);
+        }
+      } else {
+        setPermissionDetails(null);
+      }
+    };
+
+    load();
+
+    return () => {
+      cancelled = true;
+    };
   }, [address, isConnected]);
 
-  if (!isConnected || !address) {
+  if (!isConnected || !address || !isGameSpendPermissionsEnabled()) {
     return null;
   }
 
   const getBadgeVariant = () => {
-    if (!hasPermission) return 'destructive';
-    if (permissionDetails?.isExpired) return 'destructive';
-    if (permissionDetails?.daysRemaining < 7) return 'secondary';
+    if (!hasPermission) {
+      return 'destructive';
+    }
+    if (permissionDetails?.isExpired) {
+      return 'destructive';
+    }
+    if (permissionDetails && permissionDetails.daysRemaining < 7) {
+      return 'secondary';
+    }
     return 'default';
   };
 
@@ -54,7 +86,7 @@ export default function SpendPermissionBadge({
         </>
       );
     }
-    
+
     if (permissionDetails?.isExpired) {
       return (
         <>
@@ -63,8 +95,8 @@ export default function SpendPermissionBadge({
         </>
       );
     }
-    
-    if (permissionDetails?.daysRemaining < 7) {
+
+    if (permissionDetails && permissionDetails.daysRemaining < 7) {
       return (
         <>
           <Clock className="h-3 w-3 mr-1" />
@@ -72,7 +104,7 @@ export default function SpendPermissionBadge({
         </>
       );
     }
-    
+
     return (
       <>
         <CheckCircle className="h-3 w-3 mr-1" />
@@ -85,7 +117,7 @@ export default function SpendPermissionBadge({
     if (!hasPermission || permissionDetails?.isExpired) {
       return 'bg-red-500/20 text-red-400 border-red-500/30';
     }
-    if (permissionDetails?.daysRemaining < 7) {
+    if (permissionDetails && permissionDetails.daysRemaining < 7) {
       return 'bg-yellow-500/20 text-yellow-400 border-yellow-500/30';
     }
     return 'bg-green-500/20 text-green-400 border-green-500/30';
@@ -93,13 +125,11 @@ export default function SpendPermissionBadge({
 
   return (
     <div className={`flex items-center gap-2 ${className}`}>
-      <Badge 
-        variant={getBadgeVariant()}
-        className={getBadgeClassName()}
-      >
+      <Badge variant={getBadgeVariant()} className={getBadgeClassName()}>
+        <Shield className="h-3 w-3 mr-1" />
         {getBadgeContent()}
       </Badge>
-      
+
       {showDetails && hasPermission && permissionDetails && (
         <div className="text-xs text-gray-400">
           {permissionDetails.daysRemaining > 0 && (

--- a/components/game/GameEntry.tsx
+++ b/components/game/GameEntry.tsx
@@ -54,7 +54,7 @@ export default function GameEntry({
 }: GameEntryProps) {
   const isPaidMode = playerModeChoice === 'paid_solo' || playerModeChoice === 'paid_multiplayer';
   console.log('GameEntry received playerModeChoice:', playerModeChoice);
-  const { address, universalAddress, isConnected, connect } = useBaseAccount();
+  const { address, universalAddress, isConnected, connect, isConnecting } = useBaseAccount();
   const { trialStatus, isLoading: trialLoading, incrementTrialGame } = useTrialStatus(address || undefined, entryToken || undefined);
   const { getSessionToken, isLoading: sessionLoading, error: sessionError } = useSessionToken();
   const { balance, hasEnoughForEntry, isLoading: balanceLoading, error: balanceError } = useUSDCBalance();
@@ -549,7 +549,12 @@ export default function GameEntry({
                   <SubAccountDisplay showActions={true} />
                 ) : (
                   <div className="text-center">
-                    <SignInWithBaseButton colorScheme="light" onClick={connect} />
+                    <SignInWithBaseButton
+                      align="center"
+                      variant="solid"
+                      colorScheme="light"
+                      onClick={isConnecting ? undefined : connect}
+                    />
                   </div>
                 )}
               </div>

--- a/components/game/GamePayment.tsx
+++ b/components/game/GamePayment.tsx
@@ -1,14 +1,15 @@
 'use client';
 
 import { useBaseAccount } from '@/hooks/useBaseAccount';
-import { useState, useEffect } from 'react';
+import { useState } from 'react';
 import { BasePayButton } from '@base-org/account-ui/react';
-import { pay, getPaymentStatus } from '@base-org/account';
 import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card';
 import { Button } from '@/components/ui/button';
 import { Badge } from '@/components/ui/badge';
 import { DollarSign, CheckCircle, Loader2, AlertCircle, Shield, Zap } from 'lucide-react';
 import SpendPermissionManager from './SpendPermissionManager';
+import { useBasePay } from '@/hooks/useBasePay';
+import { BASE_PAY_AMOUNTS } from '@/lib/base-account/config';
 
 interface GamePaymentProps {
   onPaymentComplete?: () => void;
@@ -17,63 +18,44 @@ interface GamePaymentProps {
 
 export default function GamePayment({ onPaymentComplete, onBack }: GamePaymentProps) {
   const { address, isConnected } = useBaseAccount();
-  const [paymentStatus, setPaymentStatus] = useState<'idle' | 'processing' | 'completed' | 'failed'>('idle');
-  const [paymentId, setPaymentId] = useState<string | null>(null);
+  const { handleBasePay, isProcessing, error: payError } = useBasePay();
+  const [paymentStatus, setPaymentStatus] = useState<
+    'idle' | 'processing' | 'completed' | 'failed'
+  >('idle');
   const [error, setError] = useState<string | null>(null);
   const [showSpendPermissions, setShowSpendPermissions] = useState(false);
 
-  const handleBasePay = async () => {
-    if (!address) return;
-    
+  const handleFunding = async () => {
+    if (!address) {
+      return;
+    }
+
     setPaymentStatus('processing');
     setError(null);
-    
-    try {
-      console.log('Initiating Base Pay for wallet:', address);
-      
-      // Use Base Pay to add USDC funds
-      const payment = await pay({
-        amount: '10.00',
+
+    const result = await handleBasePay(
+      {
+        amount: BASE_PAY_AMOUNTS.gamePayment,
         to: address,
-        testnet: false, // Use mainnet for production
-      });
-      
-      setPaymentId(payment.id);
-      console.log('Base Pay initiated:', payment.id);
-      
-      // Poll for payment status
-      const checkStatus = async () => {
-        try {
-          const status = await getPaymentStatus({ id: payment.id, testnet: false });
-          console.log('Payment status:', status);
-          
-          if (status.status === 'completed') {
-            setPaymentStatus('completed');
-            onPaymentComplete?.();
-            setTimeout(() => setPaymentStatus('idle'), 3000);
-          } else if (status.status === 'failed') {
-            setPaymentStatus('failed');
-            setError('Payment failed');
-          } else {
-            // Still pending, check again in 2 seconds
-            setTimeout(checkStatus, 2000);
-          }
-        } catch (error) {
-          console.error('Error checking payment status:', error);
+        testnet: false,
+      },
+      (success) => {
+        if (success) {
+          setPaymentStatus('completed');
+          onPaymentComplete?.();
+          setTimeout(() => setPaymentStatus('idle'), 3000);
+        } else {
           setPaymentStatus('failed');
-          setError('Failed to check payment status');
         }
-      };
-      
-      // Start polling
-      setTimeout(checkStatus, 2000);
-      
-    } catch (err) {
-      console.error('Base Pay failed:', err);
-      setPaymentStatus('failed');
-      setError(err instanceof Error ? err.message : 'Payment failed');
+      }
+    );
+
+    if (!result.success) {
+      setError(result.error);
     }
   };
+
+  const displayError = error || payError;
 
   if (!isConnected || !address) {
     return (
@@ -92,7 +74,7 @@ export default function GamePayment({ onPaymentComplete, onBack }: GamePaymentPr
     );
   }
 
-  if (paymentStatus === 'processing') {
+  if (paymentStatus === 'processing' || isProcessing) {
     return (
       <div className="bg-[#000000] min-h-screen w-full flex items-center justify-center px-4">
         <div className="w-full max-w-[390px] md:max-w-[428px]">
@@ -107,14 +89,6 @@ export default function GamePayment({ onPaymentComplete, onBack }: GamePaymentPr
               <div className="text-sm text-gray-300 text-center">
                 Your Base Pay transaction is being processed...
               </div>
-              
-              {paymentId && (
-                <div className="bg-black/30 rounded-lg p-3">
-                  <div className="text-xs text-gray-400 text-center">
-                    Payment ID: {paymentId.slice(0, 8)}...{paymentId.slice(-8)}
-                  </div>
-                </div>
-              )}
             </CardContent>
           </Card>
         </div>
@@ -135,10 +109,13 @@ export default function GamePayment({ onPaymentComplete, onBack }: GamePaymentPr
             </CardHeader>
             <CardContent className="space-y-4">
               <div className="text-sm text-gray-300 text-center">
-                Your wallet has been funded with $10 USDC!
+                Your wallet has been funded with ${BASE_PAY_AMOUNTS.gamePayment} USDC!
               </div>
-              
-              <Badge variant="secondary" className="bg-green-500/20 text-green-400 w-full justify-center">
+
+              <Badge
+                variant="secondary"
+                className="bg-green-500/20 text-green-400 w-full justify-center"
+              >
                 <CheckCircle className="h-3 w-3 mr-1" />
                 Payment Complete
               </Badge>
@@ -152,7 +129,6 @@ export default function GamePayment({ onPaymentComplete, onBack }: GamePaymentPr
   return (
     <div className="bg-[#000000] min-h-screen w-full flex items-center justify-center px-4">
       <div className="w-full max-w-[390px] md:max-w-[428px] space-y-4">
-        {/* Header */}
         <Card className="bg-gradient-to-br from-purple-900/20 to-blue-900/20 border-purple-500/30">
           <CardHeader className="pb-3">
             <CardTitle className="flex items-center gap-2 text-lg text-white">
@@ -164,7 +140,7 @@ export default function GamePayment({ onPaymentComplete, onBack }: GamePaymentPr
             <div className="text-sm text-gray-300 text-center">
               Add USDC to your Base Account to join the game and compete for prizes
             </div>
-            
+
             <div className="flex items-center justify-center gap-2 text-sm">
               <Zap className="h-4 w-4 text-blue-400" />
               <span className="text-gray-300">Gasless Transactions</span>
@@ -175,19 +151,17 @@ export default function GamePayment({ onPaymentComplete, onBack }: GamePaymentPr
           </CardContent>
         </Card>
 
-        {/* Error Display */}
-        {error && (
+        {displayError && (
           <Card className="bg-red-900/20 border-red-500/30">
             <CardContent className="p-4">
               <div className="text-red-400 text-sm text-center flex items-center gap-2">
                 <AlertCircle className="h-4 w-4" />
-                {error}
+                {displayError}
               </div>
             </CardContent>
           </Card>
         )}
 
-        {/* Base Pay Component */}
         <Card className="bg-gradient-to-br from-blue-900/20 to-purple-900/20 border-blue-500/30">
           <CardHeader className="pb-3">
             <CardTitle className="flex items-center gap-2 text-lg text-white">
@@ -197,21 +171,15 @@ export default function GamePayment({ onPaymentComplete, onBack }: GamePaymentPr
           </CardHeader>
           <CardContent className="space-y-4">
             <div className="text-sm text-gray-300 text-center">
-              Use Base Pay to add $10 USDC to your account
+              Use Base Pay to add ${BASE_PAY_AMOUNTS.gamePayment} USDC to your account
             </div>
-            
-            <BasePayButton
-              colorScheme="light"
-              onClick={handleBasePay}
-            />
-            
-            <div className="text-xs text-gray-400 text-center">
-              Powered by Base Pay
-            </div>
+
+            <BasePayButton colorScheme="light" onClick={handleFunding} />
+
+            <div className="text-xs text-gray-400 text-center">Powered by Base Pay</div>
           </CardContent>
         </Card>
 
-        {/* Spend Permissions Section */}
         <Card className="bg-gradient-to-br from-purple-900/20 to-pink-900/20 border-purple-500/30">
           <CardHeader className="pb-3">
             <CardTitle className="flex items-center gap-2 text-lg text-white">
@@ -221,9 +189,9 @@ export default function GamePayment({ onPaymentComplete, onBack }: GamePaymentPr
           </CardHeader>
           <CardContent className="space-y-4">
             <div className="text-sm text-gray-300 text-center">
-              Enable gasless transactions by granting spend permissions
+              Optional server spend permissions for automated treasury charges
             </div>
-            
+
             <Button
               onClick={() => setShowSpendPermissions(!showSpendPermissions)}
               variant="outline"
@@ -231,14 +199,11 @@ export default function GamePayment({ onPaymentComplete, onBack }: GamePaymentPr
             >
               {showSpendPermissions ? 'Hide' : 'Manage'} Spend Permissions
             </Button>
-            
-            {showSpendPermissions && (
-              <SpendPermissionManager />
-            )}
+
+            {showSpendPermissions && <SpendPermissionManager />}
           </CardContent>
         </Card>
 
-        {/* Back Button */}
         {onBack && (
           <div className="text-center">
             <Button

--- a/components/game/GuestModeEntry.tsx
+++ b/components/game/GuestModeEntry.tsx
@@ -19,7 +19,7 @@ interface GuestModeEntryProps {
 export default function GuestModeEntry({ onGuestStart, onWalletConnect, className = '' }: GuestModeEntryProps) {
   const [guestName, setGuestName] = useState('');
   const [showGuestForm, setShowGuestForm] = useState(false);
-  const { isConnected, connect } = useBaseAccount();
+  const { isConnected, connect, isConnecting } = useBaseAccount();
 
   const handleGuestSubmit = (e: React.FormEvent) => {
     e.preventDefault();
@@ -178,7 +178,12 @@ export default function GuestModeEntry({ onGuestStart, onWalletConnect, classNam
             </Button>
           ) : (
             <div className="space-y-3">
-              <SignInWithBaseButton colorScheme="light" onClick={connect} />
+              <SignInWithBaseButton
+                align="center"
+                variant="solid"
+                colorScheme="light"
+                onClick={isConnecting ? undefined : connect}
+              />
               <Button
                 onClick={onWalletConnect}
                 variant="outline"

--- a/components/game/SpendPermissionManager.tsx
+++ b/components/game/SpendPermissionManager.tsx
@@ -1,19 +1,21 @@
 'use client';
 
-import { useState, useEffect } from 'react';
+import { useState, useEffect, useCallback } from 'react';
 import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card';
 import { Button } from '@/components/ui/button';
 import { Badge } from '@/components/ui/badge';
 import { Alert, AlertDescription } from '@/components/ui/alert';
 import { useBaseAccount } from '@/hooks/useBaseAccount';
-import { 
-  checkSpendPermission, 
-  requestGameSpendPermission, 
-  revokeSpendPermission, 
+import {
+  checkSpendPermission,
+  requestGameSpendPermission,
+  revokeSpendPermission,
   getSpendPermissionDetails,
-  ensureSpendPermission 
+  ensureSpendPermission,
+  isGameSpendPermissionsEnabled,
+  type SpendPermissionDetails,
 } from '@/lib/base-account/spendPermissions';
-import { Shield, CheckCircle, AlertTriangle, Clock, DollarSign, Zap } from 'lucide-react';
+import { Shield, CheckCircle, AlertTriangle, Clock, Zap } from 'lucide-react';
 
 interface SpendPermissionManagerProps {
   onPermissionGranted?: () => void;
@@ -21,45 +23,65 @@ interface SpendPermissionManagerProps {
   className?: string;
 }
 
-export default function SpendPermissionManager({ 
-  onPermissionGranted, 
-  onPermissionRevoked, 
-  className = '' 
+export default function SpendPermissionManager({
+  onPermissionGranted,
+  onPermissionRevoked,
+  className = '',
 }: SpendPermissionManagerProps) {
   const { address, isConnected } = useBaseAccount();
   const [hasPermission, setHasPermission] = useState(false);
   const [isLoading, setIsLoading] = useState(false);
-  const [permissionDetails, setPermissionDetails] = useState<any>(null);
+  const [permissionDetails, setPermissionDetails] = useState<SpendPermissionDetails | null>(null);
   const [error, setError] = useState<string | null>(null);
+  const isConfigured = isGameSpendPermissionsEnabled();
 
-  // Check permission status on mount and when address changes
-  useEffect(() => {
-    if (address && isConnected) {
-      const hasSpendPermission = checkSpendPermission(address);
-      setHasPermission(hasSpendPermission);
-      
-      if (hasSpendPermission) {
-        const details = getSpendPermissionDetails(address);
-        setPermissionDetails(details);
-      }
-    } else {
+  const refreshPermissionStatus = useCallback(async () => {
+    if (!address || !isConnected || !isConfigured) {
       setHasPermission(false);
       setPermissionDetails(null);
+      return;
     }
-  }, [address, isConnected]);
+
+    const active = await checkSpendPermission(address);
+    setHasPermission(active);
+
+    if (active) {
+      const details = await getSpendPermissionDetails(address);
+      setPermissionDetails(details);
+    } else {
+      setPermissionDetails(null);
+    }
+  }, [address, isConnected, isConfigured]);
+
+  useEffect(() => {
+    let cancelled = false;
+
+    const load = async () => {
+      if (cancelled) {
+        return;
+      }
+      await refreshPermissionStatus();
+    };
+
+    load();
+
+    return () => {
+      cancelled = true;
+    };
+  }, [refreshPermissionStatus]);
 
   const handleRequestPermission = async () => {
-    if (!address) return;
-    
+    if (!address) {
+      return;
+    }
+
     setIsLoading(true);
     setError(null);
-    
+
     try {
       const granted = await requestGameSpendPermission(address);
       if (granted) {
-        setHasPermission(true);
-        const details = getSpendPermissionDetails(address);
-        setPermissionDetails(details);
+        await refreshPermissionStatus();
         onPermissionGranted?.();
       } else {
         setError('Failed to grant spend permission');
@@ -72,11 +94,13 @@ export default function SpendPermissionManager({
   };
 
   const handleRevokePermission = async () => {
-    if (!address) return;
-    
+    if (!address) {
+      return;
+    }
+
     setIsLoading(true);
     setError(null);
-    
+
     try {
       const revoked = await revokeSpendPermission(address);
       if (revoked) {
@@ -94,17 +118,19 @@ export default function SpendPermissionManager({
   };
 
   const handleEnsurePermission = async () => {
-    if (!address) return;
-    
+    if (!address) {
+      return;
+    }
+
     setIsLoading(true);
     setError(null);
-    
+
     try {
-      const hasPermission = await ensureSpendPermission(address);
-      setHasPermission(hasPermission);
-      
-      if (hasPermission) {
-        const details = getSpendPermissionDetails(address);
+      const ensured = await ensureSpendPermission(address);
+      setHasPermission(ensured);
+
+      if (ensured) {
+        const details = await getSpendPermissionDetails(address);
         setPermissionDetails(details);
         onPermissionGranted?.();
       } else {
@@ -121,17 +147,29 @@ export default function SpendPermissionManager({
     return null;
   }
 
+  if (!isConfigured) {
+    return (
+      <Alert className="border-yellow-500/20 bg-yellow-500/10">
+        <AlertTriangle className="w-4 h-4" />
+        <AlertDescription className="text-yellow-200 text-sm">
+          Treasury spend permissions are optional. Set{' '}
+          <code className="text-xs">NEXT_PUBLIC_SPEND_PERMISSION_SPENDER</code> to your server
+          wallet address to enable automated treasury charges.
+        </AlertDescription>
+      </Alert>
+    );
+  }
+
   return (
     <div className={`space-y-4 ${className}`}>
       <Card className="bg-gradient-to-br from-purple-900/20 to-blue-900/20 border-purple-500/30">
         <CardHeader className="pb-3">
           <CardTitle className="flex items-center gap-2 text-lg text-white">
             <Shield className="h-5 w-5 text-purple-400" />
-            Spend Permissions
+            Treasury Spend Permissions
           </CardTitle>
         </CardHeader>
         <CardContent className="space-y-4">
-          {/* Permission Status */}
           <div className="flex items-center justify-between">
             <div className="flex items-center gap-2">
               {hasPermission ? (
@@ -139,19 +177,20 @@ export default function SpendPermissionManager({
               ) : (
                 <AlertTriangle className="h-4 w-4 text-yellow-400" />
               )}
-              <span className="text-sm text-white">
-                {hasPermission ? 'Active' : 'Not Set'}
-              </span>
+              <span className="text-sm text-white">{hasPermission ? 'Active' : 'Not Set'}</span>
             </div>
-            <Badge 
-              variant={hasPermission ? "default" : "destructive"}
-              className={hasPermission ? "bg-green-500/20 text-green-400" : "bg-yellow-500/20 text-yellow-400"}
+            <Badge
+              variant={hasPermission ? 'default' : 'destructive'}
+              className={
+                hasPermission
+                  ? 'bg-green-500/20 text-green-400'
+                  : 'bg-yellow-500/20 text-yellow-400'
+              }
             >
               {hasPermission ? 'Enabled' : 'Disabled'}
             </Badge>
           </div>
 
-          {/* Permission Details */}
           {hasPermission && permissionDetails && (
             <div className="bg-white/5 rounded-lg p-3 space-y-2">
               <div className="flex items-center justify-between text-sm">
@@ -178,30 +217,24 @@ export default function SpendPermissionManager({
             </div>
           )}
 
-          {/* Benefits */}
           <div className="bg-blue-500/10 border border-blue-500/20 rounded-lg p-3">
             <div className="text-xs text-blue-300">
-              <p className="font-medium mb-1">Spend Permission Benefits:</p>
+              <p className="font-medium mb-1">Treasury spend permissions allow:</p>
               <ul className="space-y-1 text-blue-200/80">
-                <li>• Gasless game entry transactions</li>
-                <li>• Seamless gameplay without signing each transaction</li>
-                <li>• Enhanced security with Sub Account isolation</li>
-                <li>• Automatic funding from universal account</li>
+                <li>• Server-initiated USDC charges without per-tx signing</li>
+                <li>• Time-limited allowance with user approval</li>
+                <li>• Separate from sub-account auto-funding (SDK default)</li>
               </ul>
             </div>
           </div>
 
-          {/* Error Display */}
           {error && (
             <Alert className="border-red-500/20 bg-red-500/10">
               <AlertTriangle className="w-4 h-4" />
-              <AlertDescription className="text-red-300 text-sm">
-                {error}
-              </AlertDescription>
+              <AlertDescription className="text-red-300 text-sm">{error}</AlertDescription>
             </Alert>
           )}
 
-          {/* Action Buttons */}
           <div className="space-y-2">
             {!hasPermission ? (
               <Button
@@ -217,7 +250,7 @@ export default function SpendPermissionManager({
                 ) : (
                   <>
                     <Shield className="h-4 w-4 mr-2" />
-                    Enable Spend Permissions
+                    Enable Treasury Spend Permissions
                   </>
                 )}
               </Button>

--- a/components/identity/BaseName.tsx
+++ b/components/identity/BaseName.tsx
@@ -1,18 +1,21 @@
 'use client';
 
-import { useEnsName } from 'wagmi';
+import { useBasename } from '@/hooks/useBasename';
 
 interface BaseNameProps {
   address: `0x${string}`;
   className?: string;
 }
 
-export function BaseName({ address, className = '' }: BaseNameProps) {
-  const { data: name } = useEnsName({ address });
+export const BaseName = ({ address, className = '' }: BaseNameProps) => {
+  const { data: name, isLoading } = useBasename(address);
+
+  const displayName =
+    name ?? `${address.slice(0, 6)}...${address.slice(-4)}`;
 
   return (
-    <span className={className}>
-      {name ?? `${address.slice(0, 6)}...${address.slice(-4)}`}
+    <span className={className} title={address}>
+      {isLoading && !name ? `${address.slice(0, 6)}...` : displayName}
     </span>
   );
-}
+};

--- a/components/providers/BaseAccountProvider.tsx
+++ b/components/providers/BaseAccountProvider.tsx
@@ -1,0 +1,65 @@
+'use client';
+
+import {
+  createContext,
+  useContext,
+  useEffect,
+  useMemo,
+  useState,
+  type ReactNode,
+} from 'react';
+import type { ProviderInterface } from '@base-org/account';
+import {
+  getBaseAccountSDK,
+  type BaseAccountSDKInstance,
+} from '@/lib/base-account/sdk';
+
+interface BaseAccountContextValue {
+  sdk: BaseAccountSDKInstance | null;
+  provider: ProviderInterface | null;
+  isReady: boolean;
+}
+
+const BaseAccountContext = createContext<BaseAccountContextValue>({
+  sdk: null,
+  provider: null,
+  isReady: false,
+});
+
+export const useBaseAccountContext = (): BaseAccountContextValue => {
+  return useContext(BaseAccountContext);
+};
+
+export const BaseAccountProvider = ({ children }: { children: ReactNode }) => {
+  const [sdk, setSdk] = useState<BaseAccountSDKInstance | null>(null);
+  const [provider, setProvider] = useState<ProviderInterface | null>(null);
+
+  useEffect(() => {
+    if (typeof window === 'undefined') {
+      return;
+    }
+
+    try {
+      const instance = getBaseAccountSDK();
+      setSdk(instance);
+      setProvider(instance.getProvider());
+    } catch (error) {
+      console.error('Failed to initialize Base Account SDK:', error);
+    }
+  }, []);
+
+  const value = useMemo(
+    () => ({
+      sdk,
+      provider,
+      isReady: !!sdk && !!provider,
+    }),
+    [sdk, provider]
+  );
+
+  return (
+    <BaseAccountContext.Provider value={value}>
+      {children}
+    </BaseAccountContext.Provider>
+  );
+};

--- a/components/wallet/WalletConnect.tsx
+++ b/components/wallet/WalletConnect.tsx
@@ -100,8 +100,10 @@ export default function WalletConnect({
         </Alert>
         
         <SignInWithBaseButton
+          align="center"
+          variant="solid"
           colorScheme="light"
-          onClick={handleConnect}
+          onClick={isConnecting ? undefined : handleConnect}
         />
       </div>
     );
@@ -111,8 +113,10 @@ export default function WalletConnect({
   return (
     <div className={`space-y-3 ${className}`}>
       <SignInWithBaseButton
+        align="center"
+        variant="solid"
         colorScheme="light"
-        onClick={handleConnect}
+        onClick={isConnecting ? undefined : handleConnect}
       />
     </div>
   );

--- a/components/wallet/WalletFunding.tsx
+++ b/components/wallet/WalletFunding.tsx
@@ -3,11 +3,12 @@
 import { useState } from 'react';
 import { useBaseAccount } from '@/hooks/useBaseAccount';
 import { BasePayButton } from '@base-org/account-ui/react';
-import { pay, getPaymentStatus } from '@base-org/account';
 import { Button } from '@/components/ui/button';
-import { Coins, ExternalLink, DollarSign, CheckCircle, Loader2 } from 'lucide-react';
+import { Coins, CheckCircle, Loader2 } from 'lucide-react';
 import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card';
 import { Badge } from '@/components/ui/badge';
+import { useBasePay } from '@/hooks/useBasePay';
+import { BASE_PAY_AMOUNTS } from '@/lib/base-account/config';
 
 interface WalletFundingProps {
   className?: string;
@@ -15,65 +16,38 @@ interface WalletFundingProps {
 
 export default function WalletFunding({ className = '' }: WalletFundingProps) {
   const { address, isConnected } = useBaseAccount();
-  const [paymentStatus, setPaymentStatus] = useState<'idle' | 'processing' | 'completed' | 'failed'>('idle');
-  const [paymentId, setPaymentId] = useState<string | null>(null);
-  const [error, setError] = useState<string | null>(null);
+  const { handleBasePay, isProcessing, error } = useBasePay();
+  const [paymentStatus, setPaymentStatus] = useState<
+    'idle' | 'processing' | 'completed' | 'failed'
+  >('idle');
 
-  const handleBasePay = async () => {
-    if (!address) return;
-    
-    setPaymentStatus('processing');
-    setError(null);
-    
-    try {
-      console.log('Initiating Base Pay for wallet:', address);
-      
-      // Use Base Pay to add USDC funds
-      const payment = await pay({
-        amount: '5.00',
-        to: address,
-        testnet: false, // Use mainnet for production
-      });
-      
-      setPaymentId(payment.id);
-      console.log('Base Pay initiated:', payment.id);
-      
-      // Poll for payment status
-      const checkStatus = async () => {
-        try {
-          const status = await getPaymentStatus({ id: payment.id, testnet: false });
-          console.log('Payment status:', status);
-          
-          if (status.status === 'completed') {
-            setPaymentStatus('completed');
-            setTimeout(() => setPaymentStatus('idle'), 3000);
-          } else if (status.status === 'failed') {
-            setPaymentStatus('failed');
-            setError('Payment failed');
-          } else {
-            // Still pending, check again in 2 seconds
-            setTimeout(checkStatus, 2000);
-          }
-        } catch (error) {
-          console.error('Error checking payment status:', error);
-          setPaymentStatus('failed');
-          setError('Failed to check payment status');
-        }
-      };
-      
-      // Start polling
-      setTimeout(checkStatus, 2000);
-      
-    } catch (err) {
-      console.error('Base Pay failed:', err);
-      setPaymentStatus('failed');
-      setError(err instanceof Error ? err.message : 'Payment failed');
+  const handleFunding = async () => {
+    if (!address) {
+      return;
     }
+
+    setPaymentStatus('processing');
+
+    const result = await handleBasePay({
+      amount: BASE_PAY_AMOUNTS.walletFunding,
+      to: address,
+      testnet: false,
+    });
+
+    if (result.success) {
+      setPaymentStatus('completed');
+      setTimeout(() => setPaymentStatus('idle'), 3000);
+      return;
+    }
+
+    setPaymentStatus('failed');
   };
 
   if (!isConnected || !address) {
     return (
-      <Card className={`bg-gradient-to-br from-purple-900/20 to-blue-900/20 border-purple-500/30 ${className}`}>
+      <Card
+        className={`bg-gradient-to-br from-purple-900/20 to-blue-900/20 border-purple-500/30 ${className}`}
+      >
         <CardContent className="p-4">
           <div className="text-center text-gray-400">
             <Coins className="h-8 w-8 mx-auto mb-2 opacity-50" />
@@ -84,9 +58,11 @@ export default function WalletFunding({ className = '' }: WalletFundingProps) {
     );
   }
 
-  if (paymentStatus === 'processing') {
+  if (paymentStatus === 'processing' || isProcessing) {
     return (
-      <Card className={`bg-gradient-to-br from-blue-900/20 to-purple-900/20 border-blue-500/30 ${className}`}>
+      <Card
+        className={`bg-gradient-to-br from-blue-900/20 to-purple-900/20 border-blue-500/30 ${className}`}
+      >
         <CardHeader className="pb-3">
           <CardTitle className="flex items-center gap-2 text-lg text-white">
             <Loader2 className="h-5 w-5 text-blue-400 animate-spin" />
@@ -97,14 +73,6 @@ export default function WalletFunding({ className = '' }: WalletFundingProps) {
           <div className="text-sm text-gray-300 text-center">
             Your Base Pay transaction is being processed...
           </div>
-          
-          {paymentId && (
-            <div className="bg-black/30 rounded-lg p-3">
-              <div className="text-xs text-gray-400 text-center">
-                Payment ID: {paymentId.slice(0, 8)}...{paymentId.slice(-8)}
-              </div>
-            </div>
-          )}
         </CardContent>
       </Card>
     );
@@ -112,7 +80,9 @@ export default function WalletFunding({ className = '' }: WalletFundingProps) {
 
   if (paymentStatus === 'completed') {
     return (
-      <Card className={`bg-gradient-to-br from-green-900/20 to-blue-900/20 border-green-500/30 ${className}`}>
+      <Card
+        className={`bg-gradient-to-br from-green-900/20 to-blue-900/20 border-green-500/30 ${className}`}
+      >
         <CardHeader className="pb-3">
           <CardTitle className="flex items-center gap-2 text-lg text-white">
             <CheckCircle className="h-5 w-5 text-green-400" />
@@ -121,10 +91,13 @@ export default function WalletFunding({ className = '' }: WalletFundingProps) {
         </CardHeader>
         <CardContent className="space-y-4">
           <div className="text-sm text-gray-300 text-center">
-            Your wallet has been funded with $5 USDC!
+            Your wallet has been funded with ${BASE_PAY_AMOUNTS.walletFunding} USDC!
           </div>
-          
-          <Badge variant="secondary" className="bg-green-500/20 text-green-400 w-full justify-center">
+
+          <Badge
+            variant="secondary"
+            className="bg-green-500/20 text-green-400 w-full justify-center"
+          >
             <CheckCircle className="h-3 w-3 mr-1" />
             Payment Complete
           </Badge>
@@ -134,7 +107,9 @@ export default function WalletFunding({ className = '' }: WalletFundingProps) {
   }
 
   return (
-    <Card className={`bg-gradient-to-br from-purple-900/20 to-blue-900/20 border-purple-500/30 ${className}`}>
+    <Card
+      className={`bg-gradient-to-br from-purple-900/20 to-blue-900/20 border-purple-500/30 ${className}`}
+    >
       <CardHeader className="pb-3">
         <CardTitle className="flex items-center gap-2 text-lg text-white">
           <Coins className="h-5 w-5 text-yellow-400" />
@@ -145,23 +120,17 @@ export default function WalletFunding({ className = '' }: WalletFundingProps) {
         <div className="text-sm text-gray-300 text-center">
           Need funds to play? Add USDC to your Base Account easily.
         </div>
-        
+
         <div className="space-y-3">
           <BasePayButton
             colorScheme="light"
-            onClick={handleBasePay}
+            onClick={isProcessing ? undefined : handleFunding}
           />
-          
-          {error && (
-            <div className="text-red-400 text-xs text-center">
-              {error}
-            </div>
-          )}
+
+          {error && <div className="text-red-400 text-xs text-center">{error}</div>}
         </div>
-        
-        <div className="text-xs text-gray-400 text-center">
-          Powered by Base Pay
-        </div>
+
+        <div className="text-xs text-gray-400 text-center">Powered by Base Pay</div>
       </CardContent>
     </Card>
   );

--- a/components/wallet/WalletWithBalance.tsx
+++ b/components/wallet/WalletWithBalance.tsx
@@ -2,81 +2,62 @@
 
 import { useState } from 'react';
 import { useBaseAccount } from '@/hooks/useBaseAccount';
-import { SignInWithBaseButton, BasePayButton } from '@base-org/account-ui/react';
-import { pay, getPaymentStatus } from '@base-org/account';
+import { BasePayButton } from '@base-org/account-ui/react';
 import { useUSDCBalance } from '@/hooks/useUSDCBalance';
+import { useBasePay } from '@/hooks/useBasePay';
+import { BASE_PAY_AMOUNTS } from '@/lib/base-account/config';
 import { Coins, DollarSign, AlertCircle, CheckCircle, Loader2 } from 'lucide-react';
 import { Badge } from '@/components/ui/badge';
 import { Button } from '@/components/ui/button';
 import { Card, CardContent } from '@/components/ui/card';
+import { SignInWithBaseButton } from '@base-org/account-ui/react';
 
 interface WalletWithBalanceProps {
   onFundingSuccess?: () => void;
   className?: string;
 }
 
-export default function WalletWithBalance({ onFundingSuccess, className = '' }: WalletWithBalanceProps) {
-  const { address, subAccountAddress, universalAddress, isConnected, connect } = useBaseAccount();
+export default function WalletWithBalance({
+  onFundingSuccess,
+  className = '',
+}: WalletWithBalanceProps) {
+  const { address, subAccountAddress, universalAddress, isConnected, isConnecting, connect } =
+    useBaseAccount();
   const { balance, hasEnoughForEntry, isLoading, error, refreshBalance } = useUSDCBalance();
+  const { handleBasePay, isProcessing, error: payError } = useBasePay();
   const [fundingSuccess, setFundingSuccess] = useState(false);
-  const [paymentLoading, setPaymentLoading] = useState(false);
 
-  const handleBasePay = async () => {
-    if (!address) return;
-    
-    setPaymentLoading(true);
-    try {
-      console.log('Initiating Base Pay for wallet:', address);
-      
-      // Use Base Pay to add USDC funds
-      const payment = await pay({
-        amount: '5.00',
-        to: address,
-        testnet: false, // Use mainnet for production
-      });
-      
-      console.log('Base Pay initiated:', payment.id);
-      
-      // Poll for payment status
-      const checkStatus = async () => {
-        try {
-          const status = await getPaymentStatus({ id: payment.id, testnet: false });
-          console.log('Payment status:', status);
-          
-          if (status.status === 'completed') {
-            setFundingSuccess(true);
-            onFundingSuccess?.();
-            refreshBalance();
-            setTimeout(() => setFundingSuccess(false), 3000);
-          } else if (status.status === 'failed') {
-            console.error('Payment failed');
-          } else {
-            // Still pending, check again in 2 seconds
-            setTimeout(checkStatus, 2000);
-          }
-        } catch (error) {
-          console.error('Error checking payment status:', error);
-        }
-      };
-      
-      // Start polling
-      setTimeout(checkStatus, 2000);
-      
-    } catch (err) {
-      console.error('Base Pay failed:', err);
-    } finally {
-      setPaymentLoading(false);
+  const handleFunding = async () => {
+    if (!address) {
+      return;
     }
+
+    const result = await handleBasePay(
+      {
+        amount: BASE_PAY_AMOUNTS.walletFunding,
+        to: address,
+        testnet: false,
+      },
+      (success) => {
+        if (success) {
+          setFundingSuccess(true);
+          onFundingSuccess?.();
+          refreshBalance();
+          setTimeout(() => setFundingSuccess(false), 3000);
+        }
+      }
+    );
+
+    return result;
   };
 
-  const formatUSDCBalance = (balance: number) => {
-    return balance.toFixed(2);
-  };
+  const formatUSDCBalance = (value: number) => value.toFixed(2);
 
   const getBalanceStatus = () => {
     if (isLoading) return { icon: Loader2, text: 'Loading...', className: 'text-gray-400' };
     if (error) return { icon: AlertCircle, text: 'Error loading balance', className: 'text-red-400' };
-    if (hasEnoughForEntry) return { icon: CheckCircle, text: 'Sufficient funds', className: 'text-green-400' };
+    if (hasEnoughForEntry)
+      return { icon: CheckCircle, text: 'Sufficient funds', className: 'text-green-400' };
     return { icon: AlertCircle, text: 'Insufficient funds', className: 'text-yellow-400' };
   };
 
@@ -85,7 +66,6 @@ export default function WalletWithBalance({ onFundingSuccess, className = '' }: 
 
   return (
     <div className={`space-y-4 ${className}`}>
-      {/* USDC Balance Card */}
       {isConnected && address && (
         <Card className="bg-gradient-to-br from-blue-900/20 to-purple-900/20 border-blue-500/30">
           <CardContent className="p-4">
@@ -108,7 +88,7 @@ export default function WalletWithBalance({ onFundingSuccess, className = '' }: 
                 )}
               </Button>
             </div>
-            
+
             <div className="space-y-2">
               <div className="flex items-center justify-between">
                 <span className="text-2xl font-bold text-white">
@@ -116,17 +96,21 @@ export default function WalletWithBalance({ onFundingSuccess, className = '' }: 
                 </span>
                 <StatusIcon className={`h-4 w-4 ${balanceStatus.className}`} />
               </div>
-              
+
               <div className="flex items-center justify-between text-sm">
                 <span className="text-gray-300">Entry Fee Required: 1 USDC</span>
-                <Badge 
-                  variant={hasEnoughForEntry ? "default" : "destructive"}
-                  className={hasEnoughForEntry ? "bg-green-500/20 text-green-400 border-green-500/30" : "bg-red-500/20 text-red-400 border-red-500/30"}
+                <Badge
+                  variant={hasEnoughForEntry ? 'default' : 'destructive'}
+                  className={
+                    hasEnoughForEntry
+                      ? 'bg-green-500/20 text-green-400 border-green-500/30'
+                      : 'bg-red-500/20 text-red-400 border-red-500/30'
+                  }
                 >
                   {hasEnoughForEntry ? 'Ready' : 'Need Funds'}
                 </Badge>
               </div>
-              
+
               {error && (
                 <div className="text-xs text-red-400 flex items-center gap-1">
                   <AlertCircle className="h-3 w-3" />
@@ -138,7 +122,6 @@ export default function WalletWithBalance({ onFundingSuccess, className = '' }: 
         </Card>
       )}
 
-      {/* Base Account Component */}
       <div className="flex justify-center">
         {isConnected ? (
           <Card className="bg-gradient-to-br from-green-900/20 to-blue-900/20 border-green-500/30">
@@ -148,7 +131,7 @@ export default function WalletWithBalance({ onFundingSuccess, className = '' }: 
                   <CheckCircle className="w-4 h-4" />
                   <span className="text-sm font-medium">Base Account Connected</span>
                 </div>
-                
+
                 <div className="space-y-1">
                   <div className="text-xs text-gray-400 font-mono">
                     Sub Account: {address?.slice(0, 6)}...{address?.slice(-4)}
@@ -158,22 +141,37 @@ export default function WalletWithBalance({ onFundingSuccess, className = '' }: 
                       Universal: {universalAddress?.slice(0, 6)}...{universalAddress?.slice(-4)}
                     </div>
                   )}
+                  {subAccountAddress && subAccountAddress !== address && (
+                    <div className="text-xs text-gray-500 font-mono">
+                      Linked Sub: {subAccountAddress?.slice(0, 6)}...{subAccountAddress?.slice(-4)}
+                    </div>
+                  )}
                 </div>
-                
+
                 <Badge variant="secondary" className="bg-green-500/20 text-green-300">
                   Base Network
                 </Badge>
-                
-                {/* Add Funds with Base Pay */}
+
+                {fundingSuccess && (
+                  <p className="text-xs text-green-400">Wallet funded successfully</p>
+                )}
+
+                {payError && <p className="text-xs text-red-400">{payError}</p>}
+
                 <BasePayButton
                   colorScheme="light"
-                  onClick={handleBasePay}
+                  onClick={isProcessing ? undefined : handleFunding}
                 />
               </div>
             </CardContent>
           </Card>
         ) : (
-          <SignInWithBaseButton colorScheme="light" onClick={connect} />
+          <SignInWithBaseButton
+            align="center"
+            variant="solid"
+            colorScheme="light"
+            onClick={isConnecting ? undefined : connect}
+          />
         )}
       </div>
     </div>

--- a/docs/BASE_ACCOUNT_INTEGRATION.md
+++ b/docs/BASE_ACCOUNT_INTEGRATION.md
@@ -1,111 +1,110 @@
 # Base Account Integration
 
-This document describes the Base Account integration alongside CDP Embedded Wallets.
+This document describes how BEAT ME integrates the Base Account SDK on Base mainnet.
 
 ## Overview
 
-The app now supports both wallet types:
+Players connect via the official Base Account UI (`SignInWithBaseButton` from `@base-org/account-ui/react`). The app uses a **singleton SDK instance** shared across hooks and transaction helpers.
 
-1. **Base Account**: Users can connect with their existing Base Account
-2. **Embedded Wallets**: Users can create/use CDP Embedded Wallets via OnchainKit
+Key features:
 
-Both wallet types are supported through wagmi connectors and work seamlessly with account abstraction features.
+1. **Sign in with Base** — wallet connect via `hooks/useBaseAccount.ts`
+2. **Sub-accounts** — `creation: 'on-connect'`, `defaultAccount: 'sub'` for frictionless game transactions
+3. **Base Pay** — `BasePayButton` + `pay()` helper for USDC funding
+4. **Gasless transactions** — paymaster via `NEXT_PUBLIC_PAYMASTER_AND_BUNDLER_ENDPOINT`
+5. **Basenames** — ENSIP-19 resolution via `lib/base-account/basename.ts`
+6. **Treasury spend permissions** (optional) — `@base-org/account/spend-permission` when `NEXT_PUBLIC_SPEND_PERMISSION_SPENDER` is set
 
-## Implementation Details
+## Architecture
 
-### Wagmi Configuration
+```
+app/rootProvider.tsx
+  └── BaseAccountProvider (components/providers/BaseAccountProvider.tsx)
+        └── getBaseAccountSDK() singleton (lib/base-account/sdk.ts)
+              ├── useBaseAccount hook
+              ├── pay() / batch transactions
+              └── spend-permission APIs
+```
 
-The wagmi config in `app/rootProvider.tsx` includes both connectors:
+### SDK configuration
+
+Defined in `lib/base-account/sdk.ts` and `lib/base-account/config.ts`:
 
 ```typescript
-const wagmiConfig = createConfig({
-  chains: [base],
-  connectors: [
-    // Base Account connector for existing Base users
-    baseAccount({
-      appName: process.env.NEXT_PUBLIC_APP_NAME || 'BEAT ME',
-    }),
-    // Coinbase Wallet connector (includes embedded wallets via OnchainKit)
-    coinbaseWallet({
-      appName: 'BEAT ME',
-      preference: 'smartWalletOnly',
-    }),
-  ],
-  // ...
+createBaseAccountSDK({
+  appName: process.env.NEXT_PUBLIC_BASE_ACCOUNT_APP_NAME || 'BEAT ME',
+  appLogoUrl: process.env.NEXT_PUBLIC_BASE_ACCOUNT_LOGO_URL,
+  appChainIds: [base.id], // Base mainnet
+  subAccounts: { creation: 'on-connect', defaultAccount: 'sub' },
+  paymasterUrls: [process.env.NEXT_PUBLIC_PAYMASTER_AND_BUNDLER_ENDPOINT],
 });
 ```
 
-### useBundlerClient Hook
+### Sub-accounts
 
-The `useBundlerClient` hook works with both wallet types:
+On connect, the SDK creates a sub-account automatically. Each session re-activates it via `wallet_addSubAccount` in `lib/base-account/subAccount.ts`.
 
-- **Base Account**: Uses the account from the Base Account connector
-- **Embedded Wallets**: Uses the account from OnchainKit's embedded wallet
+**Auto Spend (SDK default):** On the first sub-account transaction, Base Account prompts the user to fund from their universal account. Manual auto-spend configuration (`lib/base-account/autoSpend.ts`) is deprecated.
 
-Both wallet types are converted to Coinbase Smart Accounts for account abstraction operations.
+### Base Pay
 
-### How It Works
+`@base-org/account-ui` v1.0.1 exposes `BasePayButton` with `onClick` only (no `paymentOptions` prop). Payment flow uses `lib/base-account/pay.ts` (`executeBasePay`) via `hooks/useBasePay.ts`.
 
-1. User connects with either wallet type via wagmi
-2. `useBundlerClient` detects the connected wallet through `useWalletClient()`
-3. The wallet's account is used to create a Coinbase Smart Account via `toCoinbaseSmartAccount()`
-4. The smart account is used to create a bundler client for account abstraction operations
+Amounts are centralized in `lib/base-account/config.ts` (`BASE_PAY_AMOUNTS`).
 
-### Error Handling
+### Treasury spend permissions
 
-The hook includes enhanced error logging that shows:
-- Connected wallet address
-- Connector name (Base Account vs Coinbase Wallet)
-- Account availability status
-- Detailed error messages
+Separate from sub-account auto-spend. Allows a **server/treasury wallet** to spend user USDC with prior approval.
+
+Requires `NEXT_PUBLIC_SPEND_PERMISSION_SPENDER` (CDP API key wallet address recommended). Optional for v1 — game entry uses user-signed transactions.
+
+Implemented in `lib/base-account/spendPermissions.ts` using `@base-org/account/spend-permission`.
+
+### Basenames
+
+`components/identity/BaseName.tsx` uses `hooks/useBasename.ts`, which resolves `.base.eth` names via viem ENSIP-19 (`coinType` for Base) on Ethereum mainnet.
 
 ## Environment Variables
 
-Ensure these are set in your `.env.local`:
+See `docs/ENV_VARIABLES_TEMPLATE.md`. Required for Base Account:
 
 ```bash
-NEXT_PUBLIC_APP_NAME="BEAT ME"  # Used for Base Account connector
-NEXT_PUBLIC_CDP_API_KEY=your_api_key
-NEXT_PUBLIC_CDP_PROJECT_ID=your_project_id
-NEXT_PUBLIC_PAYMASTER_AND_BUNDLER_ENDPOINT=your_paymaster_endpoint
+NEXT_PUBLIC_BASE_ACCOUNT_APP_NAME=BEAT ME
+NEXT_PUBLIC_BASE_ACCOUNT_LOGO_URL=https://your-domain.com/logo.png
+NEXT_PUBLIC_PAYMASTER_AND_BUNDLER_ENDPOINT=https://api.developer.coinbase.com/rpc/v1/base/...
+NEXT_PUBLIC_USDC_ADDRESS=0x833589fcd6edb6e08f4c7c32d4f71b54bda02913
+NEXT_PUBLIC_ALCHEMY_API_KEY=your_key  # optional, improves basename resolution
+NEXT_PUBLIC_SPEND_PERMISSION_SPENDER=0x...  # optional treasury wallet
 ```
 
 ## Dependencies
 
-- `@base-org/account`: Already installed as a transitive dependency via `@wagmi/connectors`
-- `wagmi`: Already configured with both connectors
-- `@coinbase/onchainkit`: Handles embedded wallet UI and management
+- `@base-org/account` ^2.5.6 — SDK, pay(), spend-permission
+- `@base-org/account-ui` ^1.0.1 — SignInWithBaseButton, BasePayButton
+- `viem` — basename resolution, auth verification
+
+## UI components
+
+| Component | Purpose |
+|-----------|---------|
+| `components/base-account/BaseAccountButton.tsx` | Reusable connect/disconnect |
+| `components/wallet/WalletWithBalance.tsx` | Balance + Base Pay |
+| `components/game/GamePayment.tsx` | In-game funding |
+| `components/base-account/SubAccountDisplay.tsx` | Universal + sub addresses |
+| `components/game/SpendPermissionManager.tsx` | Treasury spend permissions |
 
 ## Testing
 
-1. **Base Account**: Connect using the Base Account option in the wallet modal
-2. **Embedded Wallet**: Connect using the Coinbase Wallet option (creates embedded wallet if needed)
-3. Both should work with `useBundlerClient` for account abstraction operations
+Use `components/base-account/BaseAccountTestSuite.tsx` to verify:
 
-## Troubleshooting
+1. SDK initialization and connection
+2. Sub-account addresses
+3. USDC balance
+4. Spend permission status (when spender configured)
 
-### Base Account Not Appearing
+Run `npm run build` to catch type errors after SDK updates.
 
-- Verify `@base-org/account` is available (it's a transitive dependency)
-- Check that the Base Account connector is in the wagmi config
-- Ensure you're on Base network
+## Out of scope
 
-### useBundlerClient Not Working
-
-- Check that `walletClient.account` is available
-- Verify the wallet is connected via wagmi
-- Check console for detailed error messages including connector name
-
-## Differences from CDPHooksProvider Approach
-
-This implementation uses **OnchainKit** instead of the lower-level `CDPHooksProvider` approach:
-
-- **OnchainKit**: Higher-level abstraction, includes UI components, handles wallet management
-- **CDPHooksProvider**: Lower-level, requires manual implementation of wallet UI and state management
-
-For this app, OnchainKit is the better choice as it provides:
-- Built-in wallet UI components
-- Automatic embedded wallet management
-- Integration with existing Coinbase Wallet infrastructure
-- Support for both Base Account and embedded wallets through wagmi connectors
-
+- **Full SIWB backend** — JWT sessions in `lib/base-account/auth.ts` are stubs; wallet identity is used onchain only
+- **OnchainKit wallet connector** — app uses direct Base Account SDK, not wagmi `baseAccount` connector

--- a/hooks/useBaseAccount.ts
+++ b/hooks/useBaseAccount.ts
@@ -1,8 +1,12 @@
 'use client';
 
 import { useState, useEffect, useCallback } from 'react';
-import { createBaseAccountSDK, getCryptoKeyAccount } from '@base-org/account';
 import { base } from 'viem/chains';
+import { useBaseAccountContext } from '@/components/providers/BaseAccountProvider';
+import {
+  connectSubAccountAddresses,
+  resolveSubAccountAddresses,
+} from '@/lib/base-account/subAccount';
 
 export interface BaseAccountState {
   address: string | null;
@@ -19,103 +23,29 @@ export interface UseBaseAccountReturn extends BaseAccountState {
   disconnect: () => void;
   signMessage: (message: string) => Promise<string>;
   sendTransaction: (to: string, value: string, data?: string) => Promise<string>;
-  getProvider: () => any;
+  getProvider: () => ReturnType<typeof useBaseAccountContext>['provider'];
 }
 
-export function useBaseAccount(): UseBaseAccountReturn {
-  const [state, setState] = useState<BaseAccountState>({
-    address: null,
-    subAccountAddress: null,
-    universalAddress: null,
-    isConnected: false,
-    isConnecting: false,
-    chainId: null,
-    error: null,
-  });
+const disconnectedState: BaseAccountState = {
+  address: null,
+  subAccountAddress: null,
+  universalAddress: null,
+  isConnected: false,
+  isConnecting: false,
+  chainId: null,
+  error: null,
+};
 
-  const [provider, setProvider] = useState<any>(null);
+export const useBaseAccount = (): UseBaseAccountReturn => {
+  const { provider } = useBaseAccountContext();
+  const [state, setState] = useState<BaseAccountState>(disconnectedState);
 
-  // Initialize Base Account SDK client-side only
-  useEffect(() => {
-    if (typeof window !== "undefined") {
-      try {
-        const sdk = createBaseAccountSDK({
-          appName: 'BEAT ME',
-          appLogoUrl: 'https://base.org/logo.png',
-          appChainIds: [base.id],
-          subAccounts: {
-            creation: 'on-connect',
-            defaultAccount: 'sub',
-          },
-          paymasterUrls: process.env.NEXT_PUBLIC_PAYMASTER_AND_BUNDLER_ENDPOINT ? [process.env.NEXT_PUBLIC_PAYMASTER_AND_BUNDLER_ENDPOINT] : undefined,
-        });
-        setProvider(sdk.getProvider());
-      } catch (error) {
-        console.error('Failed to initialize Base Account SDK:', error);
-      }
-    }
-  }, []);
+  const getProvider = useCallback(() => provider, [provider]);
 
-  // Get provider instance
-  const getProvider = useCallback(() => {
-    return provider;
-  }, [provider]);
-
-  // Connect to Base Account
-  const connect = useCallback(async () => {
-    if (!provider) {
-      setState(prev => ({ ...prev, error: 'Provider not ready' }));
-      return;
-    }
-
-    setState(prev => ({ ...prev, isConnecting: true, error: null }));
-
-    try {
-      // First, connect to the universal account
-      const accounts = await provider.request({
-        method: 'eth_requestAccounts',
-        params: []
-      });
-
-      if (!accounts || accounts.length === 0) {
-        throw new Error('No accounts found');
-      }
-
-      const universalAddress = accounts[0];
-      
-      // Get or create Sub Account
-      let subAccountAddress = universalAddress;
-      try {
-        // Check if Sub Account already exists
-        const { subAccounts } = await provider.request({
-          method: 'wallet_getSubAccounts',
-          params: [{
-            account: universalAddress,
-            domain: window.location.origin,
-          }]
-        });
-
-        if (subAccounts && subAccounts.length > 0) {
-          subAccountAddress = subAccounts[0].address;
-        } else {
-          // Create new Sub Account
-          const newSubAccount = await provider.request({
-            method: 'wallet_addSubAccount',
-            params: [{
-              account: {
-                type: 'create',
-              },
-            }]
-          });
-          subAccountAddress = newSubAccount.address;
-        }
-      } catch (subAccountError) {
-        console.warn('Sub Account creation failed, using universal account:', subAccountError);
-        // Continue with universal account if Sub Account creation fails
-      }
-
+  const applyAddresses = useCallback(
+    (universalAddress: string, subAccountAddress: string) => {
       setState({
-        address: subAccountAddress, // Use Sub Account as primary address
+        address: subAccountAddress,
         subAccountAddress,
         universalAddress,
         isConnected: true,
@@ -123,148 +53,99 @@ export function useBaseAccount(): UseBaseAccountReturn {
         chainId: base.id,
         error: null,
       });
+    },
+    []
+  );
 
-      console.log('✅ Base Account connected:', {
-        universal: universalAddress,
-        subAccount: subAccountAddress
-      });
+  const connect = useCallback(async () => {
+    if (!provider) {
+      setState((prev) => ({ ...prev, error: 'Provider not ready' }));
+      return;
+    }
+
+    setState((prev) => ({ ...prev, isConnecting: true, error: null }));
+
+    try {
+      const { universalAddress, subAccountAddress } =
+        await connectSubAccountAddresses(provider);
+      applyAddresses(universalAddress, subAccountAddress);
     } catch (error) {
-      console.error('❌ Base Account connection failed:', error);
-      setState(prev => ({
+      console.error('Base Account connection failed:', error);
+      setState((prev) => ({
         ...prev,
         isConnecting: false,
-        error: error instanceof Error ? error.message : 'Failed to connect to Base Account',
+        error:
+          error instanceof Error
+            ? error.message
+            : 'Failed to connect to Base Account',
       }));
     }
-  }, [provider]);
+  }, [applyAddresses, provider]);
 
-  // Disconnect from Base Account
   const disconnect = useCallback(() => {
-    setState({
-      address: null,
-      subAccountAddress: null,
-      universalAddress: null,
-      isConnected: false,
-      isConnecting: false,
-      chainId: null,
-      error: null,
-    });
+    setState(disconnectedState);
   }, []);
 
-  // Sign a message
-  const signMessage = useCallback(async (message: string): Promise<string> => {
-    if (!state.address || !provider) {
-      throw new Error('No account connected or provider not ready');
-    }
+  const signMessage = useCallback(
+    async (message: string): Promise<string> => {
+      if (!state.address || !provider) {
+        throw new Error('No account connected or provider not ready');
+      }
 
-    try {
-      const signature = await provider.request({
+      const signature = (await provider.request({
         method: 'personal_sign',
-        params: [message, state.address]
-      });
+        params: [message, state.address],
+      })) as string;
+
       return signature;
-    } catch (error) {
-      console.error('❌ Message signing failed:', error);
-      throw error;
-    }
-  }, [provider, state.address]);
+    },
+    [provider, state.address]
+  );
 
-  // Send a transaction
-  const sendTransaction = useCallback(async (to: string, value: string, data?: string): Promise<string> => {
-    if (!state.address || !provider) {
-      throw new Error('No account connected or provider not ready');
-    }
+  const sendTransaction = useCallback(
+    async (to: string, value: string, data?: string): Promise<string> => {
+      if (!state.address || !provider) {
+        throw new Error('No account connected or provider not ready');
+      }
 
-    try {
-      const txHash = await provider.request({
+      const txHash = (await provider.request({
         method: 'eth_sendTransaction',
-        params: [{
-          from: state.address,
-          to,
-          value,
-          data: data || '0x',
-        }]
-      });
-      return txHash;
-    } catch (error) {
-      console.error('❌ Transaction failed:', error);
-      throw error;
-    }
-  }, [provider, state.address]);
+        params: [
+          {
+            from: state.address,
+            to,
+            value,
+            data: data || '0x',
+          },
+        ],
+      })) as string;
 
-  // Check initial connection state
+      return txHash;
+    },
+    [provider, state.address]
+  );
+
   useEffect(() => {
-    if (!provider) return;
-    
+    if (!provider) {
+      return;
+    }
+
     const checkConnection = async () => {
       try {
-        const accounts = await provider.request({
-          method: 'eth_accounts',
-          params: []
-        });
-
-        if (accounts && accounts.length > 0) {
-          const universalAddress = accounts[0];
-          
-          // Try to get Sub Account
-          try {
-            const { subAccounts } = await provider.request({
-              method: 'wallet_getSubAccounts',
-              params: [{
-                account: universalAddress,
-                domain: window.location.origin,
-              }]
-            });
-
-            const subAccountAddress = subAccounts && subAccounts.length > 0 
-              ? subAccounts[0].address 
-              : universalAddress;
-
-            setState({
-              address: subAccountAddress,
-              subAccountAddress,
-              universalAddress,
-              isConnected: true,
-              isConnecting: false,
-              chainId: base.id,
-              error: null,
-            });
-          } catch (subAccountError) {
-            // Fallback to universal account
-            setState({
-              address: universalAddress,
-              subAccountAddress: universalAddress,
-              universalAddress,
-              isConnected: true,
-              isConnecting: false,
-              chainId: base.id,
-              error: null,
-            });
-          }
+        const resolved = await resolveSubAccountAddresses(provider);
+        if (!resolved) {
+          setState((prev) => (prev.isConnected ? disconnectedState : prev));
+          return;
         }
-      } catch (error) {
-        // Error 4100 or similar means not connected — silently handle
-        // Return prev unchanged when already disconnected to prevent re-render loop
-        setState(prev => {
-          if (prev.isConnected) {
-            return {
-              ...prev,
-              address: null,
-              subAccountAddress: null,
-              universalAddress: null,
-              isConnected: false,
-              isConnecting: false,
-              chainId: null,
-              error: null,
-            };
-          }
-          return prev;
-        });
+
+        applyAddresses(resolved.universalAddress, resolved.subAccountAddress);
+      } catch {
+        setState((prev) => (prev.isConnected ? disconnectedState : prev));
       }
     };
 
     checkConnection();
-  }, [provider]);
+  }, [applyAddresses, provider]);
 
   return {
     ...state,
@@ -274,4 +155,4 @@ export function useBaseAccount(): UseBaseAccountReturn {
     sendTransaction,
     getProvider,
   };
-}
+};

--- a/hooks/useBasePay.ts
+++ b/hooks/useBasePay.ts
@@ -1,0 +1,39 @@
+'use client';
+
+import { useCallback, useState } from 'react';
+import type { PaymentOptions } from '@base-org/account';
+import { executeBasePay } from '@/lib/base-account/pay';
+
+export const useBasePay = () => {
+  const [isProcessing, setIsProcessing] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+
+  const handleBasePay = useCallback(
+    async (
+      paymentOptions: PaymentOptions,
+      onComplete?: (success: boolean) => void
+    ) => {
+      setIsProcessing(true);
+      setError(null);
+
+      const result = await executeBasePay(paymentOptions);
+
+      if (!result.success) {
+        setError(result.error);
+        onComplete?.(false);
+      } else {
+        onComplete?.(true);
+      }
+
+      setIsProcessing(false);
+      return result;
+    },
+    []
+  );
+
+  return {
+    handleBasePay,
+    isProcessing,
+    error,
+  };
+};

--- a/hooks/useBasename.ts
+++ b/hooks/useBasename.ts
@@ -1,0 +1,20 @@
+'use client';
+
+import { useQuery } from '@tanstack/react-query';
+import { getBasename } from '@/lib/base-account/basename';
+
+export const useBasename = (address?: `0x${string}` | string | null) => {
+  const normalizedAddress = address as `0x${string}` | undefined;
+
+  return useQuery({
+    queryKey: ['basename', normalizedAddress],
+    queryFn: () => {
+      if (!normalizedAddress) {
+        return null;
+      }
+      return getBasename(normalizedAddress);
+    },
+    enabled: !!normalizedAddress,
+    staleTime: 5 * 60 * 1000,
+  });
+};

--- a/hooks/usePlayerWinnings.ts
+++ b/hooks/usePlayerWinnings.ts
@@ -2,8 +2,7 @@
 
 import { useState, useEffect, useCallback } from 'react';
 import { useBaseAccount } from './useBaseAccount';
-import { createBaseAccountSDK } from '@base-org/account';
-import { base } from 'viem/chains';
+import { useBaseAccountContext } from '@/components/providers/BaseAccountProvider';
 import { TRIVIA_ABI, TRIVIA_CONTRACT_ADDRESS } from '@/lib/blockchain/contracts';
 
 export interface PlayerWinnings {
@@ -19,6 +18,7 @@ export interface PlayerWinnings {
 
 export function usePlayerWinnings() {
   const { address, isConnected } = useBaseAccount();
+  const { provider } = useBaseAccountContext();
   const [winnings, setWinnings] = useState<PlayerWinnings>({
     hasWinnings: false,
     winningAmount: '0',
@@ -32,29 +32,6 @@ export function usePlayerWinnings() {
   const [error, setError] = useState<string | null>(null);
   const [sessionInfo, setSessionInfo] = useState<any>(null);
   const [playerScore, setPlayerScore] = useState<any>(null);
-
-  // Initialize Base Account SDK client-side only
-  const [provider, setProvider] = useState<any>(null);
-
-  useEffect(() => {
-    if (typeof window !== "undefined") {
-      try {
-        const sdk = createBaseAccountSDK({
-          appName: 'BEAT ME',
-          appLogoUrl: 'https://base.org/logo.png',
-          appChainIds: [base.id],
-          subAccounts: {
-            creation: 'on-connect',
-            defaultAccount: 'sub',
-          },
-          paymasterUrls: process.env.NEXT_PUBLIC_PAYMASTER_AND_BUNDLER_ENDPOINT ? [process.env.NEXT_PUBLIC_PAYMASTER_AND_BUNDLER_ENDPOINT] : undefined,
-        });
-        setProvider(sdk.getProvider());
-      } catch (error) {
-        console.error('Failed to initialize Base Account SDK:', error);
-      }
-    }
-  }, []);
 
   // Fetch session info using Base Account SDK
   const fetchSessionInfo = useCallback(async () => {

--- a/hooks/useTriviaContract.ts
+++ b/hooks/useTriviaContract.ts
@@ -2,8 +2,7 @@
 
 import { useState, useCallback, useEffect } from 'react';
 import { useBaseAccount } from './useBaseAccount';
-import { createBaseAccountSDK } from '@base-org/account';
-import { base } from 'viem/chains';
+import { useBaseAccountContext } from '@/components/providers/BaseAccountProvider';
 import { parseUnits, encodeFunctionData } from 'viem';
 import { TRIVIA_ABI, USDC_ABI, ENTRY_FEE_USDC, TRIVIA_CONTRACT_ADDRESS, USDC_CONTRACT_ADDRESS } from '@/lib/blockchain/contracts';
 
@@ -22,6 +21,7 @@ export interface ContractState {
 
 export function useTriviaContract(useGasless: boolean = true) {
   const { address, isConnected } = useBaseAccount();
+  const { provider } = useBaseAccountContext();
   const [state, setState] = useState<ContractState>({
     isApproving: false,
     isJoining: false,
@@ -42,29 +42,6 @@ export function useTriviaContract(useGasless: boolean = true) {
   const [isConfirmed, setIsConfirmed] = useState(false);
   const [hash, setHash] = useState<string | null>(null);
   const [writeError, setWriteError] = useState<Error | null>(null);
-
-  // Initialize Base Account SDK client-side only
-  const [provider, setProvider] = useState<any>(null);
-
-  useEffect(() => {
-    if (typeof window !== "undefined") {
-      try {
-        const sdk = createBaseAccountSDK({
-          appName: 'BEAT ME',
-          appLogoUrl: 'https://base.org/logo.png',
-          appChainIds: [base.id],
-          subAccounts: {
-            creation: 'on-connect',
-            defaultAccount: 'sub',
-          },
-          paymasterUrls: process.env.NEXT_PUBLIC_PAYMASTER_AND_BUNDLER_ENDPOINT ? [process.env.NEXT_PUBLIC_PAYMASTER_AND_BUNDLER_ENDPOINT] : undefined,
-        });
-        setProvider(sdk.getProvider());
-      } catch (error) {
-        console.error('Failed to initialize Base Account SDK:', error);
-      }
-    }
-  }, []);
 
   // Fetch session info using Base Account SDK
   const fetchSessionInfo = useCallback(async () => {
@@ -101,13 +78,13 @@ export function useTriviaContract(useGasless: boolean = true) {
         args: [],
       });
       
-      const result = await provider.request({
+      const result = (await provider.request({
         method: 'eth_call',
         params: [{
           to: TRIVIA_CONTRACT_ADDRESS,
           data,
         }, 'latest']
-      });
+      })) as string;
       
       // Parse the result - owner() returns an address (20 bytes padded to 32 bytes)
       if (result && result !== '0x') {

--- a/hooks/useUSDCBalance.ts
+++ b/hooks/useUSDCBalance.ts
@@ -2,29 +2,8 @@
 
 import { useState, useEffect, useCallback, useRef } from 'react';
 import { useBaseAccount } from './useBaseAccount';
-import { createBaseAccountSDK } from '@base-org/account';
-import { base } from 'viem/chains';
-
-// USDC contract address on Base Mainnet
-const USDC_CONTRACT_ADDRESS = '0x833589fcd6edb6e08f4c7c32d4f71b54bda02913';
-
-// USDC ABI for balance checking
-const USDC_ABI = [
-  {
-    type: 'function',
-    name: 'balanceOf',
-    inputs: [{ name: 'account', type: 'address' }],
-    outputs: [{ name: '', type: 'uint256' }],
-    stateMutability: 'view',
-  },
-  {
-    type: 'function',
-    name: 'decimals',
-    inputs: [],
-    outputs: [{ name: '', type: 'uint8' }],
-    stateMutability: 'view',
-  },
-] as const;
+import { useBaseAccountContext } from '@/components/providers/BaseAccountProvider';
+import { USDC_ADDRESS_BASE } from '@/lib/base-account/config';
 
 export interface USDCBalanceState {
   balance: number;
@@ -35,10 +14,11 @@ export interface USDCBalanceState {
   entryFeeRequired: number;
 }
 
-const ENTRY_FEE_USDC = 1; // 1 USDC entry fee
+const ENTRY_FEE_USDC = 1;
 
-export function useUSDCBalance() {
+export const useUSDCBalance = () => {
   const { address, isConnected } = useBaseAccount();
+  const { provider } = useBaseAccountContext();
   const [state, setState] = useState<USDCBalanceState>({
     balance: 0,
     balanceWei: BigInt(0),
@@ -48,35 +28,11 @@ export function useUSDCBalance() {
     entryFeeRequired: ENTRY_FEE_USDC,
   });
 
-  // Initialize Base Account SDK client-side only
-  const [provider, setProvider] = useState<any>(null);
-
-  useEffect(() => {
-    if (typeof window !== "undefined") {
-      try {
-        const sdk = createBaseAccountSDK({
-          appName: 'BEAT ME',
-          appLogoUrl: 'https://base.org/logo.png',
-          appChainIds: [base.id],
-          subAccounts: {
-            creation: 'on-connect',
-            defaultAccount: 'sub',
-          },
-          paymasterUrls: process.env.NEXT_PUBLIC_PAYMASTER_AND_BUNDLER_ENDPOINT ? [process.env.NEXT_PUBLIC_PAYMASTER_AND_BUNDLER_ENDPOINT] : undefined,
-        });
-        setProvider(sdk.getProvider());
-      } catch (error) {
-        console.error('Failed to initialize Base Account SDK:', error);
-      }
-    }
-  }, []);
-
   const hasFetchedOnce = useRef(false);
 
-  // Fetch USDC balance using Base Account SDK
   const fetchUSDCBalance = useCallback(async () => {
     if (!address || !isConnected || !provider) {
-      setState(prev => ({
+      setState((prev) => ({
         ...prev,
         balance: 0,
         balanceWei: BigInt(0),
@@ -87,38 +43,41 @@ export function useUSDCBalance() {
       return;
     }
 
-    // Only show loading spinner on the very first fetch
     if (!hasFetchedOnce.current) {
-      setState(prev => ({ ...prev, isLoading: true, error: null }));
+      setState((prev) => ({ ...prev, isLoading: true, error: null }));
     }
 
     try {
-      // Read USDC balance
-      const balanceWei = await provider.request({
+      const balanceWei = (await provider.request({
         method: 'eth_call',
-        params: [{
-          to: USDC_CONTRACT_ADDRESS,
-          data: `0x70a08231${address.slice(2).padStart(64, '0')}`, // balanceOf(address)
-        }, 'latest']
-      });
+        params: [
+          {
+            to: USDC_ADDRESS_BASE,
+            data: `0x70a08231${address.slice(2).padStart(64, '0')}`,
+          },
+          'latest',
+        ],
+      })) as string;
 
-      // Read USDC decimals
-      const decimals = await provider.request({
+      const decimals = (await provider.request({
         method: 'eth_call',
-        params: [{
-          to: USDC_CONTRACT_ADDRESS,
-          data: '0x313ce567', // decimals()
-        }, 'latest']
-      });
+        params: [
+          {
+            to: USDC_ADDRESS_BASE,
+            data: '0x313ce567',
+          },
+          'latest',
+        ],
+      })) as string;
 
-      const balanceWeiBigInt = BigInt(balanceWei as string);
-      const decimalsNum = parseInt(decimals as string, 16);
-      const balance = Number(balanceWeiBigInt) / (10 ** decimalsNum);
+      const balanceWeiBigInt = BigInt(balanceWei);
+      const decimalsNum = parseInt(decimals, 16);
+      const balance = Number(balanceWeiBigInt) / 10 ** decimalsNum;
       const hasEnough = balance >= ENTRY_FEE_USDC;
-      
+
       hasFetchedOnce.current = true;
 
-      setState(prev => ({
+      setState((prev) => ({
         ...prev,
         balance,
         balanceWei: balanceWeiBigInt,
@@ -129,25 +88,27 @@ export function useUSDCBalance() {
     } catch (error) {
       console.error('Error fetching USDC balance:', error);
       hasFetchedOnce.current = true;
-      // Preserve last known balance on error
-      setState(prev => ({
+      setState((prev) => ({
         ...prev,
         isLoading: false,
-        error: prev.balance > 0 ? null : (error instanceof Error ? error.message : 'Failed to fetch USDC balance'),
+        error:
+          prev.balance > 0
+            ? null
+            : error instanceof Error
+              ? error.message
+              : 'Failed to fetch USDC balance',
       }));
     }
   }, [address, isConnected, provider]);
 
-  // Update state when balance changes
   useEffect(() => {
-    if (provider && isConnected && address) {
-      fetchUSDCBalance();
-
-      // Set up periodic refetch every 30 seconds
-      const interval = setInterval(fetchUSDCBalance, 30000);
-
-      return () => clearInterval(interval);
+    if (!provider || !isConnected || !address) {
+      return;
     }
+
+    fetchUSDCBalance();
+    const interval = setInterval(fetchUSDCBalance, 30000);
+    return () => clearInterval(interval);
   }, [fetchUSDCBalance, provider, isConnected, address]);
 
   const refreshBalance = useCallback(() => {
@@ -160,4 +121,4 @@ export function useUSDCBalance() {
     isConnected,
     address,
   };
-}
+};

--- a/lib/base-account/auth.ts
+++ b/lib/base-account/auth.ts
@@ -1,214 +1,128 @@
 /**
  * Sign-In with Ethereum (SIWE) authentication for Base Account
- * 
- * Implements EIP-4361 standard for secure authentication
  */
 
-import { createBaseAccountSDK } from '@base-org/account';
+import { verifyMessage } from 'viem';
+import { getBaseAccountProvider } from '@/lib/base-account/sdk';
 import { base } from 'viem/chains';
 
-function getProvider() {
-  if (typeof window === 'undefined') {
-    throw new Error('Base Account SDK is only available in the browser');
-  }
-  const sdk = createBaseAccountSDK({
-    appName: 'BEAT ME',
-    appLogoUrl: 'https://base.org/logo.png',
-    appChainIds: [base.id],
-    subAccounts: {
-      creation: 'on-connect',
-      defaultAccount: 'sub',
-    },
-  });
-  return sdk.getProvider();
-}
+export const generateNonce = (): string => {
+  return (
+    Math.random().toString(36).substring(2, 15) +
+    Math.random().toString(36).substring(2, 15)
+  );
+};
 
-/**
- * Generate a unique nonce for SIWE authentication
- */
-export function generateNonce(): string {
-  return Math.random().toString(36).substring(2, 15) + 
-         Math.random().toString(36).substring(2, 15);
-}
-
-/**
- * Complete Sign-In with Base (SIWE) flow
- */
-export async function signInWithBase(): Promise<{
+export const signInWithBase = async (): Promise<{
   address: string;
   signature: string;
   message: string;
-}> {
-  try {
-    const provider = getProvider();
-    
-    // Generate nonce for this session
-    const nonce = generateNonce();
-    
-    // Create SIWE message following EIP-4361
-    const domain = window.location.host;
-    const uri = window.location.origin;
-    const version = '1';
-    const chainId = base.id;
-    
-    const message = `${domain} wants you to sign in with your Ethereum account:
-${await getAccountAddress()}
+}> => {
+  const provider = getBaseAccountProvider();
+  const nonce = generateNonce();
+  const domain = window.location.host;
+  const uri = window.location.origin;
+  const chainId = base.id;
 
-${getSiweMessage(domain, uri, nonce, version, chainId)}
+  const accounts = (await provider.request({
+    method: 'eth_accounts',
+    params: [],
+  })) as string[];
+
+  if (!accounts.length) {
+    throw new Error('No account connected');
+  }
+
+  const address = accounts[0];
+  const message = `${domain} wants you to sign in with your Ethereum account:
+${address}
+
+Sign in with Ethereum to the app.
 
 URI: ${uri}
-Version: ${version}
+Version: 1
 Chain ID: ${chainId}
 Nonce: ${nonce}
 Issued At: ${new Date().toISOString()}`;
 
-    // Request signature from user
-    const signature = (await provider.request({
-      method: 'personal_sign',
-      params: [message, await getAccountAddress()]
-    })) as string;
+  const signature = (await provider.request({
+    method: 'personal_sign',
+    params: [message, address],
+  })) as string;
 
-    const address = await getAccountAddress();
-    
-    return {
-      address,
-      signature,
-      message,
-    };
-  } catch (error) {
-    console.error('❌ SIWE authentication failed:', error);
-    throw error;
-  }
-}
+  return { address, signature, message };
+};
 
-/**
- * Get the current account address
- */
-async function getAccountAddress(): Promise<string> {
-  const provider = getProvider();
-  let accounts: string[] = [];
-  try {
-    accounts = (await provider.request({
-      method: 'eth_accounts',
-      params: []
-    })) as string[];
-  } catch {
-    throw new Error('No account connected');
-  }
-
-  if (!accounts || accounts.length === 0) {
-    throw new Error('No account connected');
-  }
-
-  return accounts[0];
-}
-
-/**
- * Create SIWE message content
- */
-function getSiweMessage(domain: string, uri: string, nonce: string, version: string, chainId: number): string {
-  return `Sign in with Ethereum to the app.
-
-This request will not trigger a blockchain transaction or cost any gas fees.
-
-Your authentication status will reset after 24 hours.
-
-URI: ${uri}
-Version: ${version}
-Chain ID: ${chainId}
-Nonce: ${nonce}
-Issued At: ${new Date().toISOString()}`;
-}
-
-/**
- * Verify SIWE signature on the server side
- * This would typically be called from an API route
- */
-export async function verifySignature(
+export const verifySignature = async (
   message: string,
   signature: string,
   address: string
-): Promise<boolean> {
+): Promise<boolean> => {
   try {
-    // In a real implementation, you would use a library like viem or ethers
-    // to verify the signature on the server side
-    // For now, we'll just validate the format
-    
     if (!message || !signature || !address) {
       return false;
     }
-    
-    // Basic validation - in production, use proper signature verification
-    return signature.startsWith('0x') && address.startsWith('0x');
+
+    return verifyMessage({
+      address: address as `0x${string}`,
+      message,
+      signature: signature as `0x${string}`,
+    });
   } catch (error) {
-    console.error('❌ Signature verification failed:', error);
+    console.error('Signature verification failed:', error);
     return false;
   }
-}
+};
 
-/**
- * Store authentication state
- */
-export function storeAuthState(authData: {
+export const storeAuthState = (authData: {
   address: string;
   signature: string;
   message: string;
-}): void {
-  localStorage.setItem('base_account_auth', JSON.stringify({
-    ...authData,
-    timestamp: Date.now(),
-    expiresAt: Date.now() + (24 * 60 * 60 * 1000), // 24 hours
-  }));
-}
+}): void => {
+  localStorage.setItem(
+    'base_account_auth',
+    JSON.stringify({
+      ...authData,
+      timestamp: Date.now(),
+      expiresAt: Date.now() + 24 * 60 * 60 * 1000,
+    })
+  );
+};
 
-/**
- * Get stored authentication state
- */
-export function getAuthState(): {
+export const getAuthState = (): {
   address: string;
   signature: string;
   message: string;
   timestamp: number;
   expiresAt: number;
-} | null {
+} | null => {
   try {
     const stored = localStorage.getItem('base_account_auth');
-    if (!stored) return null;
-    
+    if (!stored) {
+      return null;
+    }
+
     const authData = JSON.parse(stored);
-    
-    // Check if auth is expired
     if (Date.now() > authData.expiresAt) {
       localStorage.removeItem('base_account_auth');
       return null;
     }
-    
+
     return authData;
   } catch (error) {
-    console.error('❌ Error getting auth state:', error);
+    console.error('Error getting auth state:', error);
     return null;
   }
-}
+};
 
-/**
- * Clear authentication state
- */
-export function clearAuthState(): void {
+export const clearAuthState = (): void => {
   localStorage.removeItem('base_account_auth');
-}
+};
 
-/**
- * Check if user is authenticated
- */
-export function isAuthenticated(): boolean {
-  const authState = getAuthState();
-  return authState !== null;
-}
+export const isAuthenticated = (): boolean => {
+  return getAuthState() !== null;
+};
 
-/**
- * Get authenticated address
- */
-export function getAuthenticatedAddress(): string | null {
-  const authState = getAuthState();
-  return authState?.address || null;
-}
+export const getAuthenticatedAddress = (): string | null => {
+  return getAuthState()?.address || null;
+};

--- a/lib/base-account/autoSpend.ts
+++ b/lib/base-account/autoSpend.ts
@@ -1,199 +1,42 @@
-import { createBaseAccountSDK } from '@base-org/account';
-import { base } from 'viem/chains';
-import { parseUnits, formatUnits, Contract, JsonRpcProvider } from 'ethers';
-
-const USDC_ADDRESS = process.env.NEXT_PUBLIC_USDC_ADDRESS as string;
-const AUTO_SPEND_AMOUNT = '100.0'; // Amount to auto-spend in USDC
-const AUTO_SPEND_DURATION = 30 * 24 * 60 * 60; // 30 days in seconds
-
-if (!USDC_ADDRESS) {
-  console.error('Missing environment variable: NEXT_PUBLIC_USDC_ADDRESS');
-}
-
-function getAutoSpendSDK() {
-  return createBaseAccountSDK({
-    appName: 'BEAT ME',
-    appLogoUrl: 'https://base.org/logo.png',
-    appChainIds: [base.id],
-    subAccounts: { creation: 'on-connect', defaultAccount: 'sub' },
-    paymasterUrls: process.env.NEXT_PUBLIC_PAYMASTER_AND_BUNDLER_ENDPOINT ? [process.env.NEXT_PUBLIC_PAYMASTER_AND_BUNDLER_ENDPOINT] : undefined,
-  });
-}
-
 /**
- * Safely get connected accounts from provider.
- * Returns null if no accounts are connected or if eth_accounts throws (e.g. error 4100).
+ * @deprecated Sub-account auto-spend is managed by the Base Account SDK by default.
+ * On the first sub-account transaction, users are prompted to fund from their
+ * universal account and optionally grant ongoing spend permissions.
+ *
+ * Do not call these helpers — they are kept only for backward compatibility.
+ * See: https://docs.base.org/base-account/improve-ux/sub-accounts#auto-spend-permissions
  */
-async function getConnectedAccounts(provider: ReturnType<ReturnType<typeof getAutoSpendSDK>['getProvider']>): Promise<{ universal: string; subAccount: string } | null> {
-  let accounts: string[] = [];
-  try {
-    accounts = (await provider.request({ method: 'eth_accounts', params: [] })) as string[];
-  } catch {
-    return null;
-  }
 
-  if (accounts.length === 0) return null;
+const DEPRECATION_MESSAGE =
+  'Manual auto-spend configuration is deprecated. The Base Account SDK handles sub-account funding automatically on the first transaction.';
 
-  const universal = accounts[0];
-  const subAccount = accounts[1];
-  if (!subAccount) return null;
-
-  return { universal, subAccount };
-}
-
-/**
- * Configures Auto Spend Permissions for the current Base Account.
- * This allows the sub-account to automatically spend from the universal account.
- */
-export async function configureAutoSpend(): Promise<{
+export const configureAutoSpend = async (): Promise<{
   success: boolean;
-  transactionHash?: string;
   error?: string;
-}> {
-  if (!USDC_ADDRESS) {
-    return { success: false, error: 'USDC address not configured' };
-  }
+}> => {
+  console.warn(DEPRECATION_MESSAGE);
+  return { success: false, error: DEPRECATION_MESSAGE };
+};
 
-  try {
-    const provider = getAutoSpendSDK().getProvider();
-    const connected = await getConnectedAccounts(provider);
-    if (!connected) {
-      return { success: false, error: 'No Base Account connected' };
-    }
-
-    console.log('Configuring Auto Spend Permissions:', {
-      universal: connected.universal,
-      subAccount: connected.subAccount,
-      amount: AUTO_SPEND_AMOUNT,
-      duration: AUTO_SPEND_DURATION
-    });
-
-    // Request Auto Spend Permission using Base Account SDK
-    const result = (await provider.request({
-      method: 'wallet_requestSpendPermission',
-      params: {
-        tokenAddress: USDC_ADDRESS,
-        spenderAddress: connected.subAccount,
-        amount: parseUnits(AUTO_SPEND_AMOUNT, 6).toString(),
-        duration: AUTO_SPEND_DURATION,
-        autoSpend: true // Enable auto-spend functionality
-      }
-    })) as { transactionHash?: string; hash?: string };
-
-    console.log('Auto Spend Permission configured:', result);
-
-    return {
-      success: true,
-      transactionHash: result?.transactionHash || result?.hash
-    };
-
-  } catch (error: any) {
-    console.error('Error configuring Auto Spend Permissions:', error);
-    return {
-      success: false,
-      error: error.message || 'Failed to configure Auto Spend Permissions'
-    };
-  }
-}
-
-/**
- * Checks if Auto Spend Permissions are already configured for the current account.
- */
-export async function checkAutoSpendStatus(): Promise<{
+export const checkAutoSpendStatus = async (): Promise<{
   isConfigured: boolean;
   allowance?: string;
   spender?: string;
   error?: string;
-}> {
-  if (!USDC_ADDRESS) {
-    return { isConfigured: false, error: 'USDC address not configured' };
-  }
+}> => {
+  console.warn(DEPRECATION_MESSAGE);
+  return { isConfigured: false, error: DEPRECATION_MESSAGE };
+};
 
-  try {
-    const provider = getAutoSpendSDK().getProvider();
-    const connected = await getConnectedAccounts(provider);
-    if (!connected) {
-      return { isConfigured: false, error: 'No Base Account connected' };
-    }
-
-    // Check current allowance
-    const tokenContract = new Contract(
-      USDC_ADDRESS,
-      ['function allowance(address owner, address spender) view returns (uint256)'],
-      new JsonRpcProvider()
-    );
-
-    const allowance = await tokenContract.allowance(connected.universal, connected.subAccount);
-    const requiredAllowance = parseUnits(AUTO_SPEND_AMOUNT, 6);
-
-    return {
-      isConfigured: allowance.gte(requiredAllowance),
-      allowance: formatUnits(allowance, 6),
-      spender: connected.subAccount
-    };
-
-  } catch (error: any) {
-    console.error('Error checking Auto Spend status:', error);
-    return {
-      isConfigured: false,
-      error: error.message || 'Failed to check Auto Spend status'
-    };
-  }
-}
-
-/**
- * Revokes Auto Spend Permissions for the current account.
- */
-export async function revokeAutoSpend(): Promise<{
+export const revokeAutoSpend = async (): Promise<{
   success: boolean;
-  transactionHash?: string;
   error?: string;
-}> {
-  if (!USDC_ADDRESS) {
-    return { success: false, error: 'USDC address not configured' };
-  }
+}> => {
+  console.warn(DEPRECATION_MESSAGE);
+  return { success: false, error: DEPRECATION_MESSAGE };
+};
 
-  try {
-    const provider = getAutoSpendSDK().getProvider();
-    const connected = await getConnectedAccounts(provider);
-    if (!connected) {
-      return { success: false, error: 'No Base Account connected' };
-    }
-
-    console.log('Revoking Auto Spend Permissions:', {
-      universal: connected.universal,
-      subAccount: connected.subAccount
-    });
-
-    // Revoke Auto Spend Permission
-    const result = (await provider.request({
-      method: 'wallet_revokeSpendPermission',
-      params: {
-        tokenAddress: USDC_ADDRESS,
-        spenderAddress: connected.subAccount
-      }
-    })) as { transactionHash?: string; hash?: string };
-
-    console.log('Auto Spend Permissions revoked:', result);
-
-    return {
-      success: true,
-      transactionHash: result?.transactionHash || result?.hash
-    };
-
-  } catch (error: any) {
-    console.error('Error revoking Auto Spend Permissions:', error);
-    return {
-      success: false,
-      error: error.message || 'Failed to revoke Auto Spend Permissions'
-    };
-  }
-}
-
-/**
- * Gets the current Auto Spend configuration details.
- */
-export async function getAutoSpendConfig(): Promise<{
+export const getAutoSpendConfig = async (): Promise<{
   universalAddress?: string;
   subAccountAddress?: string;
   tokenAddress?: string;
@@ -201,29 +44,7 @@ export async function getAutoSpendConfig(): Promise<{
   duration?: number;
   isActive?: boolean;
   error?: string;
-}> {
-  try {
-    const provider = getAutoSpendSDK().getProvider();
-    const connected = await getConnectedAccounts(provider);
-    if (!connected) {
-      return { error: 'No Base Account connected' };
-    }
-
-    const status = await checkAutoSpendStatus();
-
-    return {
-      universalAddress: connected.universal,
-      subAccountAddress: connected.subAccount,
-      tokenAddress: USDC_ADDRESS,
-      amount: AUTO_SPEND_AMOUNT,
-      duration: AUTO_SPEND_DURATION,
-      isActive: status.isConfigured
-    };
-
-  } catch (error: any) {
-    console.error('Error getting Auto Spend config:', error);
-    return {
-      error: error.message || 'Failed to get Auto Spend configuration'
-    };
-  }
-}
+}> => {
+  console.warn(DEPRECATION_MESSAGE);
+  return { isActive: false, error: DEPRECATION_MESSAGE };
+};

--- a/lib/base-account/basename.ts
+++ b/lib/base-account/basename.ts
@@ -1,6 +1,8 @@
 import { createPublicClient, http, toCoinType } from 'viem';
 import { mainnet, base } from 'viem/chains';
 
+// ENSIP-19 reverse resolution for Base names uses the L1 Universal Resolver with
+// coinType for Base — see https://docs.base.org/base-account/framework-integrations/wagmi/basenames
 const mainnetRpc = process.env.NEXT_PUBLIC_ALCHEMY_API_KEY
   ? `https://eth-mainnet.g.alchemy.com/v2/${process.env.NEXT_PUBLIC_ALCHEMY_API_KEY}`
   : 'https://eth.llamarpc.com';

--- a/lib/base-account/basename.ts
+++ b/lib/base-account/basename.ts
@@ -1,0 +1,25 @@
+import { createPublicClient, http, toCoinType } from 'viem';
+import { mainnet, base } from 'viem/chains';
+
+const mainnetRpc = process.env.NEXT_PUBLIC_ALCHEMY_API_KEY
+  ? `https://eth-mainnet.g.alchemy.com/v2/${process.env.NEXT_PUBLIC_ALCHEMY_API_KEY}`
+  : 'https://eth.llamarpc.com';
+
+const basenameClient = createPublicClient({
+  chain: mainnet,
+  transport: http(mainnetRpc),
+});
+
+export const getBasename = async (
+  address: `0x${string}`
+): Promise<string | null> => {
+  try {
+    return await basenameClient.getEnsName({
+      address,
+      coinType: toCoinType(base.id),
+    });
+  } catch (error) {
+    console.error('Failed to resolve basename:', error);
+    return null;
+  }
+};

--- a/lib/base-account/config.ts
+++ b/lib/base-account/config.ts
@@ -1,0 +1,24 @@
+import { base } from 'viem/chains';
+
+export const BASE_ACCOUNT_APP_NAME =
+  process.env.NEXT_PUBLIC_BASE_ACCOUNT_APP_NAME || 'BEAT ME';
+
+export const BASE_ACCOUNT_LOGO_URL =
+  process.env.NEXT_PUBLIC_BASE_ACCOUNT_LOGO_URL || 'https://base.org/logo.png';
+
+export const BASE_CHAIN_ID = base.id;
+
+export const USDC_ADDRESS_BASE =
+  process.env.NEXT_PUBLIC_USDC_ADDRESS ||
+  '0x833589fCD6eDb6E08f4c7C32D4f71b54bdA02913';
+
+export const SPEND_PERMISSION_SPENDER =
+  process.env.NEXT_PUBLIC_SPEND_PERMISSION_SPENDER || '';
+
+export const PAYMASTER_URL =
+  process.env.NEXT_PUBLIC_PAYMASTER_AND_BUNDLER_ENDPOINT || undefined;
+
+export const BASE_PAY_AMOUNTS = {
+  walletFunding: '5.00',
+  gamePayment: '10.00',
+} as const;

--- a/lib/base-account/erc20Gas.ts
+++ b/lib/base-account/erc20Gas.ts
@@ -1,5 +1,4 @@
-import { createBaseAccountSDK } from '@base-org/account';
-import { base } from 'viem/chains';
+import { getBaseAccountProvider } from '@/lib/base-account/sdk';
 import { Contract, parseUnits, formatUnits, JsonRpcProvider } from 'ethers';
 
 const USDC_ADDRESS = process.env.NEXT_PUBLIC_USDC_ADDRESS as string;
@@ -66,21 +65,13 @@ export async function estimateGasCostInUSDC(
   gasPrice: string;
   error?: string;
 }> {
-  const sdk = createBaseAccountSDK({
-    appName: 'BEAT ME',
-    appLogoUrl: 'https://base.org/logo.png',
-    appChainIds: [base.id],
-    subAccounts: { creation: 'on-connect', defaultAccount: 'sub' },
-    paymasterUrls: process.env.NEXT_PUBLIC_PAYMASTER_AND_BUNDLER_ENDPOINT ? [process.env.NEXT_PUBLIC_PAYMASTER_AND_BUNDLER_ENDPOINT] : undefined,
-  });
+  const provider = getBaseAccountProvider();
 
   if (!isERC20GasEnabled()) {
     return { gasCost: '0', gasLimit: '0', gasPrice: '0', error: 'ERC20 gas payments not enabled' };
   }
 
   try {
-    const provider = sdk.getProvider();
-    
     // Estimate gas limit via EIP-1193
     const gasLimitHex = (await provider.request({
       method: 'eth_estimateGas',
@@ -138,21 +129,13 @@ export async function sendTransactionWithERC20Gas(
   transactionHash?: string;
   error?: string;
 }> {
-  const sdk = createBaseAccountSDK({
-    appName: 'BEAT ME',
-    appLogoUrl: 'https://base.org/logo.png',
-    appChainIds: [base.id],
-    subAccounts: { creation: 'on-connect', defaultAccount: 'sub' },
-    paymasterUrls: process.env.NEXT_PUBLIC_PAYMASTER_AND_BUNDLER_ENDPOINT ? [process.env.NEXT_PUBLIC_PAYMASTER_AND_BUNDLER_ENDPOINT] : undefined,
-  });
+  const provider = getBaseAccountProvider();
 
   if (!isERC20GasEnabled()) {
     return { success: false, error: 'ERC20 gas payments not enabled' };
   }
 
   try {
-    const provider = sdk.getProvider();
-    
     // Prepare the transaction with ERC20 gas payment
     const txRequest = {
       to: transaction.to,
@@ -204,21 +187,13 @@ export async function sendBatchTransactionsWithERC20Gas(
   transactionHash?: string;
   error?: string;
 }> {
-  const sdk = createBaseAccountSDK({
-    appName: 'BEAT ME',
-    appLogoUrl: 'https://base.org/logo.png',
-    appChainIds: [base.id],
-    subAccounts: { creation: 'on-connect', defaultAccount: 'sub' },
-    paymasterUrls: process.env.NEXT_PUBLIC_PAYMASTER_AND_BUNDLER_ENDPOINT ? [process.env.NEXT_PUBLIC_PAYMASTER_AND_BUNDLER_ENDPOINT] : undefined,
-  });
+  const provider = getBaseAccountProvider();
 
   if (!isERC20GasEnabled()) {
     return { success: false, error: 'ERC20 gas payments not enabled' };
   }
 
   try {
-    const provider = sdk.getProvider();
-    
     // Prepare batch calls with ERC20 gas payment
     const batchCalls = calls.map(call => ({
       to: call.to,
@@ -266,13 +241,7 @@ export async function checkUSDCBalanceForGas(
   requiredBalance: string;
   error?: string;
 }> {
-  const sdk = createBaseAccountSDK({
-    appName: 'BEAT ME',
-    appLogoUrl: 'https://base.org/logo.png',
-    appChainIds: [base.id],
-    subAccounts: { creation: 'on-connect', defaultAccount: 'sub' },
-    paymasterUrls: process.env.NEXT_PUBLIC_PAYMASTER_AND_BUNDLER_ENDPOINT ? [process.env.NEXT_PUBLIC_PAYMASTER_AND_BUNDLER_ENDPOINT] : undefined,
-  });
+  const provider = getBaseAccountProvider();
 
   if (!USDC_ADDRESS) {
     return {
@@ -284,8 +253,6 @@ export async function checkUSDCBalanceForGas(
   }
 
   try {
-    const provider = sdk.getProvider();
-    
     // Get USDC contract
     const usdcContract = new Contract(
       USDC_ADDRESS,

--- a/lib/base-account/pay.ts
+++ b/lib/base-account/pay.ts
@@ -1,0 +1,58 @@
+import { pay, getPaymentStatus, type PaymentOptions, type PaymentResult } from '@base-org/account';
+
+export type BasePayResult =
+  | { success: true; payment: PaymentResult; status: 'completed' }
+  | { success: false; error: string; status?: 'failed' | 'pending' };
+
+const pollPaymentStatus = async (
+  paymentId: string,
+  testnet: boolean,
+  maxAttempts = 30,
+  intervalMs = 2000
+): Promise<BasePayResult> => {
+  for (let attempt = 0; attempt < maxAttempts; attempt += 1) {
+    await new Promise((resolve) => setTimeout(resolve, intervalMs));
+
+    try {
+      const status = await getPaymentStatus({ id: paymentId, testnet });
+
+      if (status.status === 'completed') {
+        return { success: true, payment: { success: true, id: paymentId, amount: status.amount ?? '', to: status.recipient as `0x${string}` }, status: 'completed' };
+      }
+
+      if (status.status === 'failed') {
+        return {
+          success: false,
+          error: status.reason || status.message || 'Payment failed',
+          status: 'failed',
+        };
+      }
+    } catch (error) {
+      if (attempt === maxAttempts - 1) {
+        return {
+          success: false,
+          error: error instanceof Error ? error.message : 'Failed to check payment status',
+        };
+      }
+    }
+  }
+
+  return { success: false, error: 'Payment timed out', status: 'pending' };
+};
+
+/**
+ * Execute a Base Pay flow using paymentOptions (account-ui button is visual only in v1.0.1).
+ */
+export const executeBasePay = async (
+  paymentOptions: PaymentOptions
+): Promise<BasePayResult> => {
+  try {
+    const payment = await pay(paymentOptions);
+    return pollPaymentStatus(payment.id, paymentOptions.testnet ?? false);
+  } catch (error) {
+    return {
+      success: false,
+      error: error instanceof Error ? error.message : 'Payment failed',
+    };
+  }
+};

--- a/lib/base-account/sdk.ts
+++ b/lib/base-account/sdk.ts
@@ -1,0 +1,41 @@
+import { createBaseAccountSDK } from '@base-org/account';
+import type { ProviderInterface } from '@base-org/account';
+import { base } from 'viem/chains';
+import {
+  BASE_ACCOUNT_APP_NAME,
+  BASE_ACCOUNT_LOGO_URL,
+  PAYMASTER_URL,
+} from './config';
+
+export type BaseAccountSDKInstance = ReturnType<typeof createBaseAccountSDK>;
+
+let sdkInstance: BaseAccountSDKInstance | null = null;
+
+export const getBaseAccountSDK = (): BaseAccountSDKInstance => {
+  if (typeof window === 'undefined') {
+    throw new Error('Base Account SDK can only be used on the client');
+  }
+
+  if (!sdkInstance) {
+    sdkInstance = createBaseAccountSDK({
+      appName: BASE_ACCOUNT_APP_NAME,
+      appLogoUrl: BASE_ACCOUNT_LOGO_URL,
+      appChainIds: [base.id],
+      subAccounts: {
+        creation: 'on-connect',
+        defaultAccount: 'sub',
+      },
+      paymasterUrls: PAYMASTER_URL ? [PAYMASTER_URL] : undefined,
+    });
+  }
+
+  return sdkInstance;
+};
+
+export const getBaseAccountProvider = (): ProviderInterface => {
+  return getBaseAccountSDK().getProvider();
+};
+
+export const resetBaseAccountSDK = (): void => {
+  sdkInstance = null;
+};

--- a/lib/base-account/spendPermissions.ts
+++ b/lib/base-account/spendPermissions.ts
@@ -1,204 +1,237 @@
+'use client';
+
 /**
  * Spend Permissions utilities for Base Account
- * 
- * Handles requesting, checking, and using spend permissions for gasless transactions
  */
 
-// Note: Spend permission functions are not available in the current version of @base-org/account
-// This is a placeholder implementation until the spend permission API is available
-import { createBaseAccountSDK } from '@base-org/account';
-import { base } from 'viem/chains';
+import {
+  requestSpendPermission,
+  requestRevoke,
+  fetchPermissions,
+  getPermissionStatus,
+} from '@base-org/account/spend-permission/browser';
+import { getBaseAccountProvider } from '@/lib/base-account/sdk';
+import {
+  BASE_CHAIN_ID,
+  SPEND_PERMISSION_SPENDER,
+  USDC_ADDRESS_BASE,
+} from '@/lib/base-account/config';
 
-// Game-specific spend permission configuration
-const GAME_SPEND_CONFIG = {
-  token: '0x833589fCD6eDb6E08f4c7C32D4f71b54bdA02913', // USDC on Base
-  chainId: base.id,
-  allowance: BigInt('100000000'), // 100 USDC (6 decimals)
-  periodInDays: 30,
-  spender: process.env.NEXT_PUBLIC_SPEND_PERMISSION_SPENDER || '0xYourTreasuryAddress',
+const GAME_SPEND_ALLOWANCE = BigInt(100_000_000); // 100 USDC (6 decimals)
+const GAME_SPEND_PERIOD_DAYS = 30;
+
+const PERMISSION_STORAGE_KEY = 'beat_me_spend_permission';
+
+type StoredSpendPermission = Awaited<ReturnType<typeof requestSpendPermission>>;
+
+export interface SpendPermissionDetails {
+  account: string;
+  spender: string;
+  token: string;
+  allowance: string;
+  periodInDays: number;
+  daysRemaining: number;
+  isExpired: boolean;
+  isActive: boolean;
+  remainingSpend?: string;
+}
+
+const isSpendPermissionsConfigured = (): boolean => {
+  return (
+    !!SPEND_PERMISSION_SPENDER &&
+    SPEND_PERMISSION_SPENDER !== '0xYourTreasuryAddress'
+  );
 };
 
-// Get Base Account SDK instance (client-side only)
-let sdkInstance: any = null;
-
-function getSDK() {
-  if (typeof window === "undefined") {
-    throw new Error('Base Account SDK can only be used on the client side');
+const storePermission = (permission: StoredSpendPermission): void => {
+  if (typeof window === 'undefined') {
+    return;
   }
-  
-  if (!sdkInstance) {
-    sdkInstance = createBaseAccountSDK({
-      appName: 'BEAT ME',
-      appLogoUrl: 'https://base.org/logo.png',
-      appChainIds: [base.id],
-      subAccounts: {
-        creation: 'on-connect',
-        defaultAccount: 'sub',
-      },
-    });
-  }
-  
-  return sdkInstance;
-}
+  localStorage.setItem(PERMISSION_STORAGE_KEY, JSON.stringify(permission));
+};
 
-/**
- * Request spend permission for game entry fees
- * Note: This is a placeholder implementation until spend permission API is available
- */
-export async function requestGameSpendPermission(account: string): Promise<boolean> {
-  try {
-    console.log('🔐 Requesting spend permission for game entry...');
-    console.warn('⚠️ Spend permission API not available in current Base Account SDK version');
-    
-    // For now, simulate a successful permission request
-    // In a real implementation, this would use the Base Account spend permission API
-    const mockPermission = {
-      account,
-      spender: GAME_SPEND_CONFIG.spender,
-      token: GAME_SPEND_CONFIG.token,
-      allowance: GAME_SPEND_CONFIG.allowance.toString(),
-      periodInDays: GAME_SPEND_CONFIG.periodInDays,
-      timestamp: Date.now(),
-    };
-
-    // Store permission in localStorage for quick checks
-    localStorage.setItem('game_spend_permission', JSON.stringify(mockPermission));
-    
-    console.log('✅ Spend permission granted (mock)');
-    return true;
-  } catch (error) {
-    console.error('❌ Failed to request spend permission:', error);
-    return false;
-  }
-}
-
-/**
- * Check if valid spend permission exists
- */
-export function checkSpendPermission(account: string): boolean {
-  try {
-    const stored = localStorage.getItem('game_spend_permission');
-    if (!stored) return false;
-    
-    const permission = JSON.parse(stored);
-    
-    // Check if permission is for the same account and spender
-    if (permission.account !== account || permission.spender !== GAME_SPEND_CONFIG.spender) {
-      return false;
-    }
-    
-    // Check if permission is still valid (within 30 days)
-    const daysSinceGranted = (Date.now() - permission.timestamp) / (1000 * 60 * 60 * 24);
-    if (daysSinceGranted > GAME_SPEND_CONFIG.periodInDays) {
-      // Clear expired permission
-      localStorage.removeItem('game_spend_permission');
-      return false;
-    }
-    
-    return true;
-  } catch (error) {
-    console.error('❌ Error checking spend permission:', error);
-    return false;
-  }
-}
-
-/**
- * Use spend permission to execute a transaction
- * Note: This is a placeholder implementation until spend permission API is available
- */
-export async function useSpendPermission(
-  account: string,
-  to: string,
-  amount: string,
-  data?: string
-): Promise<string> {
-  try {
-    console.log('💸 Using spend permission for transaction...');
-    console.warn('⚠️ Spend permission API not available in current Base Account SDK version');
-    
-    // For now, simulate a transaction using regular wallet calls
-    // In a real implementation, this would use the Base Account spend permission API
-    const result = await getSDK().getProvider().request({
-      method: 'wallet_sendCalls',
-      params: [{
-        version: '1.0',
-        chainId: `0x${GAME_SPEND_CONFIG.chainId.toString(16)}`,
-        from: account,
-        calls: [{
-          to: to,
-          data: data || '0x',
-          value: '0x0',
-        }],
-        capabilities: {
-          paymasterService: {
-            url: process.env.NEXT_PUBLIC_PAYMASTER_AND_BUNDLER_ENDPOINT,
-          },
-        },
-      }],
-    });
-
-    console.log('✅ Transaction sent (without spend permission):', result);
-    return result;
-  } catch (error) {
-    console.error('❌ Failed to use spend permission:', error);
-    throw error;
-  }
-}
-
-/**
- * Revoke spend permission
- * Note: This is a placeholder implementation until spend permission API is available
- */
-export async function revokeSpendPermission(account: string): Promise<boolean> {
-  try {
-    console.log('🔒 Revoking spend permission...');
-    console.warn('⚠️ Spend permission API not available in current Base Account SDK version');
-    
-    // For now, just clear the stored permission
-    // In a real implementation, this would use the Base Account spend permission API
-    localStorage.removeItem('game_spend_permission');
-    
-    console.log('✅ Spend permission revoked (mock)');
-    return true;
-  } catch (error) {
-    console.error('❌ Failed to revoke spend permission:', error);
-    return false;
-  }
-}
-
-/**
- * Get spend permission details
- */
-export function getSpendPermissionDetails(account: string) {
-  try {
-    const stored = localStorage.getItem('game_spend_permission');
-    if (!stored) return null;
-    
-    const permission = JSON.parse(stored);
-    
-    if (permission.account !== account) return null;
-    
-    const daysSinceGranted = (Date.now() - permission.timestamp) / (1000 * 60 * 60 * 24);
-    const daysRemaining = GAME_SPEND_CONFIG.periodInDays - daysSinceGranted;
-    
-    return {
-      ...permission,
-      daysRemaining: Math.max(0, daysRemaining),
-      isExpired: daysRemaining <= 0,
-    };
-  } catch (error) {
-    console.error('❌ Error getting spend permission details:', error);
+const loadStoredPermission = (): StoredSpendPermission | null => {
+  if (typeof window === 'undefined') {
     return null;
   }
-}
 
-/**
- * Auto-request spend permission if needed
- */
-export async function ensureSpendPermission(account: string): Promise<boolean> {
-  if (checkSpendPermission(account)) {
+  try {
+    const stored = localStorage.getItem(PERMISSION_STORAGE_KEY);
+    if (!stored) {
+      return null;
+    }
+    return JSON.parse(stored) as StoredSpendPermission;
+  } catch {
+    return null;
+  }
+};
+
+const clearStoredPermission = (): void => {
+  if (typeof window === 'undefined') {
+    return;
+  }
+  localStorage.removeItem(PERMISSION_STORAGE_KEY);
+};
+
+export const isGameSpendPermissionsEnabled = (): boolean => {
+  return isSpendPermissionsConfigured();
+};
+
+export const requestGameSpendPermission = async (
+  account: string
+): Promise<boolean> => {
+  if (!isSpendPermissionsConfigured()) {
+    console.warn(
+      'Spend permissions not configured. Set NEXT_PUBLIC_SPEND_PERMISSION_SPENDER.'
+    );
+    return false;
+  }
+
+  try {
+    const provider = getBaseAccountProvider();
+    const permission = await requestSpendPermission({
+      account,
+      spender: SPEND_PERMISSION_SPENDER,
+      token: USDC_ADDRESS_BASE,
+      chainId: BASE_CHAIN_ID,
+      allowance: GAME_SPEND_ALLOWANCE,
+      periodInDays: GAME_SPEND_PERIOD_DAYS,
+      provider,
+    });
+
+    storePermission(permission);
+    return true;
+  } catch (error) {
+    console.error('Failed to request spend permission:', error);
+    return false;
+  }
+};
+
+export const checkSpendPermission = async (
+  account: string
+): Promise<boolean> => {
+  if (!isSpendPermissionsConfigured()) {
+    return false;
+  }
+
+  try {
+    const provider = getBaseAccountProvider();
+    const permissions = await fetchPermissions({
+      account,
+      spender: SPEND_PERMISSION_SPENDER,
+      chainId: BASE_CHAIN_ID,
+      provider,
+    });
+
+    if (permissions.length > 0) {
+      storePermission(permissions[0]);
+      const status = await getPermissionStatus(permissions[0]);
+      return status.isActive && !status.isRevoked && !status.isExpired;
+    }
+
+    const stored = loadStoredPermission();
+    if (!stored) {
+      return false;
+    }
+
+    const status = await getPermissionStatus(stored);
+    return status.isActive && !status.isRevoked && !status.isExpired;
+  } catch (error) {
+    console.error('Error checking spend permission:', error);
+    return false;
+  }
+};
+
+export const revokeSpendPermission = async (
+  account: string
+): Promise<boolean> => {
+  if (!isSpendPermissionsConfigured()) {
+    return false;
+  }
+
+  try {
+    const provider = getBaseAccountProvider();
+    let permission = loadStoredPermission();
+
+    if (!permission) {
+      const permissions = await fetchPermissions({
+        account,
+        spender: SPEND_PERMISSION_SPENDER,
+        chainId: BASE_CHAIN_ID,
+        provider,
+      });
+      permission = permissions[0] ?? null;
+    }
+
+    if (!permission) {
+      return false;
+    }
+
+    await requestRevoke({ provider, permission });
+    clearStoredPermission();
+    return true;
+  } catch (error) {
+    console.error('Failed to revoke spend permission:', error);
+    return false;
+  }
+};
+
+export const getSpendPermissionDetails = async (
+  account: string
+): Promise<SpendPermissionDetails | null> => {
+  if (!isSpendPermissionsConfigured()) {
+    return null;
+  }
+
+  try {
+    const provider = getBaseAccountProvider();
+    let permission = loadStoredPermission();
+
+    if (!permission) {
+      const permissions = await fetchPermissions({
+        account,
+        spender: SPEND_PERMISSION_SPENDER,
+        chainId: BASE_CHAIN_ID,
+        provider,
+      });
+      permission = permissions[0] ?? null;
+    }
+
+    if (!permission) {
+      return null;
+    }
+
+    const status = await getPermissionStatus(permission);
+    const periodEnd = status.currentPeriod.end;
+    const periodStart = status.currentPeriod.start;
+    const daysRemaining = Math.max(
+      0,
+      (periodEnd - Math.floor(Date.now() / 1000)) / (60 * 60 * 24)
+    );
+
+    return {
+      account,
+      spender: SPEND_PERMISSION_SPENDER,
+      token: USDC_ADDRESS_BASE,
+      allowance: GAME_SPEND_ALLOWANCE.toString(),
+      periodInDays: GAME_SPEND_PERIOD_DAYS,
+      daysRemaining,
+      isExpired: status.isExpired,
+      isActive: status.isActive,
+      remainingSpend: status.remainingSpend.toString(),
+    };
+  } catch (error) {
+    console.error('Error getting spend permission details:', error);
+    return null;
+  }
+};
+
+export const ensureSpendPermission = async (
+  account: string
+): Promise<boolean> => {
+  const hasPermission = await checkSpendPermission(account);
+  if (hasPermission) {
     return true;
   }
-  
-  return await requestGameSpendPermission(account);
-}
+  return requestGameSpendPermission(account);
+};

--- a/lib/base-account/subAccount.ts
+++ b/lib/base-account/subAccount.ts
@@ -39,7 +39,7 @@ export const resolveSubAccountAddresses = async (
     return null;
   }
 
-  const universalAddress = accounts.length > 1 ? accounts[0] : accounts[0];
+  const universalAddress = accounts[0];
 
   try {
     await provider.request({

--- a/lib/base-account/subAccount.ts
+++ b/lib/base-account/subAccount.ts
@@ -1,0 +1,118 @@
+import type { ProviderInterface } from '@base-org/account';
+
+export interface SubAccountAddresses {
+  universalAddress: string;
+  subAccountAddress: string;
+}
+
+interface SubAccountEntry {
+  address: string;
+}
+
+interface GetSubAccountsResponse {
+  subAccounts: SubAccountEntry[];
+}
+
+interface AddSubAccountResponse {
+  address: string;
+}
+
+/**
+ * Re-activate the app sub-account for the current session and resolve addresses.
+ * Per Base docs, wallet_addSubAccount should be called each session before use.
+ */
+export const resolveSubAccountAddresses = async (
+  provider: ProviderInterface
+): Promise<SubAccountAddresses | null> => {
+  let accounts: string[] = [];
+
+  try {
+    accounts = (await provider.request({
+      method: 'eth_accounts',
+      params: [],
+    })) as string[];
+  } catch {
+    return null;
+  }
+
+  if (!accounts.length) {
+    return null;
+  }
+
+  const universalAddress = accounts.length > 1 ? accounts[0] : accounts[0];
+
+  try {
+    await provider.request({
+      method: 'wallet_addSubAccount',
+      params: [
+        {
+          account: {
+            type: 'create',
+          },
+        },
+      ],
+    });
+  } catch {
+    // Sub-account may already be active for this session.
+  }
+
+  try {
+    const response = (await provider.request({
+      method: 'wallet_getSubAccounts',
+      params: [
+        {
+          account: universalAddress,
+          domain: window.location.origin,
+        },
+      ],
+    })) as GetSubAccountsResponse;
+
+    const subFromIndex = response.subAccounts?.[0]?.address;
+    if (subFromIndex) {
+      return { universalAddress, subAccountAddress: subFromIndex };
+    }
+  } catch {
+    // Fall through to eth_accounts ordering.
+  }
+
+  const refreshedAccounts = (await provider.request({
+    method: 'eth_accounts',
+    params: [],
+  })) as string[];
+
+  if (refreshedAccounts.length > 1) {
+    return {
+      universalAddress: refreshedAccounts[0],
+      subAccountAddress: refreshedAccounts[1],
+    };
+  }
+
+  const fallback = refreshedAccounts[0] ?? universalAddress;
+  return {
+    universalAddress: fallback,
+    subAccountAddress: fallback,
+  };
+};
+
+/**
+ * Connect wallet and resolve sub-account addresses.
+ */
+export const connectSubAccountAddresses = async (
+  provider: ProviderInterface
+): Promise<SubAccountAddresses> => {
+  const accounts = (await provider.request({
+    method: 'eth_requestAccounts',
+    params: [],
+  })) as string[];
+
+  if (!accounts.length) {
+    throw new Error('No accounts found');
+  }
+
+  const resolved = await resolveSubAccountAddresses(provider);
+  if (!resolved) {
+    throw new Error('Failed to resolve sub-account');
+  }
+
+  return resolved;
+};

--- a/lib/transaction/batchTransactions.ts
+++ b/lib/transaction/batchTransactions.ts
@@ -1,6 +1,5 @@
-import { createBaseAccountSDK } from '@base-org/account';
-import { base } from 'viem/chains';
 import { Interface } from 'ethers';
+import { getBaseAccountProvider } from '@/lib/base-account/sdk';
 import { BUILDER_CODE_DATA_SUFFIX } from '@/lib/blockchain/builderCode';
 
 export interface BatchCall {
@@ -27,14 +26,7 @@ export interface BatchTransactionResult {
  * @returns Promise with transaction result
  */
 export async function sendBatchCalls(options: BatchTransactionOptions): Promise<BatchTransactionResult> {
-  const sdk = createBaseAccountSDK({
-    appName: 'BEAT ME',
-    appLogoUrl: 'https://base.org/logo.png',
-    appChainIds: [base.id],
-    subAccounts: { creation: 'on-connect', defaultAccount: 'sub' },
-    paymasterUrls: process.env.NEXT_PUBLIC_PAYMASTER_AND_BUNDLER_ENDPOINT ? [process.env.NEXT_PUBLIC_PAYMASTER_AND_BUNDLER_ENDPOINT] : undefined,
-  });
-
+  const provider = getBaseAccountProvider();
   const { calls, atomicRequired = true, gasless = true } = options;
 
   if (!calls || calls.length === 0) {
@@ -49,9 +41,6 @@ export async function sendBatchCalls(options: BatchTransactionOptions): Promise<
       value: call.value || '0'
     })));
 
-    const provider = sdk.getProvider();
-    
-    // Use wallet_sendCalls for batch transactions
     const result = (await provider.request({
       method: 'wallet_sendCalls',
       params: {

--- a/package-lock.json
+++ b/package-lock.json
@@ -8,7 +8,7 @@
       "name": "ocs-alpha",
       "version": "0.1.0",
       "dependencies": {
-        "@base-org/account": "^2.4.0",
+        "@base-org/account": "^2.5.6",
         "@base-org/account-ui": "^1.0.1",
         "@coinbase/cdp-sdk": "^1.38.2",
         "@coinbase/coinbase-sdk": "^0.25.0",
@@ -404,13 +404,13 @@
       }
     },
     "node_modules/@base-org/account": {
-      "version": "2.4.0",
-      "resolved": "https://registry.npmjs.org/@base-org/account/-/account-2.4.0.tgz",
-      "integrity": "sha512-A4Umpi8B9/pqR78D1Yoze4xHyQaujioVRqqO3d6xuDFw9VRtjg6tK3bPlwE0aW+nVH/ntllCpPa2PbI8Rnjcug==",
+      "version": "2.5.6",
+      "resolved": "https://registry.npmjs.org/@base-org/account/-/account-2.5.6.tgz",
+      "integrity": "sha512-DOKfn3Ax80NQGh9m+iUFTu0it9lqu2Oo0AgM7UQhbDR8iUMijT87J2EINLnUTV0YqX2Gr8m/rM6w6RDhQcPy4g==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@coinbase/cdp-sdk": "^1.0.0",
-        "@noble/hashes": "1.4.0",
+        "@coinbase/cdp-sdk": "^1.48.3",
+        "brotli-wasm": "^3.0.0",
         "clsx": "1.2.1",
         "eventemitter3": "5.0.1",
         "idb-keyval": "6.2.1",
@@ -418,6 +418,9 @@
         "preact": "10.24.2",
         "viem": "^2.31.7",
         "zustand": "5.0.3"
+      },
+      "engines": {
+        "node": ">=20"
       }
     },
     "node_modules/@base-org/account-ui": {
@@ -443,18 +446,6 @@
         "vue": {
           "optional": true
         }
-      }
-    },
-    "node_modules/@base-org/account/node_modules/@noble/hashes": {
-      "version": "1.4.0",
-      "resolved": "https://registry.npmjs.org/@noble/hashes/-/hashes-1.4.0.tgz",
-      "integrity": "sha512-V1JJ1WTRUqHHrOSh597hURcMqVKVGL/ea3kv0gSnEdsEZ0/+VyPghM1lMNGc00z7CIQorSvbKpuJkxvuHbvdbg==",
-      "license": "MIT",
-      "engines": {
-        "node": ">= 16"
-      },
-      "funding": {
-        "url": "https://paulmillr.com/funding/"
       }
     },
     "node_modules/@base-org/account/node_modules/clsx": {
@@ -1177,21 +1168,38 @@
       }
     },
     "node_modules/@coinbase/cdp-sdk": {
-      "version": "1.38.2",
-      "resolved": "https://registry.npmjs.org/@coinbase/cdp-sdk/-/cdp-sdk-1.38.2.tgz",
-      "integrity": "sha512-S7+xKeZGGi+zc1PotTeQ5Pvn5a0e4ikT+iMm8pPfPjObNlDEUKLei4cmRHON1wXgql0oDXn30YKTo1LQWxXvDw==",
+      "version": "1.51.0",
+      "resolved": "https://registry.npmjs.org/@coinbase/cdp-sdk/-/cdp-sdk-1.51.0.tgz",
+      "integrity": "sha512-XK8+OXDER1jirYpuiOct4ij65ODQ31LsmyRrZi/J7zF4GB89qxWZ0KPfAdsqJMP7VvE4no+Q++MKkQtAJUBoyg==",
       "license": "MIT",
       "dependencies": {
-        "@solana/spl-token": "^0.4.13",
-        "@solana/web3.js": "^1.98.1",
+        "@solana-program/system": "^0.10.0",
+        "@solana-program/token": "^0.9.0",
+        "@solana/kit": "^5.5.1",
         "abitype": "1.0.6",
-        "axios": "^1.12.2",
+        "axios": "1.16.0",
         "axios-retry": "^4.5.0",
-        "jose": "^6.0.8",
+        "bs58": "^6.0.0",
+        "jose": "^6.2.0",
         "md5": "^2.3.0",
         "uncrypto": "^0.1.3",
-        "viem": "^2.21.26",
-        "zod": "^3.24.4"
+        "viem": "^2.47.0",
+        "zod": "^3.25.76"
+      }
+    },
+    "node_modules/@coinbase/cdp-sdk/node_modules/base-x": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/base-x/-/base-x-5.0.1.tgz",
+      "integrity": "sha512-M7uio8Zt++eg3jPj+rHMfCC+IuygQHHCOU+IYsVtik6FWjuYpVt/+MRKcgsAMHh8mMFAwnB+Bs+mTrFiXjMzKg==",
+      "license": "MIT"
+    },
+    "node_modules/@coinbase/cdp-sdk/node_modules/bs58": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/bs58/-/bs58-6.0.0.tgz",
+      "integrity": "sha512-PD0wEnEYg6ijszw/u8s+iI3H17cTymlrwkKhDhPZq+Sokl3AU4htyBFTjAeNAlCCmg0f53g6ih3jATyCKftTfw==",
+      "license": "MIT",
+      "dependencies": {
+        "base-x": "^5.0.0"
       }
     },
     "node_modules/@coinbase/coinbase-sdk": {
@@ -10326,6 +10334,93 @@
       "integrity": "sha512-9BCxFwvbGg/RsZK9tjXd8s4UcwR0MWeFQ1XEKIQVVvAGJyINdrqKMcTRyLoK8Rse1GjzLV9cwjWV1olXRWEXVA==",
       "license": "MIT"
     },
+    "node_modules/@solana-program/system": {
+      "version": "0.10.0",
+      "resolved": "https://registry.npmjs.org/@solana-program/system/-/system-0.10.0.tgz",
+      "integrity": "sha512-Go+LOEZmqmNlfr+Gjy5ZWAdY5HbYzk2RBewD9QinEU/bBSzpFfzqDRT55JjFRBGJUvMgf3C2vfXEGT4i8DSI4g==",
+      "license": "Apache-2.0",
+      "peerDependencies": {
+        "@solana/kit": "^5.0"
+      }
+    },
+    "node_modules/@solana-program/token": {
+      "version": "0.9.0",
+      "resolved": "https://registry.npmjs.org/@solana-program/token/-/token-0.9.0.tgz",
+      "integrity": "sha512-vnZxndd4ED4Fc56sw93cWZ2djEeeOFxtaPS8SPf5+a+JZjKA/EnKqzbE1y04FuMhIVrLERQ8uR8H2h72eZzlsA==",
+      "license": "Apache-2.0",
+      "peerDependencies": {
+        "@solana/kit": "^5.0"
+      }
+    },
+    "node_modules/@solana/accounts": {
+      "version": "5.5.1",
+      "resolved": "https://registry.npmjs.org/@solana/accounts/-/accounts-5.5.1.tgz",
+      "integrity": "sha512-TfOY9xixg5rizABuLVuZ9XI2x2tmWUC/OoN556xwfDlhBHBjKfszicYYOyD6nbFmwTGYarCmyGIdteXxTXIdhQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@solana/addresses": "5.5.1",
+        "@solana/codecs-core": "5.5.1",
+        "@solana/codecs-strings": "5.5.1",
+        "@solana/errors": "5.5.1",
+        "@solana/rpc-spec": "5.5.1",
+        "@solana/rpc-types": "5.5.1"
+      },
+      "engines": {
+        "node": ">=20.18.0"
+      },
+      "peerDependencies": {
+        "typescript": "^5.0.0"
+      },
+      "peerDependenciesMeta": {
+        "typescript": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@solana/addresses": {
+      "version": "5.5.1",
+      "resolved": "https://registry.npmjs.org/@solana/addresses/-/addresses-5.5.1.tgz",
+      "integrity": "sha512-5xoah3Q9G30HQghu/9BiHLb5pzlPKRC3zydQDmE3O9H//WfayxTFppsUDCL6FjYUHqj/wzK6CWHySglc2RkpdA==",
+      "license": "MIT",
+      "dependencies": {
+        "@solana/assertions": "5.5.1",
+        "@solana/codecs-core": "5.5.1",
+        "@solana/codecs-strings": "5.5.1",
+        "@solana/errors": "5.5.1",
+        "@solana/nominal-types": "5.5.1"
+      },
+      "engines": {
+        "node": ">=20.18.0"
+      },
+      "peerDependencies": {
+        "typescript": "^5.0.0"
+      },
+      "peerDependenciesMeta": {
+        "typescript": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@solana/assertions": {
+      "version": "5.5.1",
+      "resolved": "https://registry.npmjs.org/@solana/assertions/-/assertions-5.5.1.tgz",
+      "integrity": "sha512-YTCSWAlGwSlVPnWtWLm3ukz81wH4j2YaCveK+TjpvUU88hTy6fmUqxi0+hvAMAe4zKXpJyj3Az7BrLJRxbIm4Q==",
+      "license": "MIT",
+      "dependencies": {
+        "@solana/errors": "5.5.1"
+      },
+      "engines": {
+        "node": ">=20.18.0"
+      },
+      "peerDependencies": {
+        "typescript": "^5.0.0"
+      },
+      "peerDependenciesMeta": {
+        "typescript": {
+          "optional": true
+        }
+      }
+    },
     "node_modules/@solana/buffer-layout": {
       "version": "4.0.1",
       "resolved": "https://registry.npmjs.org/@solana/buffer-layout/-/buffer-layout-4.0.1.tgz",
@@ -10338,179 +10433,892 @@
         "node": ">=5.10"
       }
     },
-    "node_modules/@solana/buffer-layout-utils": {
-      "version": "0.2.0",
-      "resolved": "https://registry.npmjs.org/@solana/buffer-layout-utils/-/buffer-layout-utils-0.2.0.tgz",
-      "integrity": "sha512-szG4sxgJGktbuZYDg2FfNmkMi0DYQoVjN2h7ta1W1hPrwzarcFLBq9UpX1UjNXsNpT9dn+chgprtWGioUAr4/g==",
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@solana/buffer-layout": "^4.0.0",
-        "@solana/web3.js": "^1.32.0",
-        "bigint-buffer": "^1.1.5",
-        "bignumber.js": "^9.0.1"
-      },
-      "engines": {
-        "node": ">= 10"
-      }
-    },
     "node_modules/@solana/codecs": {
-      "version": "2.0.0-rc.1",
-      "resolved": "https://registry.npmjs.org/@solana/codecs/-/codecs-2.0.0-rc.1.tgz",
-      "integrity": "sha512-qxoR7VybNJixV51L0G1RD2boZTcxmwUWnKCaJJExQ5qNKwbpSyDdWfFJfM5JhGyKe9DnPVOZB+JHWXnpbZBqrQ==",
+      "version": "5.5.1",
+      "resolved": "https://registry.npmjs.org/@solana/codecs/-/codecs-5.5.1.tgz",
+      "integrity": "sha512-Vea29nJub/bXjfzEV7ZZQ/PWr1pYLZo3z0qW0LQL37uKKVzVFRQlwetd7INk3YtTD3xm9WUYr7bCvYUk3uKy2g==",
       "license": "MIT",
       "dependencies": {
-        "@solana/codecs-core": "2.0.0-rc.1",
-        "@solana/codecs-data-structures": "2.0.0-rc.1",
-        "@solana/codecs-numbers": "2.0.0-rc.1",
-        "@solana/codecs-strings": "2.0.0-rc.1",
-        "@solana/options": "2.0.0-rc.1"
+        "@solana/codecs-core": "5.5.1",
+        "@solana/codecs-data-structures": "5.5.1",
+        "@solana/codecs-numbers": "5.5.1",
+        "@solana/codecs-strings": "5.5.1",
+        "@solana/options": "5.5.1"
+      },
+      "engines": {
+        "node": ">=20.18.0"
       },
       "peerDependencies": {
-        "typescript": ">=5"
+        "typescript": "^5.0.0"
+      },
+      "peerDependenciesMeta": {
+        "typescript": {
+          "optional": true
+        }
       }
     },
     "node_modules/@solana/codecs-core": {
-      "version": "2.0.0-rc.1",
-      "resolved": "https://registry.npmjs.org/@solana/codecs-core/-/codecs-core-2.0.0-rc.1.tgz",
-      "integrity": "sha512-bauxqMfSs8EHD0JKESaNmNuNvkvHSuN3bbWAF5RjOfDu2PugxHrvRebmYauvSumZ3cTfQ4HJJX6PG5rN852qyQ==",
+      "version": "5.5.1",
+      "resolved": "https://registry.npmjs.org/@solana/codecs-core/-/codecs-core-5.5.1.tgz",
+      "integrity": "sha512-TgBt//bbKBct0t6/MpA8ElaOA3sa8eYVvR7LGslCZ84WiAwwjCY0lW/lOYsFHJQzwREMdUyuEyy5YWBKtdh8Rw==",
       "license": "MIT",
       "dependencies": {
-        "@solana/errors": "2.0.0-rc.1"
+        "@solana/errors": "5.5.1"
+      },
+      "engines": {
+        "node": ">=20.18.0"
       },
       "peerDependencies": {
-        "typescript": ">=5"
+        "typescript": "^5.0.0"
+      },
+      "peerDependenciesMeta": {
+        "typescript": {
+          "optional": true
+        }
       }
     },
     "node_modules/@solana/codecs-data-structures": {
-      "version": "2.0.0-rc.1",
-      "resolved": "https://registry.npmjs.org/@solana/codecs-data-structures/-/codecs-data-structures-2.0.0-rc.1.tgz",
-      "integrity": "sha512-rinCv0RrAVJ9rE/rmaibWJQxMwC5lSaORSZuwjopSUE6T0nb/MVg6Z1siNCXhh/HFTOg0l8bNvZHgBcN/yvXog==",
+      "version": "5.5.1",
+      "resolved": "https://registry.npmjs.org/@solana/codecs-data-structures/-/codecs-data-structures-5.5.1.tgz",
+      "integrity": "sha512-97bJWGyUY9WvBz3mX1UV3YPWGDTez6btCfD0ip3UVEXJbItVuUiOkzcO5iFDUtQT5riKT6xC+Mzl+0nO76gd0w==",
       "license": "MIT",
       "dependencies": {
-        "@solana/codecs-core": "2.0.0-rc.1",
-        "@solana/codecs-numbers": "2.0.0-rc.1",
-        "@solana/errors": "2.0.0-rc.1"
+        "@solana/codecs-core": "5.5.1",
+        "@solana/codecs-numbers": "5.5.1",
+        "@solana/errors": "5.5.1"
+      },
+      "engines": {
+        "node": ">=20.18.0"
       },
       "peerDependencies": {
-        "typescript": ">=5"
+        "typescript": "^5.0.0"
+      },
+      "peerDependenciesMeta": {
+        "typescript": {
+          "optional": true
+        }
       }
     },
     "node_modules/@solana/codecs-numbers": {
-      "version": "2.0.0-rc.1",
-      "resolved": "https://registry.npmjs.org/@solana/codecs-numbers/-/codecs-numbers-2.0.0-rc.1.tgz",
-      "integrity": "sha512-J5i5mOkvukXn8E3Z7sGIPxsThRCgSdgTWJDQeZvucQ9PT6Y3HiVXJ0pcWiOWAoQ3RX8e/f4I3IC+wE6pZiJzDQ==",
+      "version": "5.5.1",
+      "resolved": "https://registry.npmjs.org/@solana/codecs-numbers/-/codecs-numbers-5.5.1.tgz",
+      "integrity": "sha512-rllMIZAHqmtvC0HO/dc/21wDuWaD0B8Ryv8o+YtsICQBuiL/0U4AGwH7Pi5GNFySYk0/crSuwfIqQFtmxNSPFw==",
       "license": "MIT",
       "dependencies": {
-        "@solana/codecs-core": "2.0.0-rc.1",
-        "@solana/errors": "2.0.0-rc.1"
+        "@solana/codecs-core": "5.5.1",
+        "@solana/errors": "5.5.1"
+      },
+      "engines": {
+        "node": ">=20.18.0"
       },
       "peerDependencies": {
-        "typescript": ">=5"
+        "typescript": "^5.0.0"
+      },
+      "peerDependenciesMeta": {
+        "typescript": {
+          "optional": true
+        }
       }
     },
     "node_modules/@solana/codecs-strings": {
-      "version": "2.0.0-rc.1",
-      "resolved": "https://registry.npmjs.org/@solana/codecs-strings/-/codecs-strings-2.0.0-rc.1.tgz",
-      "integrity": "sha512-9/wPhw8TbGRTt6mHC4Zz1RqOnuPTqq1Nb4EyuvpZ39GW6O2t2Q7Q0XxiB3+BdoEjwA2XgPw6e2iRfvYgqty44g==",
+      "version": "5.5.1",
+      "resolved": "https://registry.npmjs.org/@solana/codecs-strings/-/codecs-strings-5.5.1.tgz",
+      "integrity": "sha512-7klX4AhfHYA+uKKC/nxRGP2MntbYQCR3N6+v7bk1W/rSxYuhNmt+FN8aoThSZtWIKwN6BEyR1167ka8Co1+E7A==",
       "license": "MIT",
       "dependencies": {
-        "@solana/codecs-core": "2.0.0-rc.1",
-        "@solana/codecs-numbers": "2.0.0-rc.1",
-        "@solana/errors": "2.0.0-rc.1"
+        "@solana/codecs-core": "5.5.1",
+        "@solana/codecs-numbers": "5.5.1",
+        "@solana/errors": "5.5.1"
+      },
+      "engines": {
+        "node": ">=20.18.0"
       },
       "peerDependencies": {
         "fastestsmallesttextencoderdecoder": "^1.0.22",
-        "typescript": ">=5"
+        "typescript": "^5.0.0"
+      },
+      "peerDependenciesMeta": {
+        "fastestsmallesttextencoderdecoder": {
+          "optional": true
+        },
+        "typescript": {
+          "optional": true
+        }
       }
     },
     "node_modules/@solana/errors": {
-      "version": "2.0.0-rc.1",
-      "resolved": "https://registry.npmjs.org/@solana/errors/-/errors-2.0.0-rc.1.tgz",
-      "integrity": "sha512-ejNvQ2oJ7+bcFAYWj225lyRkHnixuAeb7RQCixm+5mH4n1IA4Qya/9Bmfy5RAAHQzxK43clu3kZmL5eF9VGtYQ==",
+      "version": "5.5.1",
+      "resolved": "https://registry.npmjs.org/@solana/errors/-/errors-5.5.1.tgz",
+      "integrity": "sha512-vFO3p+S7HoyyrcAectnXbdsMfwUzY2zYFUc2DEe5BwpiE9J1IAxPBGjOWO6hL1bbYdBrlmjNx8DXCslqS+Kcmg==",
       "license": "MIT",
       "dependencies": {
-        "chalk": "^5.3.0",
-        "commander": "^12.1.0"
+        "chalk": "5.6.2",
+        "commander": "14.0.2"
       },
       "bin": {
         "errors": "bin/cli.mjs"
       },
+      "engines": {
+        "node": ">=20.18.0"
+      },
       "peerDependencies": {
-        "typescript": ">=5"
+        "typescript": "^5.0.0"
+      },
+      "peerDependenciesMeta": {
+        "typescript": {
+          "optional": true
+        }
       }
     },
     "node_modules/@solana/errors/node_modules/commander": {
-      "version": "12.1.0",
-      "resolved": "https://registry.npmjs.org/commander/-/commander-12.1.0.tgz",
-      "integrity": "sha512-Vw8qHK3bZM9y/P10u3Vib8o/DdkvA2OtPtZvD871QKjy74Wj1WSKFILMPRPSdUSx5RFK1arlJzEtA4PkFgnbuA==",
+      "version": "14.0.2",
+      "resolved": "https://registry.npmjs.org/commander/-/commander-14.0.2.tgz",
+      "integrity": "sha512-TywoWNNRbhoD0BXs1P3ZEScW8W5iKrnbithIl0YH+uCmBd0QpPOA8yc82DS3BIE5Ma6FnBVUsJ7wVUDz4dvOWQ==",
       "license": "MIT",
       "engines": {
-        "node": ">=18"
+        "node": ">=20"
+      }
+    },
+    "node_modules/@solana/fast-stable-stringify": {
+      "version": "5.5.1",
+      "resolved": "https://registry.npmjs.org/@solana/fast-stable-stringify/-/fast-stable-stringify-5.5.1.tgz",
+      "integrity": "sha512-Ni7s2FN33zTzhTFgRjEbOVFO+UAmK8qi3Iu0/GRFYK4jN696OjKHnboSQH/EacQ+yGqS54bfxf409wU5dsLLCw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=20.18.0"
+      },
+      "peerDependencies": {
+        "typescript": "^5.0.0"
+      },
+      "peerDependenciesMeta": {
+        "typescript": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@solana/functional": {
+      "version": "5.5.1",
+      "resolved": "https://registry.npmjs.org/@solana/functional/-/functional-5.5.1.tgz",
+      "integrity": "sha512-tTHoJcEQq3gQx5qsdsDJ0LEJeFzwNpXD80xApW9o/PPoCNimI3SALkZl+zNW8VnxRrV3l3yYvfHWBKe/X3WG3w==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=20.18.0"
+      },
+      "peerDependencies": {
+        "typescript": "^5.0.0"
+      },
+      "peerDependenciesMeta": {
+        "typescript": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@solana/instruction-plans": {
+      "version": "5.5.1",
+      "resolved": "https://registry.npmjs.org/@solana/instruction-plans/-/instruction-plans-5.5.1.tgz",
+      "integrity": "sha512-7z3CB7YMcFKuVvgcnNY8bY6IsZ8LG61Iytbz7HpNVGX2u1RthOs1tRW8luTzSG1MPL0Ox7afyAVMYeFqSPHnaQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@solana/errors": "5.5.1",
+        "@solana/instructions": "5.5.1",
+        "@solana/keys": "5.5.1",
+        "@solana/promises": "5.5.1",
+        "@solana/transaction-messages": "5.5.1",
+        "@solana/transactions": "5.5.1"
+      },
+      "engines": {
+        "node": ">=20.18.0"
+      },
+      "peerDependencies": {
+        "typescript": "^5.0.0"
+      },
+      "peerDependenciesMeta": {
+        "typescript": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@solana/instructions": {
+      "version": "5.5.1",
+      "resolved": "https://registry.npmjs.org/@solana/instructions/-/instructions-5.5.1.tgz",
+      "integrity": "sha512-h0G1CG6S+gUUSt0eo6rOtsaXRBwCq1+Js2a+Ps9Bzk9q7YHNFA75/X0NWugWLgC92waRp66hrjMTiYYnLBoWOQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@solana/codecs-core": "5.5.1",
+        "@solana/errors": "5.5.1"
+      },
+      "engines": {
+        "node": ">=20.18.0"
+      },
+      "peerDependencies": {
+        "typescript": "^5.0.0"
+      },
+      "peerDependenciesMeta": {
+        "typescript": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@solana/keys": {
+      "version": "5.5.1",
+      "resolved": "https://registry.npmjs.org/@solana/keys/-/keys-5.5.1.tgz",
+      "integrity": "sha512-KRD61cL7CRL+b4r/eB9dEoVxIf/2EJ1Pm1DmRYhtSUAJD2dJ5Xw8QFuehobOGm9URqQ7gaQl+Fkc1qvDlsWqKg==",
+      "license": "MIT",
+      "dependencies": {
+        "@solana/assertions": "5.5.1",
+        "@solana/codecs-core": "5.5.1",
+        "@solana/codecs-strings": "5.5.1",
+        "@solana/errors": "5.5.1",
+        "@solana/nominal-types": "5.5.1"
+      },
+      "engines": {
+        "node": ">=20.18.0"
+      },
+      "peerDependencies": {
+        "typescript": "^5.0.0"
+      },
+      "peerDependenciesMeta": {
+        "typescript": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@solana/kit": {
+      "version": "5.5.1",
+      "resolved": "https://registry.npmjs.org/@solana/kit/-/kit-5.5.1.tgz",
+      "integrity": "sha512-irKUGiV2yRoyf+4eGQ/ZeCRxa43yjFEL1DUI5B0DkcfZw3cr0VJtVJnrG8OtVF01vT0OUfYOcUn6zJW5TROHvQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@solana/accounts": "5.5.1",
+        "@solana/addresses": "5.5.1",
+        "@solana/codecs": "5.5.1",
+        "@solana/errors": "5.5.1",
+        "@solana/functional": "5.5.1",
+        "@solana/instruction-plans": "5.5.1",
+        "@solana/instructions": "5.5.1",
+        "@solana/keys": "5.5.1",
+        "@solana/offchain-messages": "5.5.1",
+        "@solana/plugin-core": "5.5.1",
+        "@solana/programs": "5.5.1",
+        "@solana/rpc": "5.5.1",
+        "@solana/rpc-api": "5.5.1",
+        "@solana/rpc-parsed-types": "5.5.1",
+        "@solana/rpc-spec-types": "5.5.1",
+        "@solana/rpc-subscriptions": "5.5.1",
+        "@solana/rpc-types": "5.5.1",
+        "@solana/signers": "5.5.1",
+        "@solana/sysvars": "5.5.1",
+        "@solana/transaction-confirmation": "5.5.1",
+        "@solana/transaction-messages": "5.5.1",
+        "@solana/transactions": "5.5.1"
+      },
+      "engines": {
+        "node": ">=20.18.0"
+      },
+      "peerDependencies": {
+        "typescript": "^5.0.0"
+      },
+      "peerDependenciesMeta": {
+        "typescript": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@solana/nominal-types": {
+      "version": "5.5.1",
+      "resolved": "https://registry.npmjs.org/@solana/nominal-types/-/nominal-types-5.5.1.tgz",
+      "integrity": "sha512-I1ImR+kfrLFxN5z22UDiTWLdRZeKtU0J/pkWkO8qm/8WxveiwdIv4hooi8pb6JnlR4mSrWhq0pCIOxDYrL9GIQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=20.18.0"
+      },
+      "peerDependencies": {
+        "typescript": "^5.0.0"
+      },
+      "peerDependenciesMeta": {
+        "typescript": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@solana/offchain-messages": {
+      "version": "5.5.1",
+      "resolved": "https://registry.npmjs.org/@solana/offchain-messages/-/offchain-messages-5.5.1.tgz",
+      "integrity": "sha512-g+xHH95prTU+KujtbOzj8wn+C7ZNoiLhf3hj6nYq3MTyxOXtBEysguc97jJveUZG0K97aIKG6xVUlMutg5yxhw==",
+      "license": "MIT",
+      "dependencies": {
+        "@solana/addresses": "5.5.1",
+        "@solana/codecs-core": "5.5.1",
+        "@solana/codecs-data-structures": "5.5.1",
+        "@solana/codecs-numbers": "5.5.1",
+        "@solana/codecs-strings": "5.5.1",
+        "@solana/errors": "5.5.1",
+        "@solana/keys": "5.5.1",
+        "@solana/nominal-types": "5.5.1"
+      },
+      "engines": {
+        "node": ">=20.18.0"
+      },
+      "peerDependencies": {
+        "typescript": "^5.0.0"
+      },
+      "peerDependenciesMeta": {
+        "typescript": {
+          "optional": true
+        }
       }
     },
     "node_modules/@solana/options": {
-      "version": "2.0.0-rc.1",
-      "resolved": "https://registry.npmjs.org/@solana/options/-/options-2.0.0-rc.1.tgz",
-      "integrity": "sha512-mLUcR9mZ3qfHlmMnREdIFPf9dpMc/Bl66tLSOOWxw4ml5xMT2ohFn7WGqoKcu/UHkT9CrC6+amEdqCNvUqI7AA==",
+      "version": "5.5.1",
+      "resolved": "https://registry.npmjs.org/@solana/options/-/options-5.5.1.tgz",
+      "integrity": "sha512-eo971c9iLNLmk+yOFyo7yKIJzJ/zou6uKpy6mBuyb/thKtS/haiKIc3VLhyTXty3OH2PW8yOlORJnv4DexJB8A==",
       "license": "MIT",
       "dependencies": {
-        "@solana/codecs-core": "2.0.0-rc.1",
-        "@solana/codecs-data-structures": "2.0.0-rc.1",
-        "@solana/codecs-numbers": "2.0.0-rc.1",
-        "@solana/codecs-strings": "2.0.0-rc.1",
-        "@solana/errors": "2.0.0-rc.1"
-      },
-      "peerDependencies": {
-        "typescript": ">=5"
-      }
-    },
-    "node_modules/@solana/spl-token": {
-      "version": "0.4.14",
-      "resolved": "https://registry.npmjs.org/@solana/spl-token/-/spl-token-0.4.14.tgz",
-      "integrity": "sha512-u09zr96UBpX4U685MnvQsNzlvw9TiY005hk1vJmJr7gMJldoPG1eYU5/wNEyOA5lkMLiR/gOi9SFD4MefOYEsA==",
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@solana/buffer-layout": "^4.0.0",
-        "@solana/buffer-layout-utils": "^0.2.0",
-        "@solana/spl-token-group": "^0.0.7",
-        "@solana/spl-token-metadata": "^0.1.6",
-        "buffer": "^6.0.3"
+        "@solana/codecs-core": "5.5.1",
+        "@solana/codecs-data-structures": "5.5.1",
+        "@solana/codecs-numbers": "5.5.1",
+        "@solana/codecs-strings": "5.5.1",
+        "@solana/errors": "5.5.1"
       },
       "engines": {
-        "node": ">=16"
+        "node": ">=20.18.0"
       },
       "peerDependencies": {
-        "@solana/web3.js": "^1.95.5"
+        "typescript": "^5.0.0"
+      },
+      "peerDependenciesMeta": {
+        "typescript": {
+          "optional": true
+        }
       }
     },
-    "node_modules/@solana/spl-token-group": {
-      "version": "0.0.7",
-      "resolved": "https://registry.npmjs.org/@solana/spl-token-group/-/spl-token-group-0.0.7.tgz",
-      "integrity": "sha512-V1N/iX7Cr7H0uazWUT2uk27TMqlqedpXHRqqAbVO2gvmJyT0E0ummMEAVQeXZ05ZhQ/xF39DLSdBp90XebWEug==",
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@solana/codecs": "2.0.0-rc.1"
-      },
+    "node_modules/@solana/plugin-core": {
+      "version": "5.5.1",
+      "resolved": "https://registry.npmjs.org/@solana/plugin-core/-/plugin-core-5.5.1.tgz",
+      "integrity": "sha512-VUZl30lDQFJeiSyNfzU1EjYt2QZvoBFKEwjn1lilUJw7KgqD5z7mbV7diJhT+dLFs36i0OsjXvq5kSygn8YJ3A==",
+      "license": "MIT",
       "engines": {
-        "node": ">=16"
+        "node": ">=20.18.0"
       },
       "peerDependencies": {
-        "@solana/web3.js": "^1.95.3"
+        "typescript": "^5.0.0"
+      },
+      "peerDependenciesMeta": {
+        "typescript": {
+          "optional": true
+        }
       }
     },
-    "node_modules/@solana/spl-token-metadata": {
-      "version": "0.1.6",
-      "resolved": "https://registry.npmjs.org/@solana/spl-token-metadata/-/spl-token-metadata-0.1.6.tgz",
-      "integrity": "sha512-7sMt1rsm/zQOQcUWllQX9mD2O6KhSAtY1hFR2hfFwgqfFWzSY9E9GDvFVNYUI1F0iQKcm6HmePU9QbKRXTEBiA==",
-      "license": "Apache-2.0",
+    "node_modules/@solana/programs": {
+      "version": "5.5.1",
+      "resolved": "https://registry.npmjs.org/@solana/programs/-/programs-5.5.1.tgz",
+      "integrity": "sha512-7U9kn0Jsx1NuBLn5HRTFYh78MV4XN145Yc3WP/q5BlqAVNlMoU9coG5IUTJIG847TUqC1lRto3Dnpwm6T4YRpA==",
+      "license": "MIT",
       "dependencies": {
-        "@solana/codecs": "2.0.0-rc.1"
+        "@solana/addresses": "5.5.1",
+        "@solana/errors": "5.5.1"
       },
       "engines": {
-        "node": ">=16"
+        "node": ">=20.18.0"
       },
       "peerDependencies": {
-        "@solana/web3.js": "^1.95.3"
+        "typescript": "^5.0.0"
+      },
+      "peerDependenciesMeta": {
+        "typescript": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@solana/promises": {
+      "version": "5.5.1",
+      "resolved": "https://registry.npmjs.org/@solana/promises/-/promises-5.5.1.tgz",
+      "integrity": "sha512-T9lfuUYkGykJmppEcssNiCf6yiYQxJkhiLPP+pyAc2z84/7r3UVIb2tNJk4A9sucS66pzJnVHZKcZVGUUp6wzA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=20.18.0"
+      },
+      "peerDependencies": {
+        "typescript": "^5.0.0"
+      },
+      "peerDependenciesMeta": {
+        "typescript": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@solana/rpc": {
+      "version": "5.5.1",
+      "resolved": "https://registry.npmjs.org/@solana/rpc/-/rpc-5.5.1.tgz",
+      "integrity": "sha512-ku8zTUMrkCWci66PRIBC+1mXepEnZH/q1f3ck0kJZ95a06bOTl5KU7HeXWtskkyefzARJ5zvCs54AD5nxjQJ+A==",
+      "license": "MIT",
+      "dependencies": {
+        "@solana/errors": "5.5.1",
+        "@solana/fast-stable-stringify": "5.5.1",
+        "@solana/functional": "5.5.1",
+        "@solana/rpc-api": "5.5.1",
+        "@solana/rpc-spec": "5.5.1",
+        "@solana/rpc-spec-types": "5.5.1",
+        "@solana/rpc-transformers": "5.5.1",
+        "@solana/rpc-transport-http": "5.5.1",
+        "@solana/rpc-types": "5.5.1"
+      },
+      "engines": {
+        "node": ">=20.18.0"
+      },
+      "peerDependencies": {
+        "typescript": "^5.0.0"
+      },
+      "peerDependenciesMeta": {
+        "typescript": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@solana/rpc-api": {
+      "version": "5.5.1",
+      "resolved": "https://registry.npmjs.org/@solana/rpc-api/-/rpc-api-5.5.1.tgz",
+      "integrity": "sha512-XWOQQPhKl06Vj0xi3RYHAc6oEQd8B82okYJ04K7N0Vvy3J4PN2cxeK7klwkjgavdcN9EVkYCChm2ADAtnztKnA==",
+      "license": "MIT",
+      "dependencies": {
+        "@solana/addresses": "5.5.1",
+        "@solana/codecs-core": "5.5.1",
+        "@solana/codecs-strings": "5.5.1",
+        "@solana/errors": "5.5.1",
+        "@solana/keys": "5.5.1",
+        "@solana/rpc-parsed-types": "5.5.1",
+        "@solana/rpc-spec": "5.5.1",
+        "@solana/rpc-transformers": "5.5.1",
+        "@solana/rpc-types": "5.5.1",
+        "@solana/transaction-messages": "5.5.1",
+        "@solana/transactions": "5.5.1"
+      },
+      "engines": {
+        "node": ">=20.18.0"
+      },
+      "peerDependencies": {
+        "typescript": "^5.0.0"
+      },
+      "peerDependenciesMeta": {
+        "typescript": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@solana/rpc-parsed-types": {
+      "version": "5.5.1",
+      "resolved": "https://registry.npmjs.org/@solana/rpc-parsed-types/-/rpc-parsed-types-5.5.1.tgz",
+      "integrity": "sha512-HEi3G2nZqGEsa3vX6U0FrXLaqnUCg4SKIUrOe8CezD+cSFbRTOn3rCLrUmJrhVyXlHoQVaRO9mmeovk31jWxJg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=20.18.0"
+      },
+      "peerDependencies": {
+        "typescript": "^5.0.0"
+      },
+      "peerDependenciesMeta": {
+        "typescript": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@solana/rpc-spec": {
+      "version": "5.5.1",
+      "resolved": "https://registry.npmjs.org/@solana/rpc-spec/-/rpc-spec-5.5.1.tgz",
+      "integrity": "sha512-m3LX2bChm3E3by4mQrH4YwCAFY57QBzuUSWqlUw7ChuZ+oLLOq7b2czi4i6L4Vna67j3eCmB3e+4tqy1j5wy7Q==",
+      "license": "MIT",
+      "dependencies": {
+        "@solana/errors": "5.5.1",
+        "@solana/rpc-spec-types": "5.5.1"
+      },
+      "engines": {
+        "node": ">=20.18.0"
+      },
+      "peerDependencies": {
+        "typescript": "^5.0.0"
+      },
+      "peerDependenciesMeta": {
+        "typescript": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@solana/rpc-spec-types": {
+      "version": "5.5.1",
+      "resolved": "https://registry.npmjs.org/@solana/rpc-spec-types/-/rpc-spec-types-5.5.1.tgz",
+      "integrity": "sha512-6OFKtRpIEJQs8Jb2C4OO8KyP2h2Hy1MFhatMAoXA+0Ik8S3H+CicIuMZvGZ91mIu/tXicuOOsNNLu3HAkrakrw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=20.18.0"
+      },
+      "peerDependencies": {
+        "typescript": "^5.0.0"
+      },
+      "peerDependenciesMeta": {
+        "typescript": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@solana/rpc-subscriptions": {
+      "version": "5.5.1",
+      "resolved": "https://registry.npmjs.org/@solana/rpc-subscriptions/-/rpc-subscriptions-5.5.1.tgz",
+      "integrity": "sha512-CTMy5bt/6mDh4tc6vUJms9EcuZj3xvK0/xq8IQ90rhkpYvate91RjBP+egvjgSayUg9yucU9vNuUpEjz4spM7w==",
+      "license": "MIT",
+      "dependencies": {
+        "@solana/errors": "5.5.1",
+        "@solana/fast-stable-stringify": "5.5.1",
+        "@solana/functional": "5.5.1",
+        "@solana/promises": "5.5.1",
+        "@solana/rpc-spec-types": "5.5.1",
+        "@solana/rpc-subscriptions-api": "5.5.1",
+        "@solana/rpc-subscriptions-channel-websocket": "5.5.1",
+        "@solana/rpc-subscriptions-spec": "5.5.1",
+        "@solana/rpc-transformers": "5.5.1",
+        "@solana/rpc-types": "5.5.1",
+        "@solana/subscribable": "5.5.1"
+      },
+      "engines": {
+        "node": ">=20.18.0"
+      },
+      "peerDependencies": {
+        "typescript": "^5.0.0"
+      },
+      "peerDependenciesMeta": {
+        "typescript": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@solana/rpc-subscriptions-api": {
+      "version": "5.5.1",
+      "resolved": "https://registry.npmjs.org/@solana/rpc-subscriptions-api/-/rpc-subscriptions-api-5.5.1.tgz",
+      "integrity": "sha512-5Oi7k+GdeS8xR2ly1iuSFkAv6CZqwG0Z6b1QZKbEgxadE1XGSDrhM2cn59l+bqCozUWCqh4c/A2znU/qQjROlw==",
+      "license": "MIT",
+      "dependencies": {
+        "@solana/addresses": "5.5.1",
+        "@solana/keys": "5.5.1",
+        "@solana/rpc-subscriptions-spec": "5.5.1",
+        "@solana/rpc-transformers": "5.5.1",
+        "@solana/rpc-types": "5.5.1",
+        "@solana/transaction-messages": "5.5.1",
+        "@solana/transactions": "5.5.1"
+      },
+      "engines": {
+        "node": ">=20.18.0"
+      },
+      "peerDependencies": {
+        "typescript": "^5.0.0"
+      },
+      "peerDependenciesMeta": {
+        "typescript": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@solana/rpc-subscriptions-channel-websocket": {
+      "version": "5.5.1",
+      "resolved": "https://registry.npmjs.org/@solana/rpc-subscriptions-channel-websocket/-/rpc-subscriptions-channel-websocket-5.5.1.tgz",
+      "integrity": "sha512-7tGfBBrYY8TrngOyxSHoCU5shy86iA9SRMRrPSyBhEaZRAk6dnbdpmUTez7gtdVo0BCvh9nzQtUycKWSS7PnFQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@solana/errors": "5.5.1",
+        "@solana/functional": "5.5.1",
+        "@solana/rpc-subscriptions-spec": "5.5.1",
+        "@solana/subscribable": "5.5.1",
+        "ws": "^8.19.0"
+      },
+      "engines": {
+        "node": ">=20.18.0"
+      },
+      "peerDependencies": {
+        "typescript": "^5.0.0"
+      },
+      "peerDependenciesMeta": {
+        "typescript": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@solana/rpc-subscriptions-channel-websocket/node_modules/ws": {
+      "version": "8.21.0",
+      "resolved": "https://registry.npmjs.org/ws/-/ws-8.21.0.tgz",
+      "integrity": "sha512-Vsp28b7DRcimFQvrqu2Wek3z1iYxDCWqHYB8Qsnk/S4RfaCQzPGPyBNuVjJV3cd6UiKtUtp6sNM77gWvzcCH+g==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=10.0.0"
+      },
+      "peerDependencies": {
+        "bufferutil": "^4.0.1",
+        "utf-8-validate": ">=5.0.2"
+      },
+      "peerDependenciesMeta": {
+        "bufferutil": {
+          "optional": true
+        },
+        "utf-8-validate": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@solana/rpc-subscriptions-spec": {
+      "version": "5.5.1",
+      "resolved": "https://registry.npmjs.org/@solana/rpc-subscriptions-spec/-/rpc-subscriptions-spec-5.5.1.tgz",
+      "integrity": "sha512-iq+rGq5fMKP3/mKHPNB6MC8IbVW41KGZg83Us/+LE3AWOTWV1WT20KT2iH1F1ik9roi42COv/TpoZZvhKj45XQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@solana/errors": "5.5.1",
+        "@solana/promises": "5.5.1",
+        "@solana/rpc-spec-types": "5.5.1",
+        "@solana/subscribable": "5.5.1"
+      },
+      "engines": {
+        "node": ">=20.18.0"
+      },
+      "peerDependencies": {
+        "typescript": "^5.0.0"
+      },
+      "peerDependenciesMeta": {
+        "typescript": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@solana/rpc-transformers": {
+      "version": "5.5.1",
+      "resolved": "https://registry.npmjs.org/@solana/rpc-transformers/-/rpc-transformers-5.5.1.tgz",
+      "integrity": "sha512-OsWqLCQdcrRJKvHiMmwFhp9noNZ4FARuMkHT5us3ustDLXaxOjF0gfqZLnMkulSLcKt7TGXqMhBV+HCo7z5M8Q==",
+      "license": "MIT",
+      "dependencies": {
+        "@solana/errors": "5.5.1",
+        "@solana/functional": "5.5.1",
+        "@solana/nominal-types": "5.5.1",
+        "@solana/rpc-spec-types": "5.5.1",
+        "@solana/rpc-types": "5.5.1"
+      },
+      "engines": {
+        "node": ">=20.18.0"
+      },
+      "peerDependencies": {
+        "typescript": "^5.0.0"
+      },
+      "peerDependenciesMeta": {
+        "typescript": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@solana/rpc-transport-http": {
+      "version": "5.5.1",
+      "resolved": "https://registry.npmjs.org/@solana/rpc-transport-http/-/rpc-transport-http-5.5.1.tgz",
+      "integrity": "sha512-yv8GoVSHqEV0kUJEIhkdOVkR2SvJ6yoWC51cJn2rSV7plr6huLGe0JgujCmB7uZhhaLbcbP3zxXxu9sOjsi7Fg==",
+      "license": "MIT",
+      "dependencies": {
+        "@solana/errors": "5.5.1",
+        "@solana/rpc-spec": "5.5.1",
+        "@solana/rpc-spec-types": "5.5.1",
+        "undici-types": "^7.19.2"
+      },
+      "engines": {
+        "node": ">=20.18.0"
+      },
+      "peerDependencies": {
+        "typescript": "^5.0.0"
+      },
+      "peerDependenciesMeta": {
+        "typescript": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@solana/rpc-transport-http/node_modules/undici-types": {
+      "version": "7.27.2",
+      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-7.27.2.tgz",
+      "integrity": "sha512-cH9f42mHuljpNuoS47sWDDWXVxWnJgYCzHVUlr3tn7+HVx0L6QSO+VG5qgzT4kXkR2K8ZsReaT5bupam6RNAEQ==",
+      "license": "MIT"
+    },
+    "node_modules/@solana/rpc-types": {
+      "version": "5.5.1",
+      "resolved": "https://registry.npmjs.org/@solana/rpc-types/-/rpc-types-5.5.1.tgz",
+      "integrity": "sha512-bibTFQ7PbHJJjGJPmfYC2I+/5CRFS4O2p9WwbFraX1Keeel+nRrt/NBXIy8veP5AEn2sVJIyJPpWBRpCx1oATA==",
+      "license": "MIT",
+      "dependencies": {
+        "@solana/addresses": "5.5.1",
+        "@solana/codecs-core": "5.5.1",
+        "@solana/codecs-numbers": "5.5.1",
+        "@solana/codecs-strings": "5.5.1",
+        "@solana/errors": "5.5.1",
+        "@solana/nominal-types": "5.5.1"
+      },
+      "engines": {
+        "node": ">=20.18.0"
+      },
+      "peerDependencies": {
+        "typescript": "^5.0.0"
+      },
+      "peerDependenciesMeta": {
+        "typescript": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@solana/signers": {
+      "version": "5.5.1",
+      "resolved": "https://registry.npmjs.org/@solana/signers/-/signers-5.5.1.tgz",
+      "integrity": "sha512-FY0IVaBT2kCAze55vEieR6hag4coqcuJ31Aw3hqRH7mv6sV8oqwuJmUrx+uFwOp1gwd5OEAzlv6N4hOOple4sQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@solana/addresses": "5.5.1",
+        "@solana/codecs-core": "5.5.1",
+        "@solana/errors": "5.5.1",
+        "@solana/instructions": "5.5.1",
+        "@solana/keys": "5.5.1",
+        "@solana/nominal-types": "5.5.1",
+        "@solana/offchain-messages": "5.5.1",
+        "@solana/transaction-messages": "5.5.1",
+        "@solana/transactions": "5.5.1"
+      },
+      "engines": {
+        "node": ">=20.18.0"
+      },
+      "peerDependencies": {
+        "typescript": "^5.0.0"
+      },
+      "peerDependenciesMeta": {
+        "typescript": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@solana/subscribable": {
+      "version": "5.5.1",
+      "resolved": "https://registry.npmjs.org/@solana/subscribable/-/subscribable-5.5.1.tgz",
+      "integrity": "sha512-9K0PsynFq0CsmK1CDi5Y2vUIJpCqkgSS5yfDN0eKPgHqEptLEaia09Kaxc90cSZDZU5mKY/zv1NBmB6Aro9zQQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@solana/errors": "5.5.1"
+      },
+      "engines": {
+        "node": ">=20.18.0"
+      },
+      "peerDependencies": {
+        "typescript": "^5.0.0"
+      },
+      "peerDependenciesMeta": {
+        "typescript": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@solana/sysvars": {
+      "version": "5.5.1",
+      "resolved": "https://registry.npmjs.org/@solana/sysvars/-/sysvars-5.5.1.tgz",
+      "integrity": "sha512-k3Quq87Mm+geGUu1GWv6knPk0ALsfY6EKSJGw9xUJDHzY/RkYSBnh0RiOrUhtFm2TDNjOailg8/m0VHmi3reFA==",
+      "license": "MIT",
+      "dependencies": {
+        "@solana/accounts": "5.5.1",
+        "@solana/codecs": "5.5.1",
+        "@solana/errors": "5.5.1",
+        "@solana/rpc-types": "5.5.1"
+      },
+      "engines": {
+        "node": ">=20.18.0"
+      },
+      "peerDependencies": {
+        "typescript": "^5.0.0"
+      },
+      "peerDependenciesMeta": {
+        "typescript": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@solana/transaction-confirmation": {
+      "version": "5.5.1",
+      "resolved": "https://registry.npmjs.org/@solana/transaction-confirmation/-/transaction-confirmation-5.5.1.tgz",
+      "integrity": "sha512-j4mKlYPHEyu+OD7MBt3jRoX4ScFgkhZC6H65on4Fux6LMScgivPJlwnKoZMnsgxFgWds0pl+BYzSiALDsXlYtw==",
+      "license": "MIT",
+      "dependencies": {
+        "@solana/addresses": "5.5.1",
+        "@solana/codecs-strings": "5.5.1",
+        "@solana/errors": "5.5.1",
+        "@solana/keys": "5.5.1",
+        "@solana/promises": "5.5.1",
+        "@solana/rpc": "5.5.1",
+        "@solana/rpc-subscriptions": "5.5.1",
+        "@solana/rpc-types": "5.5.1",
+        "@solana/transaction-messages": "5.5.1",
+        "@solana/transactions": "5.5.1"
+      },
+      "engines": {
+        "node": ">=20.18.0"
+      },
+      "peerDependencies": {
+        "typescript": "^5.0.0"
+      },
+      "peerDependenciesMeta": {
+        "typescript": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@solana/transaction-messages": {
+      "version": "5.5.1",
+      "resolved": "https://registry.npmjs.org/@solana/transaction-messages/-/transaction-messages-5.5.1.tgz",
+      "integrity": "sha512-aXyhMCEaAp3M/4fP0akwBBQkFPr4pfwoC5CLDq999r/FUwDax2RE/h4Ic7h2Xk+JdcUwsb+rLq85Y52hq84XvQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@solana/addresses": "5.5.1",
+        "@solana/codecs-core": "5.5.1",
+        "@solana/codecs-data-structures": "5.5.1",
+        "@solana/codecs-numbers": "5.5.1",
+        "@solana/errors": "5.5.1",
+        "@solana/functional": "5.5.1",
+        "@solana/instructions": "5.5.1",
+        "@solana/nominal-types": "5.5.1",
+        "@solana/rpc-types": "5.5.1"
+      },
+      "engines": {
+        "node": ">=20.18.0"
+      },
+      "peerDependencies": {
+        "typescript": "^5.0.0"
+      },
+      "peerDependenciesMeta": {
+        "typescript": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@solana/transactions": {
+      "version": "5.5.1",
+      "resolved": "https://registry.npmjs.org/@solana/transactions/-/transactions-5.5.1.tgz",
+      "integrity": "sha512-8hHtDxtqalZ157pnx6p8k10D7J/KY/biLzfgh9R09VNLLY3Fqi7kJvJCr7M2ik3oRll56pxhraAGCC9yIT6eOA==",
+      "license": "MIT",
+      "dependencies": {
+        "@solana/addresses": "5.5.1",
+        "@solana/codecs-core": "5.5.1",
+        "@solana/codecs-data-structures": "5.5.1",
+        "@solana/codecs-numbers": "5.5.1",
+        "@solana/codecs-strings": "5.5.1",
+        "@solana/errors": "5.5.1",
+        "@solana/functional": "5.5.1",
+        "@solana/instructions": "5.5.1",
+        "@solana/keys": "5.5.1",
+        "@solana/nominal-types": "5.5.1",
+        "@solana/rpc-types": "5.5.1",
+        "@solana/transaction-messages": "5.5.1"
+      },
+      "engines": {
+        "node": ">=20.18.0"
+      },
+      "peerDependencies": {
+        "typescript": "^5.0.0"
+      },
+      "peerDependenciesMeta": {
+        "typescript": {
+          "optional": true
+        }
       }
     },
     "node_modules/@solana/web3.js": {
@@ -14731,14 +15539,14 @@
       }
     },
     "node_modules/axios": {
-      "version": "1.12.2",
-      "resolved": "https://registry.npmjs.org/axios/-/axios-1.12.2.tgz",
-      "integrity": "sha512-vMJzPewAlRyOgxV2dU0Cuz2O8zzzx9VYtbJOaBgXFeLc4IV/Eg50n4LowmehOOR61S8ZMpc2K5Sa7g6A4jfkUw==",
+      "version": "1.16.0",
+      "resolved": "https://registry.npmjs.org/axios/-/axios-1.16.0.tgz",
+      "integrity": "sha512-6hp5CwvTPlN2A31g5dxnwAX0orzM7pmCRDLnZSX772mv8WDqICwFjowHuPs04Mc8deIld1+ejhtaMn5vp6b+1w==",
       "license": "MIT",
       "dependencies": {
-        "follow-redirects": "^1.15.6",
-        "form-data": "^4.0.4",
-        "proxy-from-env": "^1.1.0"
+        "follow-redirects": "^1.16.0",
+        "form-data": "^4.0.5",
+        "proxy-from-env": "^2.1.0"
       }
     },
     "node_modules/axios-mock-adapter": {
@@ -14787,6 +15595,15 @@
       },
       "peerDependencies": {
         "axios": "0.x || 1.x"
+      }
+    },
+    "node_modules/axios/node_modules/proxy-from-env": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/proxy-from-env/-/proxy-from-env-2.1.0.tgz",
+      "integrity": "sha512-cJ+oHTW1VAEa8cJslgmUZrc+sjRKgAKl3Zyse6+PV38hZe/V6Z14TbCuXcan9F9ghlz4QrFr2c92TNF82UkYHA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=10"
       }
     },
     "node_modules/axobject-query": {
@@ -14879,19 +15696,6 @@
         "url": "https://opencollective.com/bigjs"
       }
     },
-    "node_modules/bigint-buffer": {
-      "version": "1.1.5",
-      "resolved": "https://registry.npmjs.org/bigint-buffer/-/bigint-buffer-1.1.5.tgz",
-      "integrity": "sha512-trfYco6AoZ+rKhKnxA0hgX0HAbVP/s808/EuDSe2JDzUnCp/xAsli35Orvk67UrTEcwuxZqYZDmfA2RXJgxVvA==",
-      "hasInstallScript": true,
-      "license": "Apache-2.0",
-      "dependencies": {
-        "bindings": "^1.3.0"
-      },
-      "engines": {
-        "node": ">= 10.0.0"
-      }
-    },
     "node_modules/bigint-mod-arith": {
       "version": "3.3.1",
       "resolved": "https://registry.npmjs.org/bigint-mod-arith/-/bigint-mod-arith-3.3.1.tgz",
@@ -14899,15 +15703,6 @@
       "license": "MIT",
       "engines": {
         "node": ">=10.4.0"
-      }
-    },
-    "node_modules/bignumber.js": {
-      "version": "9.3.1",
-      "resolved": "https://registry.npmjs.org/bignumber.js/-/bignumber.js-9.3.1.tgz",
-      "integrity": "sha512-Ko0uX15oIUS7wJ3Rb30Fs6SkVbLmPBAKdlm7q9+ak9bbIeFf0MwuBsQV6z7+X768/cHsfg+WlysDWJcmthjsjQ==",
-      "license": "MIT",
-      "engines": {
-        "node": "*"
       }
     },
     "node_modules/binary-extensions": {
@@ -14921,15 +15716,6 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
-      }
-    },
-    "node_modules/bindings": {
-      "version": "1.5.0",
-      "resolved": "https://registry.npmjs.org/bindings/-/bindings-1.5.0.tgz",
-      "integrity": "sha512-p2q/t/mhvuOj/UeLlV6566GD/guowlr0hHxClI0W9m7MWYkL1F0hLo+0Aexs9HSPCtR1SXQ0TD3MMKrXZajbiQ==",
-      "license": "MIT",
-      "dependencies": {
-        "file-uri-to-path": "1.0.0"
       }
     },
     "node_modules/bip32": {
@@ -15087,6 +15873,15 @@
       "resolved": "https://registry.npmjs.org/brorand/-/brorand-1.1.0.tgz",
       "integrity": "sha512-cKV8tMCEpQs4hK/ik71d6LrPOnpkpGBR0wzxqr68g2m/LB2GxVYQroAjMJZRVM1Y4BCjCKc3vAamxSzOY2RP+w==",
       "license": "MIT"
+    },
+    "node_modules/brotli-wasm": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/brotli-wasm/-/brotli-wasm-3.0.1.tgz",
+      "integrity": "sha512-U3K72/JAi3jITpdhZBqzSUq+DUY697tLxOuFXB+FpAE/Ug+5C3VZrv4uA674EUZHxNAuQ9wETXNqQkxZD6oL4A==",
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=v18.0.0"
+      }
     },
     "node_modules/browser-readablestream-to-it": {
       "version": "1.0.3",
@@ -18490,13 +19285,6 @@
       ],
       "license": "BSD-3-Clause"
     },
-    "node_modules/fastestsmallesttextencoderdecoder": {
-      "version": "1.0.22",
-      "resolved": "https://registry.npmjs.org/fastestsmallesttextencoderdecoder/-/fastestsmallesttextencoderdecoder-1.0.22.tgz",
-      "integrity": "sha512-Pb8d48e+oIuY4MaM64Cd7OW1gt4nxCHs7/ddPPZ/Ic3sg8yVGM7O9wDvZ7us6ScaUupzM+pfBolwtYhN1IxBIw==",
-      "license": "CC0-1.0",
-      "peer": true
-    },
     "node_modules/fastq": {
       "version": "1.19.1",
       "resolved": "https://registry.npmjs.org/fastq/-/fastq-1.19.1.tgz",
@@ -18519,12 +19307,6 @@
       "engines": {
         "node": "^10.12.0 || >=12.0.0"
       }
-    },
-    "node_modules/file-uri-to-path": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/file-uri-to-path/-/file-uri-to-path-1.0.0.tgz",
-      "integrity": "sha512-0Zt+s3L7Vf1biwWZ29aARiVYLx7iMGnEUl9x33fbB/j3jR81u/O2LbqK+Bm1CDSNDKVtJ/YjwY7TUd5SkeLQLw==",
-      "license": "MIT"
     },
     "node_modules/fill-range": {
       "version": "7.1.1",
@@ -18621,9 +19403,9 @@
       "license": "ISC"
     },
     "node_modules/follow-redirects": {
-      "version": "1.15.11",
-      "resolved": "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.15.11.tgz",
-      "integrity": "sha512-deG2P0JfjrTxl50XGCDyfI97ZGVCxIpfKYmfyrQ54n5FO/0gfIES8C/Psl6kWVDolizcaaxZJnTS0QSMxvnsBQ==",
+      "version": "1.16.0",
+      "resolved": "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.16.0.tgz",
+      "integrity": "sha512-y5rN/uOsadFT/JfYwhxRS5R7Qce+g3zG97+JrtFZlC9klX/W5hD7iiLzScI4nZqUS7DNUdhPgw4xI8W2LuXlUw==",
       "funding": [
         {
           "type": "individual",
@@ -18656,16 +19438,16 @@
       }
     },
     "node_modules/form-data": {
-      "version": "4.0.4",
-      "resolved": "https://registry.npmjs.org/form-data/-/form-data-4.0.4.tgz",
-      "integrity": "sha512-KrGhL9Q4zjj0kiUt5OO4Mr/A/jlI2jDYs5eHBpYHPcBEVSiipAvn2Ko2HnPe20rmcuuvMHNdZFp+4IlGTMF0Ow==",
+      "version": "4.0.6",
+      "resolved": "https://registry.npmjs.org/form-data/-/form-data-4.0.6.tgz",
+      "integrity": "sha512-vKatAh4SlVfgbv+YtmhiRjhEMJsYpsG1Y2rMQtR+SVSbytsSD1YGzDIcrAJmdFec88u/+VoGmxnl+80gL1tRCQ==",
       "license": "MIT",
       "dependencies": {
         "asynckit": "^0.4.0",
         "combined-stream": "^1.0.8",
         "es-set-tostringtag": "^2.1.0",
-        "hasown": "^2.0.2",
-        "mime-types": "^2.1.12"
+        "hasown": "^2.0.4",
+        "mime-types": "^2.1.35"
       },
       "engines": {
         "node": ">= 6"
@@ -19605,9 +20387,9 @@
       }
     },
     "node_modules/hasown": {
-      "version": "2.0.2",
-      "resolved": "https://registry.npmjs.org/hasown/-/hasown-2.0.2.tgz",
-      "integrity": "sha512-0hJU9SCPvmMzIBdZFqNPXWa6dqh7WdH0cII9y+CyS8rG3nL48Bclra9HmKhVVUHyPWNH5Y7xDwAB7bfgSjkUMQ==",
+      "version": "2.0.4",
+      "resolved": "https://registry.npmjs.org/hasown/-/hasown-2.0.4.tgz",
+      "integrity": "sha512-T2UbfbBEF32wiepXIsMlTW9+dDYC6wMh/t/vYA4tuOMKqWz/n3vr1NFSxQiyP+zk2mXsoMA/i/7qV6LKut1t1A==",
       "license": "MIT",
       "dependencies": {
         "function-bind": "^1.1.2"
@@ -20800,9 +21582,9 @@
       }
     },
     "node_modules/jose": {
-      "version": "6.1.0",
-      "resolved": "https://registry.npmjs.org/jose/-/jose-6.1.0.tgz",
-      "integrity": "sha512-TTQJyoEoKcC1lscpVDCSsVgYzUDg/0Bt3WE//WiTPK6uOCQC2KZS4MpugbMWt/zyjkopgZoXhZuCi00gLudfUA==",
+      "version": "6.2.3",
+      "resolved": "https://registry.npmjs.org/jose/-/jose-6.2.3.tgz",
+      "integrity": "sha512-YYVDInQKFJfR/xa3ojUTl8c2KoTwiL1R5Wg9YCydwH0x0B9grbzlg5HC7mMjCtUJjbQ/YnGEZIhI5tCgfTb4Hw==",
       "license": "MIT",
       "funding": {
         "url": "https://github.com/sponsors/panva"
@@ -27232,9 +28014,9 @@
       }
     },
     "node_modules/viem": {
-      "version": "2.37.6",
-      "resolved": "https://registry.npmjs.org/viem/-/viem-2.37.6.tgz",
-      "integrity": "sha512-b+1IozQ8TciVQNdQUkOH5xtFR0z7ZxR8pyloENi/a+RA408lv4LoX12ofwoiT3ip0VRhO5ni1em//X0jn/eW0g==",
+      "version": "2.52.2",
+      "resolved": "https://registry.npmjs.org/viem/-/viem-2.52.2.tgz",
+      "integrity": "sha512-HSU12p5aD/kAPZfrlbCUqdiP4P/c6hQ9AhfTS51VbLUQIjkWd1d5EjrCx/SCxZ0zhZVRn4Iv5X5WDqXPG8Ubew==",
       "funding": [
         {
           "type": "github",
@@ -27247,10 +28029,10 @@
         "@noble/hashes": "1.8.0",
         "@scure/bip32": "1.7.0",
         "@scure/bip39": "1.6.0",
-        "abitype": "1.1.0",
+        "abitype": "1.2.3",
         "isows": "1.0.7",
-        "ox": "0.9.3",
-        "ws": "8.18.3"
+        "ox": "0.14.29",
+        "ws": "8.20.1"
       },
       "peerDependencies": {
         "typescript": ">=5.0.4"
@@ -27262,9 +28044,9 @@
       }
     },
     "node_modules/viem/node_modules/@adraffy/ens-normalize": {
-      "version": "1.11.0",
-      "resolved": "https://registry.npmjs.org/@adraffy/ens-normalize/-/ens-normalize-1.11.0.tgz",
-      "integrity": "sha512-/3DDPKHqqIqxUULp8yP4zODUY1i+2xvVWsv8A79xGWdCAG+8sb0hRh0Rk2QyOJUnnbyPUAZYcpBuRe3nS2OIUg==",
+      "version": "1.11.1",
+      "resolved": "https://registry.npmjs.org/@adraffy/ens-normalize/-/ens-normalize-1.11.1.tgz",
+      "integrity": "sha512-nhCBV3quEgesuf7c7KYfperqSS14T8bYuvJ8PcLJp6znkZpFc0AuW4qBtr8eKVyPPe/8RSr7sglCWPU5eaxwKQ==",
       "license": "MIT"
     },
     "node_modules/viem/node_modules/@noble/ciphers": {
@@ -27295,9 +28077,9 @@
       }
     },
     "node_modules/viem/node_modules/abitype": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/abitype/-/abitype-1.1.0.tgz",
-      "integrity": "sha512-6Vh4HcRxNMLA0puzPjM5GBgT4aAcFGKZzSgAXvuZ27shJP6NEpielTuqbBmZILR5/xd0PizkBGy5hReKz9jl5A==",
+      "version": "1.2.3",
+      "resolved": "https://registry.npmjs.org/abitype/-/abitype-1.2.3.tgz",
+      "integrity": "sha512-Ofer5QUnuUdTFsBRwARMoWKOH1ND5ehwYhJ3OJ/BQO+StkwQjHw0XyVh4vDttzHB7QOFhPHa/o413PJ82gU/Tg==",
       "license": "MIT",
       "funding": {
         "url": "https://github.com/sponsors/wevm"
@@ -27316,9 +28098,9 @@
       }
     },
     "node_modules/viem/node_modules/ox": {
-      "version": "0.9.3",
-      "resolved": "https://registry.npmjs.org/ox/-/ox-0.9.3.tgz",
-      "integrity": "sha512-KzyJP+fPV4uhuuqrTZyok4DC7vFzi7HLUFiUNEmpbyh59htKWkOC98IONC1zgXJPbHAhQgqs6B0Z6StCGhmQvg==",
+      "version": "0.14.29",
+      "resolved": "https://registry.npmjs.org/ox/-/ox-0.14.29.tgz",
+      "integrity": "sha512-M5j87Ec4V99MQdRct/g09eWXW60g6zhHTUs1lr4deUtrPDnezBdCJTgKd7pxqTpSZBFveV0ALi9jMMuT1qKyNg==",
       "funding": [
         {
           "type": "github",
@@ -27333,7 +28115,7 @@
         "@noble/hashes": "^1.8.0",
         "@scure/bip32": "^1.7.0",
         "@scure/bip39": "^1.6.0",
-        "abitype": "^1.0.9",
+        "abitype": "^1.2.3",
         "eventemitter3": "5.0.1"
       },
       "peerDependencies": {
@@ -27850,9 +28632,9 @@
       "license": "ISC"
     },
     "node_modules/ws": {
-      "version": "8.18.3",
-      "resolved": "https://registry.npmjs.org/ws/-/ws-8.18.3.tgz",
-      "integrity": "sha512-PEIGCY5tSlUt50cqyMXfCzX+oOPqN0vuGqWzbcJ2xvnkzkq46oOpz7dQaTDBdfICb4N14+GARUDw2XV2N4tvzg==",
+      "version": "8.20.1",
+      "resolved": "https://registry.npmjs.org/ws/-/ws-8.20.1.tgz",
+      "integrity": "sha512-It4dO0K5v//JtTXuPkfEOaI3uUN87iYPnqo/ZzqCoG3g8uhA66QUMs/SrM0YK7/NAu+r4LMh/9dq2A7k+rHs+w==",
       "license": "MIT",
       "engines": {
         "node": ">=10.0.0"

--- a/package.json
+++ b/package.json
@@ -33,7 +33,7 @@
     "spacetime:publish:maincloud": "spacetime publish -s maincloud -p spacetime-module/beat-me -c=on-conflict -y beat-me"
   },
   "dependencies": {
-    "@base-org/account": "^2.4.0",
+    "@base-org/account": "^2.5.6",
     "@base-org/account-ui": "^1.0.1",
     "@coinbase/cdp-sdk": "^1.38.2",
     "@coinbase/coinbase-sdk": "^0.25.0",


### PR DESCRIPTION
## Summary
- Centralize `@base-org/account` (^2.5.6) in a shared `BaseAccountProvider` singleton used across hooks and transaction helpers.
- Align `SignInWithBaseButton` and `BasePayButton` with current account-ui APIs via shared pay helpers and consistent button props.
- Replace mock spend permissions with official `@base-org/account/spend-permission` helpers and async onchain status checks.
- Add ENSIP-19 basename resolution (viem) and deprecate manual sub-account auto-spend in favor of SDK defaults.

## Test plan
- [ ] `npm run build` passes
- [ ] Sign in with Base Account — universal + sub-account addresses shown; reload keeps sub-account active
- [ ] Base Pay funding completes and balance refreshes
- [ ] Spend permission manager shows guidance when `NEXT_PUBLIC_SPEND_PERMISSION_SPENDER` is unset
- [ ] Basenames resolve on leaderboard/profile for `.base.eth` addresses
- [ ] Paid game entry and batch transactions still work with shared SDK provider


Made with [Cursor](https://cursor.com)