### PR TITLE
UX fixes: funding, answer feedback, leaderboard, and home navigation

### DIFF
--- a/app/api/save-paid-score/route.ts
+++ b/app/api/save-paid-score/route.ts
@@ -20,6 +20,8 @@ export async function POST(req: NextRequest) {
       );
     }
 
+    const normalizedWallet = walletAddress.trim().toLowerCase();
+
     if (typeof finalScore !== 'number' || finalScore < 0 || !Number.isFinite(finalScore)) {
       return NextResponse.json(
         { error: 'finalScore must be a non-negative number' },
@@ -45,7 +47,7 @@ export async function POST(req: NextRequest) {
         );
       }
       // Verify the wallet address matches the token identity
-      if (payload.identity.walletAddress?.toLowerCase() !== walletAddress.toLowerCase()) {
+      if (payload.identity.walletAddress?.toLowerCase() !== normalizedWallet) {
         return NextResponse.json(
           { error: 'Wallet address does not match entry token' },
           { status: 403 }
@@ -62,20 +64,20 @@ export async function POST(req: NextRequest) {
       );
     }
 
-    const current = spacetimeClient.getPlayerProfile(walletAddress);
+    const current = spacetimeClient.getPlayerProfile(normalizedWallet);
 
     if (!current) {
-      await spacetimeClient.createPlayer(walletAddress, username);
+      await spacetimeClient.createPlayer(normalizedWallet, username);
     }
 
-    const existing = spacetimeClient.getPlayerProfile(walletAddress);
+    const existing = spacetimeClient.getPlayerProfile(normalizedWallet);
     const totalScore = (existing?.totalScore ?? 0) + finalScore;
     const gamesPlayed = (existing?.gamesPlayed ?? 0) + 1;
     const bestScore = Math.max(existing?.bestScore ?? 0, finalScore);
     const totalEarnings = existing?.totalEarnings ?? 0;
 
     await spacetimeClient.updatePlayerStats(
-      walletAddress,
+      normalizedWallet,
       totalScore,
       gamesPlayed,
       bestScore,
@@ -84,7 +86,7 @@ export async function POST(req: NextRequest) {
 
     // Fire-and-forget on-chain sync for CRE prize distribution.
     submitScoresOnChainAsync(
-      [walletAddress as `0x${string}`],
+      [normalizedWallet as `0x${string}`],
       [BigInt(bestScore)]
     );
 

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -14,6 +14,7 @@ import AudioPlayer from '@/components/game/AudioPlayer';
 import ActivePlayers from '@/components/game/ActivePlayers';
 import type { TriviaQuestion, PlayerModeChoice, GameStartOptions } from '@/types/game';
 import { useBaseAccount } from '@/hooks/useBaseAccount';
+import { useBasename } from '@/hooks/useBasename';
 import { useTrialStatus } from '@/hooks/useTrialStatus';
 import { useContractUSDCBalance } from '@/hooks/useContractUSDCBalance';
 import GameTitle from '@/components/ui/GameTitle';
@@ -77,6 +78,8 @@ function HomePage() {
   const paidScoreSavedRef = useRef(false);
   // Add trial status hook
   const { address } = useBaseAccount();
+  const { data: basename } = useBasename(address ?? undefined);
+  const playerDisplayName = basename ?? (address ? `${address.slice(0, 6)}...${address.slice(-4)}` : 'Player');
   const [joinGameStartError, setJoinGameStartError] = useState<string | null>(null);
   const { trialStatus, incrementTrialGame } = useTrialStatus(address as string, entryToken ?? undefined);
   
@@ -126,7 +129,7 @@ function HomePage() {
     if (paidScoreSavedRef.current) return;
     paidScoreSavedRef.current = true;
     const finalScore = totalScore;
-    const wallet = address;
+    const wallet = address.toLowerCase();
     void (async () => {
       try {
         const res = await fetch('/api/save-paid-score', {
@@ -136,6 +139,7 @@ function HomePage() {
             walletAddress: wallet,
             finalScore,
             entryToken: entryToken ?? undefined,
+            username: playerDisplayName ?? undefined,
           }),
         });
         if (!res.ok) {
@@ -149,7 +153,7 @@ function HomePage() {
         console.error('save-paid-score error', e);
       }
     })();
-  }, [gameCompleted, address, totalScore, refreshContractUsdcBalance]);
+  }, [gameCompleted, address, totalScore, refreshContractUsdcBalance, entryToken, playerDisplayName]);
 
   const loadRandomQuestion = useCallback(async () => {
     setGameLoading(true);
@@ -523,7 +527,7 @@ function HomePage() {
         onLeaveLobby={async () => {
           await leaveGame();
           setInMultiplayerLobby(false);
-          setShowGameEntry(true);
+          setShowGameEntry(false);
         }}
       />
     );
@@ -534,6 +538,14 @@ function HomePage() {
     return (
       <div className="bg-[#000000] min-h-screen w-full flex items-center justify-center px-4">
         <div className="w-full max-w-[390px] md:max-w-[428px] space-y-4">
+          <button
+            type="button"
+            onClick={() => setShowGameEntry(false)}
+            className="text-sm text-gray-400 hover:text-white transition-colors"
+            aria-label="Back to home"
+          >
+            ← Back to Home
+          </button>
           {/* Player mode: Trial | Solo (paid) | Multiplayer (paid) */}
           <Card className="bg-gradient-to-br from-purple-900/20 to-blue-900/20 border-purple-500/30">
             <CardContent className="p-6">
@@ -700,7 +712,7 @@ function HomePage() {
               <div className="mb-6">
                 <HighScoreDisplay
                   currentScore={totalScore}
-                  playerName={isGuestMode ? guestName : 'Player'}
+                  playerName={isGuestMode ? guestName : playerDisplayName}
                   isGuest={isGuestMode}
                   isTrialGame={completedAsTrial}
                   walletAddress={!completedAsTrial && address ? address : undefined}
@@ -869,21 +881,24 @@ function HomePage() {
                   isAnswered
                     ? isVerifying
                       ? selectedAnswer === index
-                        ? 'bg-purple-600 text-white animate-pulse'  // Pulsing while verifying
+                        ? 'bg-purple-600 text-white animate-pulse'
                         : 'bg-gray-700 text-gray-400'
                       : selectedAnswer === index
                         ? verifiedCorrectAnswer === index
-                          ? 'bg-green-600 text-white'  // Green if selected AND correct
-                          : 'bg-red-600 text-white'    // Red if selected AND wrong
-                        : verifiedCorrectAnswer === index
-                          ? 'bg-green-600/50 text-white'  // Dim green to reveal correct answer
-                          : 'bg-gray-700 text-gray-400'  // Gray for unselected options
+                          ? 'bg-green-600 text-white'
+                          : 'bg-red-600 text-white'
+                        : 'bg-gray-700 text-gray-400'
                     : gameTimeRemaining <= 0
                     ? 'bg-gray-800 text-gray-500 cursor-not-allowed'
                     : 'bg-gray-700 hover:bg-gray-600 text-white border border-gray-600'
                 }`}
               >
-                {option}
+                <span>{option}</span>
+                {isAnswered && !isVerifying && selectedAnswer === index && verifiedCorrectAnswer !== null && (
+                  <span className="block mt-1 text-xs font-semibold">
+                    {verifiedCorrectAnswer === index ? '✓ Correct' : '✗ Incorrect'}
+                  </span>
+                )}
               </button>
             ))}
           </div>
@@ -1109,7 +1124,7 @@ function HomePage() {
               Paid games only — practice / trial scores are not listed
             </p>
             <div className="w-full max-w-[328px]">
-              <TopEarners limit={10} />
+              <TopEarners limit={10} currentWalletAddress={address ?? undefined} />
             </div>
           </div>
           

--- a/components/base-account/SubAccountDisplay.tsx
+++ b/components/base-account/SubAccountDisplay.tsx
@@ -203,13 +203,6 @@ export default function SubAccountDisplay({
                     </button>
                     <button
                       type="button"
-                      onClick={() => openFundingUrl('https://bridge.base.org')}
-                      className="text-xs text-amber-300/90 underline text-left hover:text-amber-200"
-                    >
-                      Bridge ETH from another network
-                    </button>
-                    <button
-                      type="button"
                       onClick={() => copyToClipboard(subAccountAddress, 'sub')}
                       className="text-xs text-zinc-400 underline text-left hover:text-zinc-300"
                     >

--- a/components/game/GameEntry.tsx
+++ b/components/game/GameEntry.tsx
@@ -687,8 +687,8 @@ export default function GameEntry({
                       {hasEnoughForEntry ? 'Sufficient funds for entry' : 'Need 1 USDC to play'}
                     </div>
 
-                    {/* CDP Onramp - Buy USDC button when balance is insufficient */}
-                    {!hasEnoughForEntry && !balanceLoading && (
+                    {/* USDC onramp — always available so players can add more funds */}
+                    {!balanceLoading && (
                       <div className="mt-3 pt-3 border-t border-gray-700/50">
                         <Button
                           onClick={handleBuyUsdc}
@@ -704,12 +704,12 @@ export default function GameEntry({
                           ) : (
                             <>
                               <Coins className="h-3 w-3 mr-2" />
-                              {fundingUrl ? 'Buy USDC with Card' : 'Retry Onramp Setup'}
+                              {hasEnoughForEntry ? 'Add More USDC' : fundingUrl ? 'Buy USDC with Card' : 'Retry Onramp Setup'}
                             </>
                           )}
                         </Button>
                         <p className="text-[10px] text-gray-400 text-center mt-1.5">
-                          Powered by Coinbase Onramp &middot; Card or Apple Pay
+                          USDC entry fee &middot; Powered by Coinbase Onramp
                         </p>
                       </div>
                     )}

--- a/components/game/HighScoreDisplay.tsx
+++ b/components/game/HighScoreDisplay.tsx
@@ -1,14 +1,18 @@
 'use client';
 
-import { useState, useEffect } from 'react';
+import { useState, useEffect, useMemo } from 'react';
 import { Trophy, Medal, Award, Crown, Coins, CheckCircle } from 'lucide-react';
 import { useHighScores } from '@/hooks/useHighScores';
+import { useTopEarners } from '@/hooks/useTopEarners';
 import { usePlayerWinnings } from '@/hooks/usePlayerWinnings';
 import { Badge } from '@/components/ui/badge';
 import { useBaseAccount } from '@/hooks/useBaseAccount';
 import ClaimWinningsButton from '@/components/game/ClaimWinningsButton';
 import { BaseName } from '@/components/identity/BaseName';
+import ComposeCastButton from '@/components/social/ComposeCastButton';
 import { Confetti } from '@neoconfetti/react';
+
+const LEADERBOARD_LIMIT = 10;
 
 interface HighScoreDisplayProps {
   currentScore: number;
@@ -30,7 +34,8 @@ export default function HighScoreDisplay({
   walletAddress,
   className = '' 
 }: HighScoreDisplayProps) {
-  const { highScores, getCurrentHighScore, getPlayerRank, submitScore } = useHighScores();
+  const { submitScore } = useHighScores();
+  const { topEarners, isLoading: leaderboardLoading } = useTopEarners(LEADERBOARD_LIMIT, { viewType: 'scores' });
   const { address, isConnected } = useBaseAccount();
   const { winnings, markAsClaimed, refreshWinnings } = usePlayerWinnings();
   const [hasSubmitted, setHasSubmitted] = useState(false);
@@ -40,9 +45,59 @@ export default function HighScoreDisplay({
   } | null>(null);
   const [showConfetti, setShowConfetti] = useState(false);
 
-  const currentHighScore = getCurrentHighScore();
-  const playerRank = getPlayerRank(currentScore);
-  const isHighestScore = currentScore >= currentHighScore;
+  const normalizedWallet = walletAddress?.toLowerCase();
+
+  const leaderboardEntries = useMemo(() => {
+    if (isTrialGame) return [];
+
+    const entries = [...topEarners];
+    if (!normalizedWallet || currentScore <= 0) {
+      return entries.slice(0, LEADERBOARD_LIMIT);
+    }
+
+    const existingIdx = entries.findIndex(
+      (e) => e.walletAddress.toLowerCase() === normalizedWallet
+    );
+
+    if (existingIdx >= 0) {
+      const updated = [...entries];
+      updated[existingIdx] = {
+        ...updated[existingIdx],
+        bestScore: Math.max(updated[existingIdx].bestScore, currentScore),
+        username: playerName || updated[existingIdx].username,
+      };
+      return updated
+        .sort((a, b) => b.bestScore - a.bestScore)
+        .slice(0, LEADERBOARD_LIMIT);
+    }
+
+    const merged = [
+      ...entries,
+      {
+        walletAddress: normalizedWallet,
+        username: playerName,
+        bestScore: currentScore,
+        totalEarnings: 0,
+        gamesPlayed: 1,
+      },
+    ]
+      .sort((a, b) => b.bestScore - a.bestScore)
+      .slice(0, LEADERBOARD_LIMIT);
+
+    return merged;
+  }, [isTrialGame, topEarners, normalizedWallet, currentScore, playerName]);
+
+  const playerRank = useMemo(() => {
+    if (isTrialGame || currentScore <= 0) return null;
+    const idx = leaderboardEntries.findIndex(
+      (e) => e.walletAddress.toLowerCase() === normalizedWallet
+    );
+    return idx >= 0 ? idx + 1 : null;
+  }, [isTrialGame, currentScore, leaderboardEntries, normalizedWallet]);
+
+  const isOnLeaderboard = playerRank !== null && playerRank <= LEADERBOARD_LIMIT;
+  const currentHighScore = leaderboardEntries[0]?.bestScore ?? 0;
+  const isHighestScore = !isTrialGame && playerRank === 1;
 
   const handleClaimSuccess = () => {
     markAsClaimed();
@@ -69,11 +124,11 @@ export default function HighScoreDisplay({
       if (result) {
         setHasSubmitted(true);
         setSubmissionResult({
-          isNewHighScore: result.isNewHighScore,
-          rank: result.rank,
+          isNewHighScore: isHighestScore,
+          rank: playerRank ?? result.rank,
         });
 
-        if (result.isNewHighScore) {
+        if (isHighestScore) {
           setShowConfetti(true);
           setTimeout(() => setShowConfetti(false), 4000);
         }
@@ -89,6 +144,8 @@ export default function HighScoreDisplay({
     isTrialGame,
     hasSubmitted,
     submitScore,
+    isHighestScore,
+    playerRank,
   ]);
 
   const getRankIcon = (rank: number) => {
@@ -120,7 +177,6 @@ export default function HighScoreDisplay({
     if (username) {
       return <span>{username}</span>;
     }
-    
     if (walletAddress) {
       return (
         <BaseName
@@ -177,7 +233,13 @@ export default function HighScoreDisplay({
                 </div>
               )}
               <p className="text-sm text-blue-600">
-                {isTrialGame ? 'Rank: — (practice)' : `Rank: #${playerRank}`}
+                {isTrialGame
+                  ? 'Rank: — (practice)'
+                  : playerRank
+                    ? `Rank: #${playerRank}${isOnLeaderboard ? ' · Top 10' : ''}`
+                    : leaderboardLoading
+                      ? 'Rank: updating...'
+                      : 'Rank: —'}
               </p>
             </div>
           </div>
@@ -276,6 +338,16 @@ export default function HighScoreDisplay({
           </div>
         )}
 
+        {isOnLeaderboard && !isTrialGame && (
+          <div className="mb-3 flex justify-center">
+            <ComposeCastButton
+              achievementType={playerRank === 1 ? 'high-score' : 'game-complete'}
+              score={currentScore}
+              className="w-full"
+            />
+          </div>
+        )}
+
         {/* Current High Score */}
         {currentHighScore > 0 && (
           <div className="bg-yellow-50 border border-yellow-200 rounded-lg p-3 mb-3">
@@ -294,33 +366,43 @@ export default function HighScoreDisplay({
 
       {/* Top Scores List */}
       <div>
-        <h4 className="text-sm font-semibold text-gray-700 mb-2">Top Scores</h4>
+        <h4 className="text-sm font-semibold text-gray-700 mb-2">Top {LEADERBOARD_LIMIT} (Paid)</h4>
         <div className="space-y-2">
-          {highScores.slice(0, 5).map((score, index) => (
-            <div 
-              key={score.id}
-              className={`flex items-center justify-between p-2 rounded ${
-                score.playerName === playerName && score.score === currentScore
-                  ? 'bg-blue-100 border border-blue-300'
-                  : 'bg-gray-50'
-              }`}
-            >
-              <div className="flex items-center">
-                {getRankIcon(index + 1)}
-                <span className="ml-2 text-sm font-medium text-gray-700">
-                  <PlayerDisplayName 
-                    walletAddress={score.walletAddress}
-                    username={score.playerName}
-                    isGuest={score.isGuest}
-                  />
-                  {score.isGuest && <span className="text-xs text-gray-500 ml-1">(Guest)</span>}
-                </span>
-              </div>
-              <span className="text-sm font-bold text-gray-900">
-                {formatScore(score.score)}
-              </span>
-            </div>
-          ))}
+          {leaderboardLoading && leaderboardEntries.length === 0 ? (
+            <p className="text-sm text-gray-500 text-center py-2">Loading leaderboard...</p>
+          ) : leaderboardEntries.length === 0 ? (
+            <p className="text-sm text-gray-500 text-center py-2">No scores yet — be the first!</p>
+          ) : (
+            leaderboardEntries.map((entry, index) => {
+              const isCurrentPlayer =
+                normalizedWallet &&
+                entry.walletAddress.toLowerCase() === normalizedWallet;
+              return (
+                <div
+                  key={`${entry.walletAddress}-${index}`}
+                  className={`flex items-center justify-between p-2 rounded ${
+                    isCurrentPlayer ? 'bg-blue-100 border border-blue-300' : 'bg-gray-50'
+                  }`}
+                >
+                  <div className="flex items-center">
+                    {getRankIcon(index + 1)}
+                    <span className="ml-2 text-sm font-medium text-gray-700">
+                      <PlayerDisplayName
+                        walletAddress={entry.walletAddress}
+                        username={entry.username}
+                      />
+                      {isCurrentPlayer && (
+                        <span className="text-xs text-blue-600 ml-1">(You)</span>
+                      )}
+                    </span>
+                  </div>
+                  <span className="text-sm font-bold text-gray-900">
+                    {formatScore(entry.bestScore)}
+                  </span>
+                </div>
+              );
+            })
+          )}
         </div>
       </div>
     </div>

--- a/components/game/TriviaQuestion.tsx
+++ b/components/game/TriviaQuestion.tsx
@@ -139,12 +139,10 @@ export default function TriviaQuestion({
         : 'bg-gray-50 border-gray-200 text-gray-500';
     }
 
-    if (resolvedCorrect !== null && index === resolvedCorrect) {
-      return 'bg-green-100 border-green-500 text-green-800';
-    }
-
-    if (index === selectedAnswer && resolvedCorrect !== null && index !== resolvedCorrect) {
-      return 'bg-red-100 border-red-500 text-red-800';
+    if (index === selectedAnswer && resolvedCorrect !== null) {
+      return index === resolvedCorrect
+        ? 'bg-green-100 border-green-500 text-green-800'
+        : 'bg-red-100 border-red-500 text-red-800';
     }
 
     return 'bg-gray-50 border-gray-200 text-gray-500';

--- a/components/leaderboard/TopEarners.tsx
+++ b/components/leaderboard/TopEarners.tsx
@@ -10,9 +10,15 @@ interface TopEarnersProps {
   limit?: number;
   className?: string;
   viewType?: LeaderboardViewType;
+  currentWalletAddress?: string;
 }
 
-export default function TopEarners({ limit = 10, className = '', viewType = 'scores' }: TopEarnersProps) {
+export default function TopEarners({
+  limit = 10,
+  className = '',
+  viewType = 'scores',
+  currentWalletAddress,
+}: TopEarnersProps) {
   const { topEarners, isLoading, error } = useTopEarners(limit, { viewType });
 
   const formatScore = (score: number) => {
@@ -29,7 +35,7 @@ export default function TopEarners({ limit = 10, className = '', viewType = 'sco
   // 3. Shortened wallet address
   const PlayerDisplayName = ({ walletAddress, username }: { walletAddress: string; username?: string }) => {
     if (username) {
-      return <span className="text-[#ffffff] text-[12px]">{username.toUpperCase()}</span>;
+      return <span className="text-[#ffffff] text-[12px]">{username}</span>;
     }
     
     return (
@@ -72,10 +78,16 @@ export default function TopEarners({ limit = 10, className = '', viewType = 'sco
 
   return (
     <div className={`w-full ${className}`}>
-      {topEarners.map((earner, index) => (
+      {topEarners.map((earner, index) => {
+        const isCurrentPlayer =
+          currentWalletAddress &&
+          earner.walletAddress.toLowerCase() === currentWalletAddress.toLowerCase();
+        return (
         <div 
           key={earner.walletAddress}
-          className="content-stretch flex items-center justify-between relative shrink-0 w-full mb-3"
+          className={`content-stretch flex items-center justify-between relative shrink-0 w-full mb-3 ${
+            isCurrentPlayer ? 'rounded-lg bg-white/10 px-2 py-1 -mx-2' : ''
+          }`}
         >
           <div className="content-stretch flex gap-4 items-center justify-start relative shrink-0">
             <div className="font-['Audiowide:Regular',_sans-serif] leading-[0] not-italic relative shrink-0 text-[#ffffff] text-[12px] w-5">
@@ -97,6 +109,9 @@ export default function TopEarners({ limit = 10, className = '', viewType = 'sco
                     walletAddress={earner.walletAddress} 
                     username={earner.username} 
                   />
+                  {isCurrentPlayer && (
+                    <span className="text-[10px] text-purple-300 ml-1">(You)</span>
+                  )}
                 </p>
               </div>
             </div>
@@ -110,7 +125,8 @@ export default function TopEarners({ limit = 10, className = '', viewType = 'sco
             </p>
           </div>
         </div>
-      ))}
+        );
+      })}
       {topEarners.length === 0 && (
         <div className="text-gray-400 text-sm text-center p-4">
           No winners yet. Be the first!

--- a/components/social/ComposeCastButton.tsx
+++ b/components/social/ComposeCastButton.tsx
@@ -30,15 +30,15 @@ export default function ComposeCastButton({
     
     switch (achievementType) {
       case 'high-score':
-        return `${baseText} 🏆 Scored ${score} USDC and set a new high score! Can you beat me?`;
+        return `${baseText} 🏆 Scored ${score} points and set a new high score! Can you beat me?`;
       case 'game-complete':
-        return `${baseText} 🎉 Completed all ${totalRounds} rounds with ${score} USDC total! Ready for the challenge?`;
+        return `${baseText} 🎉 Completed all ${totalRounds} rounds with ${score} points! Ready for the challenge?`;
       case 'round-win':
-        return `${baseText} 🥇 Won Round ${round} with ${score} USDC! Think you can do better?`;
+        return `${baseText} 🥇 Won Round ${round} with ${score} points! Think you can do better?`;
       case 'perfect-round':
-        return `${baseText} ⭐ Perfect Round ${round}! Got every question right for ${score} USDC!`;
+        return `${baseText} ⭐ Perfect Round ${round}! Got every question right for ${score} points!`;
       default:
-        return `${baseText} Scored ${score} USDC! Can you beat my score?`;
+        return `${baseText} Scored ${score} points! Can you beat my score?`;
     }
   };
 

--- a/lib/apis/spacetime.ts
+++ b/lib/apis/spacetime.ts
@@ -502,8 +502,9 @@ class SpacetimeDBClient {
   getPlayerProfile(walletAddress: string): Player | null {
     if (!this.connection) return null;
 
+    const normalized = walletAddress.toLowerCase();
     const players = (Array.from(this.connection.db.players.iter()) as Player[]).filter(
-      (p: Player) => p.walletAddress === walletAddress
+      (p: Player) => p.walletAddress.toLowerCase() === normalized
     );
 
     return players.length > 0 ? players[0] : null;


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Addresses post-merge UX feedback across funding, gameplay, leaderboard, and navigation.

## Changes

### Funding
- **Add More USDC** button always visible when wallet is connected (not hidden when balance ≥ 1 USDC)
- ETH section in `SubAccountDisplay` remains gas-only
- Removed **Bridge ETH from another network** link (not integrated into the app)

### Gameplay
- Removed correct-answer reveal on unselected options
- Selected answer still shows green/red with **✓ Correct** / **✗ Incorrect** feedback

### Leaderboard
- Post-game scores now use **Spacetime top 10** (same source as home TOP EARNERS)
- Wallet addresses normalized to lowercase for consistent matching
- Basename/username passed to `save-paid-score` and shown on leaderboard (no forced uppercase)
- Current player highlighted with **(You)** on home and post-game lists
- **Share** button appears when you land in the top 10

### Navigation
- **← Back to Home** on game entry / mode selection screen
- Leaving multiplayer lobby returns to home (not back into game entry)

## Testing
1. Connect wallet with ≥ 1 USDC — confirm **Add More USDC** is visible
2. Play a paid game — wrong answers should not reveal the correct option
3. Finish with a top-10 score — confirm you appear on leaderboard with correct name and share button
4. From game entry, tap **Back to Home** — returns to main screen with TOP EARNERS
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-aba6ca61-278f-4b95-9b69-8524171f332b"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-aba6ca61-278f-4b95-9b69-8524171f332b"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

