### PR TITLE
Fix onramp stuck on "Initializing Onramp..." loading state

### DIFF
--- a/components/game/GameEntry.tsx
+++ b/components/game/GameEntry.tsx
@@ -75,7 +75,7 @@ export default function GameEntry({
   const [isFundingUrlGenerating, setIsFundingUrlGenerating] = useState(false);
   const paidGameCalls = useMemo(() => createBaseAccountPaidGameCalls(), []);
   const paidTxRef = useRef<BaseAccountTransactionHandle>(null);
-  const onrampGeneratingRef = useRef(false);
+  const generatingAddressRef = useRef<string | null>(null);
   const paymasterConfigured = Boolean(process.env.NEXT_PUBLIC_PAYMASTER_AND_BUNDLER_ENDPOINT);
 
   // Local countdown timer that ticks every second from the server-provided value
@@ -102,14 +102,18 @@ export default function GameEntry({
   }, [address]);
 
   const generateOnrampUrls = useCallback(async (): Promise<string | null> => {
-    if (!address || onrampGeneratingRef.current) return null;
+    if (!address || generatingAddressRef.current === address) return null;
 
-    onrampGeneratingRef.current = true;
+    generatingAddressRef.current = address;
     setIsFundingUrlGenerating(true);
 
     try {
       await clearBrowserCache();
       const sessionToken = await getSessionToken(address);
+
+      if (generatingAddressRef.current !== address) {
+        return null;
+      }
 
       const usdcUrl = generateFundingUrl({ walletAddress: address, sessionToken });
       setFundingUrl(usdcUrl);
@@ -124,13 +128,16 @@ export default function GameEntry({
       setError(null);
       return usdcUrl;
     } catch (err) {
+      if (generatingAddressRef.current !== address) return null;
       console.error('Failed to generate onramp URLs:', err);
       const errorMessage = err instanceof Error ? err.message : 'Unknown error occurred';
       setError(`Failed to initialize onramp: ${errorMessage}`);
       return null;
     } finally {
-      onrampGeneratingRef.current = false;
-      setIsFundingUrlGenerating(false);
+      if (generatingAddressRef.current === address) {
+        generatingAddressRef.current = null;
+        setIsFundingUrlGenerating(false);
+      }
     }
   }, [address, getSessionToken]);
 

--- a/components/game/GameEntry.tsx
+++ b/components/game/GameEntry.tsx
@@ -75,6 +75,7 @@ export default function GameEntry({
   const [isFundingUrlGenerating, setIsFundingUrlGenerating] = useState(false);
   const paidGameCalls = useMemo(() => createBaseAccountPaidGameCalls(), []);
   const paidTxRef = useRef<BaseAccountTransactionHandle>(null);
+  const onrampGeneratingRef = useRef(false);
   const paymasterConfigured = Boolean(process.env.NEXT_PUBLIC_PAYMASTER_AND_BUNDLER_ENDPOINT);
 
   // Local countdown timer that ticks every second from the server-provided value
@@ -100,50 +101,44 @@ export default function GameEntry({
     setEthFundingUrl(null);
   }, [address]);
 
+  const generateOnrampUrls = useCallback(async (): Promise<string | null> => {
+    if (!address || onrampGeneratingRef.current) return null;
+
+    onrampGeneratingRef.current = true;
+    setIsFundingUrlGenerating(true);
+
+    try {
+      await clearBrowserCache();
+      const sessionToken = await getSessionToken(address);
+
+      const usdcUrl = generateFundingUrl({ walletAddress: address, sessionToken });
+      setFundingUrl(usdcUrl);
+      setEthFundingUrl(
+        generateAssetFundingUrl({
+          walletAddress: address,
+          sessionToken,
+          asset: 'ETH',
+          presetFiatAmount: '5',
+        })
+      );
+      setError(null);
+      return usdcUrl;
+    } catch (err) {
+      console.error('Failed to generate onramp URLs:', err);
+      const errorMessage = err instanceof Error ? err.message : 'Unknown error occurred';
+      setError(`Failed to initialize onramp: ${errorMessage}`);
+      return null;
+    } finally {
+      onrampGeneratingRef.current = false;
+      setIsFundingUrlGenerating(false);
+    }
+  }, [address, getSessionToken]);
+
   // Auto-generate USDC + ETH onramp URLs when address is available
   useEffect(() => {
-    let active = true;
-
-    const generateOnrampUrls = async () => {
-      if (!address || (fundingUrl && ethFundingUrl) || isFundingUrlGenerating) return;
-
-      try {
-        setIsFundingUrlGenerating(true);
-        await clearBrowserCache();
-        const sessionToken = await getSessionToken(address);
-
-        if (!active) return;
-
-        setFundingUrl(
-          generateFundingUrl({ walletAddress: address, sessionToken })
-        );
-        setEthFundingUrl(
-          generateAssetFundingUrl({
-            walletAddress: address,
-            sessionToken,
-            asset: 'ETH',
-            presetFiatAmount: '5',
-          })
-        );
-        setError(null);
-      } catch (err) {
-        if (!active) return;
-        console.error('Failed to generate onramp URLs:', err);
-        const errorMessage = err instanceof Error ? err.message : 'Unknown error occurred';
-        setError(`Failed to initialize onramp: ${errorMessage}`);
-      } finally {
-        if (active) {
-          setIsFundingUrlGenerating(false);
-        }
-      }
-    };
-
-    generateOnrampUrls();
-
-    return () => {
-      active = false;
-    };
-  }, [address, fundingUrl, ethFundingUrl, isFundingUrlGenerating, getSessionToken]);
+    if (!address || fundingUrl) return;
+    void generateOnrampUrls();
+  }, [address, fundingUrl, generateOnrampUrls]);
 
   // Handle transaction status updates
   const handleTransactionStatus = useCallback((
@@ -445,39 +440,27 @@ export default function GameEntry({
     setError(null);
   };
 
-  // Manual refresh of funding URL (if needed)
   const handleRefreshFundingUrl = async () => {
     if (!address) return;
-    
-    try {
-      setIsFundingUrlGenerating(true);
-      console.log('🔄 Manually refreshing CDP funding URL...');
-      
-      // Clear existing URL and cache
-      setFundingUrl(null);
-      setEthFundingUrl(null);
-      setError(null);
-      await clearBrowserCache();
-      
-      const sessionToken = await getSessionToken(address);
 
-      setFundingUrl(generateFundingUrl({ walletAddress: address, sessionToken }));
-      setEthFundingUrl(
-        generateAssetFundingUrl({
-          walletAddress: address,
-          sessionToken,
-          asset: 'ETH',
-          presetFiatAmount: '5',
-        })
-      );
+    setFundingUrl(null);
+    setEthFundingUrl(null);
+    setError(null);
+    const url = await generateOnrampUrls();
+    if (url) {
       setFundingSuccess(true);
       setTimeout(() => setFundingSuccess(false), 2000);
-    } catch (err) {
-      console.error('❌ Failed to refresh funding URL:', err);
-      const errorMessage = err instanceof Error ? err.message : 'Unknown error occurred';
-      setError(`Failed to refresh onramp URL: ${errorMessage}`);
-    } finally {
-      setIsFundingUrlGenerating(false);
+    }
+  };
+
+  const handleBuyUsdc = async () => {
+    if (fundingUrl) {
+      openFundingUrl(fundingUrl);
+      return;
+    }
+    const url = await generateOnrampUrls();
+    if (url) {
+      openFundingUrl(url);
     }
   };
 
@@ -701,12 +684,8 @@ export default function GameEntry({
                     {!hasEnoughForEntry && !balanceLoading && (
                       <div className="mt-3 pt-3 border-t border-gray-700/50">
                         <Button
-                          onClick={() => {
-                            if (fundingUrl) {
-                              openFundingUrl(fundingUrl);
-                            }
-                          }}
-                          disabled={!fundingUrl || isFundingUrlGenerating}
+                          onClick={handleBuyUsdc}
+                          disabled={isFundingUrlGenerating}
                           className="w-full !bg-gradient-to-r !from-blue-500 !to-indigo-500 hover:!from-blue-400 hover:!to-indigo-400 text-white text-sm cursor-pointer disabled:opacity-50 disabled:cursor-not-allowed"
                           size="sm"
                         >
@@ -718,7 +697,7 @@ export default function GameEntry({
                           ) : (
                             <>
                               <Coins className="h-3 w-3 mr-2" />
-                              Buy USDC with Card
+                              {fundingUrl ? 'Buy USDC with Card' : 'Retry Onramp Setup'}
                             </>
                           )}
                         </Button>


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Problem

On the paid multiplayer entry screen, the "Buy USDC with Card" button could get stuck indefinitely on **"Initializing Onramp..."**, preventing users from purchasing USDC via Coinbase Onramp.

## Root cause

A React `useEffect` race condition in `GameEntry.tsx`:

1. The effect set `isFundingUrlGenerating = true` to show loading
2. That state was in the effect's dependency array, so the effect re-ran immediately
3. Cleanup from the first run set `active = false`
4. When the async session-token request finished, `finally` only cleared loading when `active` was true — but cleanup had already set it to `false`
5. Result: `isFundingUrlGenerating` stayed `true` forever

## Fix

- Track in-flight generation with `generatingAddressRef` (wallet address, not a boolean) to prevent concurrent/stale updates when switching wallets
- Always clear loading state in `finally` only for the matching address
- Skip stale state updates if the wallet address changed mid-request
- Extract shared `generateOnrampUrls()` helper used by auto-init, refresh, and buy button
- Enable the buy button even when URL isn't pre-cached; clicking generates and opens on demand
- Show "Retry Onramp Setup" if pre-generation failed

## Testing

1. Connect wallet on paid multiplayer screen with 0 USDC
2. Confirm button transitions from "Initializing Onramp..." to "Buy USDC with Card"
3. Tap button — Coinbase Pay should open
4. If init fails, button shows "Retry Onramp Setup" and is clickable
5. Switch wallet address while generating — new address should auto-generate without getting stuck
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-aba6ca61-278f-4b95-9b69-8524171f332b"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-aba6ca61-278f-4b95-9b69-8524171f332b"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

