### PR TITLE
Fix paid game start and weekly payout interval

### DIFF
--- a/app/api/game-session/route.ts
+++ b/app/api/game-session/route.ts
@@ -187,6 +187,37 @@ export async function POST(req: NextRequest) {
       }
 
       if (!useMemoryLobbyForPaidMultiplayer) {
+        if (!token) {
+          console.error('No entry token provided');
+          return NextResponse.json({ error: 'Entry token required' }, { status: 401 });
+        }
+
+        const validation = validatePlayerAccess(token);
+        if (!validation.isValid) {
+          return NextResponse.json(
+            { error: validation.error || 'Invalid or expired entry token' },
+            { status: 401 }
+          );
+        }
+
+        const playerInfo = validation.playerInfo!;
+
+        if (playerInfo.entryId !== entryId) {
+          return NextResponse.json({ error: 'Entry ID mismatch' }, { status: 401 });
+        }
+
+        const actualIsPaidPlayer = playerInfo.playerType === 'paid';
+
+        const mode: JoinPlayerMode = actualIsPaidPlayer
+          ? playerMode === 'paid_multiplayer'
+            ? 'paid_multiplayer'
+            : 'paid_solo'
+          : 'trial';
+
+        if (!playerId || typeof playerId !== 'string') {
+          return NextResponse.json({ error: 'Player ID required' }, { status: 400 });
+        }
+
         try {
           await spacetimeClient.initialize();
 
@@ -209,71 +240,46 @@ export async function POST(req: NextRequest) {
         } catch {
           console.warn('⚠️ SpacetimeDB initialization failed, using memory fallback');
         }
-      }
 
-      if (!token) {
-        console.error('No entry token provided');
-        return NextResponse.json({ error: 'Entry token required' }, { status: 401 });
-      }
+        let s;
+        try {
+          s = memJoin(actualIsPaidPlayer, playerId, {
+            playerMode: mode,
+            lobbyDurationSec: typeof lobbyDurationSec === 'number' ? lobbyDurationSec : undefined,
+            walletAddress: playerInfo.walletAddress || undefined,
+          });
+        } catch (e) {
+          const msg = e instanceof Error ? e.message : 'Cannot join session';
+          return NextResponse.json({ error: msg }, { status: 409 });
+        }
 
-      const validation = validatePlayerAccess(token);
-      if (!validation.isValid) {
-        return NextResponse.json(
-          { error: validation.error || 'Invalid or expired entry token' },
-          { status: 401 }
-        );
-      }
+        reconcileLobbyToActive();
+        const timeRemaining = memTime(s);
+        const lobbyTimeRemaining = getLobbyTimeRemainingSeconds(s);
+        const inLobby = s.status === 'lobby';
+        const isFirstPaidPlayer =
+          actualIsPaidPlayer && s.paid_player_count === 1 && (s.status === 'active' || s.status === 'lobby');
+        const waitingForPaidPlayer = s.paid_player_count === 0 && !inLobby;
 
-      const playerInfo = validation.playerInfo!;
+        const isWaiting = s.status === 'waiting';
+        const isLobbyOpen = inLobby && lobbyTimeRemaining > 0;
+        const isActiveWithTime = s.status === 'active' && s.paid_player_count > 0 && timeRemaining > 0;
+        const hasNoPaidPlayers = s.paid_player_count === 0;
+        const canJoin = isWaiting || isLobbyOpen || isActiveWithTime || hasNoPaidPlayers;
 
-      if (playerInfo.entryId !== entryId) {
-        return NextResponse.json({ error: 'Entry ID mismatch' }, { status: 401 });
-      }
-
-      const actualIsPaidPlayer = playerInfo.playerType === 'paid';
-
-      const mode: JoinPlayerMode = actualIsPaidPlayer
-        ? playerMode === 'paid_multiplayer'
-          ? 'paid_multiplayer'
-          : 'paid_solo'
-        : 'trial';
-
-      let s;
-      try {
-        s = memJoin(actualIsPaidPlayer, playerId, {
-          playerMode: mode,
-          lobbyDurationSec: typeof lobbyDurationSec === 'number' ? lobbyDurationSec : undefined,
-          walletAddress: playerInfo.walletAddress || undefined,
+        return NextResponse.json({
+          session: s,
+          timeRemaining,
+          lobbyTimeRemaining,
+          inLobby,
+          isFirstPaidPlayer,
+          waitingForPaidPlayer,
+          canJoin,
+          source: 'memory',
         });
-      } catch (e) {
-        const msg = e instanceof Error ? e.message : 'Cannot join session';
-        return NextResponse.json({ error: msg }, { status: 409 });
       }
 
-      reconcileLobbyToActive();
-      const timeRemaining = memTime(s);
-      const lobbyTimeRemaining = getLobbyTimeRemainingSeconds(s);
-      const inLobby = s.status === 'lobby';
-      const isFirstPaidPlayer =
-        actualIsPaidPlayer && s.paid_player_count === 1 && (s.status === 'active' || s.status === 'lobby');
-      const waitingForPaidPlayer = s.paid_player_count === 0 && !inLobby;
-
-      const isWaiting = s.status === 'waiting';
-      const isLobbyOpen = inLobby && lobbyTimeRemaining > 0;
-      const isActiveWithTime = s.status === 'active' && s.paid_player_count > 0 && timeRemaining > 0;
-      const hasNoPaidPlayers = s.paid_player_count === 0;
-      const canJoin = isWaiting || isLobbyOpen || isActiveWithTime || hasNoPaidPlayers;
-
-      return NextResponse.json({
-        session: s,
-        timeRemaining,
-        lobbyTimeRemaining,
-        inLobby,
-        isFirstPaidPlayer,
-        waitingForPaidPlayer,
-        canJoin,
-        source: 'memory',
-      });
+      return NextResponse.json({ error: 'Invalid join request' }, { status: 400 });
     }
 
     if (action === 'end_lobby') {

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -81,6 +81,7 @@ function HomePage() {
   const { data: basename } = useBasename(address ?? undefined);
   const playerDisplayName = basename ?? (address ? `${address.slice(0, 6)}...${address.slice(-4)}` : 'Player');
   const [joinGameStartError, setJoinGameStartError] = useState<string | null>(null);
+  const [isJoiningAfterPayment, setIsJoiningAfterPayment] = useState(false);
   const { trialStatus, incrementTrialGame } = useTrialStatus(address as string, entryToken ?? undefined);
   
   // Add contract USDC balance hook
@@ -269,6 +270,9 @@ function HomePage() {
     walletUniversalAddress,
   }: GameStartOptions) => {
     setJoinGameStartError(null);
+    if (!isTrial) {
+      setIsJoiningAfterPayment(true);
+    }
     try {
       const data = await joinGame(!isTrial, paidTxHash, {
         playerMode,
@@ -295,6 +299,8 @@ function HomePage() {
         error instanceof Error ? error.message : 'Could not join the game. Please try again.';
       setJoinGameStartError(message);
       setShowGameEntry(true);
+    } finally {
+      setIsJoiningAfterPayment(false);
     }
   };
 
@@ -668,6 +674,7 @@ function HomePage() {
             onDismissJoinStartError={() => setJoinGameStartError(null)}
             sessionBusy={!canJoin}
             sessionTimeRemaining={timeRemaining}
+            isJoiningAfterPayment={isJoiningAfterPayment}
           />
           {/* Debug info */}
           {/* <div className="text-xs text-gray-500 text-center mt-2">

--- a/components/base-account/BaseAccountTransaction.tsx
+++ b/components/base-account/BaseAccountTransaction.tsx
@@ -5,8 +5,13 @@ import { Button } from '@/components/ui/button';
 import { useBaseAccount } from '@/hooks/useBaseAccount';
 import { useBaseAccountContext } from '@/components/providers/BaseAccountProvider';
 import { getBaseAccountProvider } from '@/lib/base-account/sdk';
+import {
+  sendAtomicBatchCalls,
+  sendSequentialTransactions,
+  supportsAtomicBatch,
+} from '@/lib/base-account/batchCalls';
 import { base } from 'viem/chains';
-import { createPublicClient, http, numberToHex, type Hex } from 'viem';
+import { createPublicClient, http, type Hex } from 'viem';
 import { Loader2, CheckCircle, XCircle } from 'lucide-react';
 
 const basePublicClient = createPublicClient({
@@ -15,8 +20,10 @@ const basePublicClient = createPublicClient({
 });
 
 export type BaseAccountTxStatusExtras = {
-  /** Last `eth_sendTransaction` hash (e.g. `joinBattle` after approve in a batch). */
+  /** Last tx hash (joinBattle op — from batch or sequential send). */
   lastTxHash?: string;
+  /** True when approve + join were batched into one wallet confirmation. */
+  usedBatch?: boolean;
 };
 
 export type BaseAccountTransactionHandle = {
@@ -49,12 +56,12 @@ const BaseAccountTransaction = forwardRef<BaseAccountTransactionHandle, BaseAcco
   ) {
   const { isConnected: hookConnected, address: hookAddress } = useBaseAccount();
   const { provider: contextProvider } = useBaseAccountContext();
-  // Prefer parent-provided address to avoid race condition where hook hasn't resolved yet
   const address = connectedAddress || hookAddress;
   const isConnected = Boolean(address) || hookConnected;
   const [isLoading, setIsLoading] = useState(false);
   const [status, setStatus] = useState<'idle' | 'pending' | 'success' | 'error'>('idle');
   const [message, setMessage] = useState<string>('');
+  const [usedBatch, setUsedBatch] = useState(false);
   const inFlightRef = useRef(false);
 
   const handleTransaction = useCallback(async () => {
@@ -67,77 +74,71 @@ const BaseAccountTransaction = forwardRef<BaseAccountTransactionHandle, BaseAcco
 
     setIsLoading(true);
     setStatus('pending');
+    setUsedBatch(false);
     onStatus?.('pending', 'Transaction pending...');
 
     try {
       const provider = contextProvider ?? getBaseAccountProvider();
 
-      // Smart accounts (4337): each user op bumps the account nonce on-chain only after
-      // inclusion. Sending approve + joinBattle back-to-back causes AA25 invalid account nonce
-      // on the second op — wait for each receipt before the next send.
       if (calls.length === 0) {
         throw new Error('No transaction calls provided');
       }
 
-      const results: string[] = [];
-      for (let i = 0; i < calls.length; i++) {
-        const call = calls[i];
-        const result = (await provider.request({
-          method: 'eth_sendTransaction',
-          params: [{
-            from: address,
-            to: call.to,
-            value: call.value,
-            data: call.data,
-            chainId: numberToHex(base.id),
-          }]
-        })) as Hex;
+      let lastTxHash: string | undefined;
+      let batchPath = false;
 
-        results.push(result);
+      const canBatch =
+        calls.length > 1 && (await supportsAtomicBatch(provider, address));
 
-        const receipt = await basePublicClient.waitForTransactionReceipt({
-          hash: result,
-          timeout: 180_000,
-        });
-
-        if (receipt.status !== 'success') {
-          throw new Error(
-            `Transaction ${i + 1} of ${calls.length} reverted on-chain. Try again in a moment.`
-          );
-        }
+      if (canBatch) {
+        batchPath = true;
+        onStatus?.('pending', 'Confirm once in your wallet (approve + join)...');
+        lastTxHash = await sendAtomicBatchCalls(provider, address, calls);
+      } else {
+        onStatus?.('pending', 'Confirm in your wallet (step 1 of 2)...');
+        lastTxHash = await sendSequentialTransactions(
+          provider,
+          address,
+          calls,
+          (hash) =>
+            basePublicClient.waitForTransactionReceipt({
+              hash,
+              timeout: 180_000,
+            })
+        );
       }
 
-      const lastTxHash = results.length > 0 ? results[results.length - 1] : undefined;
-      console.log('Transactions confirmed:', results);
+      setUsedBatch(batchPath);
+      console.log('Transaction confirmed:', lastTxHash, { batch: batchPath });
       setStatus('success');
-      setMessage('Transaction successful!');
-      onStatus?.('success', 'Transaction successful!', { lastTxHash });
-    } catch (error: any) {
-      // Safely serialize error to avoid BigInt serialization issues
+      setMessage(batchPath ? 'Payment confirmed!' : 'Transaction successful!');
+      onStatus?.('success', 'Transaction successful!', { lastTxHash, usedBatch: batchPath });
+    } catch (error: unknown) {
+      const err = error as { message?: string; code?: number; name?: string };
       const safeError = {
-        message: error?.message || 'Unknown error',
-        code: error?.code,
-        name: error?.name
+        message: err?.message || 'Unknown error',
+        code: err?.code,
+        name: err?.name,
       };
       console.error('Transaction failed:', safeError);
       setStatus('error');
-      
+
       let errorMessage = 'Transaction failed';
-      if (error?.code === 4001) {
+      if (err?.code === 4001) {
         errorMessage = 'Transaction rejected by user';
-      } else if (error?.code === 5740) {
+      } else if (err?.code === 5740) {
         errorMessage = 'Transaction too large for wallet to process';
-      } else if (error?.message) {
-        errorMessage = error.message;
+      } else if (err?.message) {
+        errorMessage = err.message;
       }
-      
+
       setMessage(errorMessage);
       onStatus?.('error', errorMessage);
     } finally {
       setIsLoading(false);
       inFlightRef.current = false;
     }
-  }, [isConnected, address, calls, onStatus]);
+  }, [isConnected, address, calls, onStatus, contextProvider]);
 
   useImperativeHandle(
     ref,
@@ -161,6 +162,10 @@ const BaseAccountTransaction = forwardRef<BaseAccountTransactionHandle, BaseAcco
         return null;
     }
   };
+
+  const pendingMessage = usedBatch
+    ? 'Confirm once in your wallet, then wait for on-chain confirmation…'
+    : 'Confirm in your wallet, then wait for on-chain confirmation…';
 
   return (
     <div className={className}>
@@ -194,17 +199,15 @@ const BaseAccountTransaction = forwardRef<BaseAccountTransactionHandle, BaseAcco
           {isLoading ? (
             <>
               <Loader2 className="h-8 w-8 animate-spin text-amber-400" aria-hidden />
-              <span className="text-sm text-zinc-300">
-                Confirm in your wallet, then wait for on-chain confirmation…
-              </span>
+              <span className="text-sm text-zinc-300">{pendingMessage}</span>
             </>
           ) : null}
         </div>
       )}
       {message && (
         <div className={`mt-2 text-sm text-center ${
-          status === 'success' ? 'text-green-400' : 
-          status === 'error' ? 'text-red-400' : 
+          status === 'success' ? 'text-green-400' :
+          status === 'error' ? 'text-red-400' :
           'text-gray-400'
         }`}>
           {message}

--- a/components/game/GameEntry.tsx
+++ b/components/game/GameEntry.tsx
@@ -29,6 +29,11 @@ import { TRIVIA_CONTRACT_ADDRESS } from '@/lib/blockchain/contracts';
 import { base } from 'viem/chains';
 import type { GameStartOptions, PlayerModeChoice } from '@/types/game';
 import type { BaseAccountTxStatusExtras } from '@/components/base-account/BaseAccountTransaction';
+import {
+  savePendingPaidEntry,
+  loadPendingPaidEntry,
+  type PendingPaidEntry,
+} from '@/lib/game/pendingPaidEntry';
 
 interface GameEntryProps {
   onGameStart: (options: GameStartOptions) => void | Promise<void>;
@@ -41,6 +46,8 @@ interface GameEntryProps {
   sessionBusy?: boolean;
   /** seconds remaining in the active round (from server) */
   sessionTimeRemaining?: number;
+  /** Parent shows full-screen overlay while verifying payment + joining */
+  isJoiningAfterPayment?: boolean;
 }
 
 export default function GameEntry({
@@ -52,6 +59,7 @@ export default function GameEntry({
   onDismissJoinStartError,
   sessionBusy = false,
   sessionTimeRemaining = 0,
+  isJoiningAfterPayment = false,
 }: GameEntryProps) {
   const isPaidMode = playerModeChoice === 'paid_solo' || playerModeChoice === 'paid_multiplayer';
   console.log('GameEntry received playerModeChoice:', playerModeChoice);
@@ -77,6 +85,11 @@ export default function GameEntry({
   const paidTxRef = useRef<BaseAccountTransactionHandle>(null);
   const generatingAddressRef = useRef<string | null>(null);
   const paymasterConfigured = Boolean(process.env.NEXT_PUBLIC_PAYMASTER_AND_BUNDLER_ENDPOINT);
+  const [pendingPaidEntry, setPendingPaidEntry] = useState<PendingPaidEntry | null>(null);
+
+  useEffect(() => {
+    setPendingPaidEntry(loadPendingPaidEntry(address));
+  }, [address, joinStartError]);
 
   // Local countdown timer that ticks every second from the server-provided value
   const [localCountdown, setLocalCountdown] = useState(sessionTimeRemaining);
@@ -157,14 +170,32 @@ export default function GameEntry({
     
     if (status === 'success') {
       console.log('Paid game transaction successful!');
+      const paidTxHash = extras?.lastTxHash;
+      if (!paidTxHash) {
+        setError('Payment succeeded but no transaction hash was returned. Check your wallet activity and use Continue paid game.');
+        setIsProcessingPayment(false);
+        setAwaitingWalletOpen(true);
+        setIsStartingGame(false);
+        return;
+      }
+
+      if (address) {
+        savePendingPaidEntry({
+          paidTxHash,
+          playerMode: playerModeChoice,
+          walletAddress: address,
+          walletUniversalAddress: universalAddress ?? undefined,
+        });
+        setPendingPaidEntry(loadPendingPaidEntry(address));
+      }
+
       setIsProcessingPayment(false);
       setAwaitingWalletOpen(false);
-      setIsStartingGame(false);
       setTransactionError(null);
       setError(null);
       void onGameStart({
         isTrial: false,
-        paidTxHash: extras?.lastTxHash,
+        paidTxHash,
         playerMode: playerModeChoice,
         walletUniversalAddress: universalAddress ?? undefined,
       });
@@ -412,13 +443,22 @@ export default function GameEntry({
   };
 
   const handlePaymentSuccess = () => {
-    setError(null);
+    setError(
+      'USDC added to your wallet. Tap Start paid game to approve and join on-chain (one wallet confirmation).'
+    );
     setShowPayment(false);
-    // USDC onramp only — no joinBattle hash; server may reject paid verification until user completes on-chain join.
+  };
+
+  const handleContinuePendingPaid = () => {
+    const pending = pendingPaidEntry ?? loadPendingPaidEntry(address);
+    if (!pending?.paidTxHash) return;
+    setError(null);
+    onDismissJoinStartError?.();
     void onGameStart({
       isTrial: false,
-      playerMode: playerModeChoice,
-      walletUniversalAddress: universalAddress ?? undefined,
+      paidTxHash: pending.paidTxHash,
+      playerMode: pending.playerMode,
+      walletUniversalAddress: pending.walletUniversalAddress,
     });
   };
 
@@ -523,22 +563,57 @@ export default function GameEntry({
 
       {joinStartError ? (
         <div
-          className="rounded-lg border border-red-500/40 bg-red-950/40 px-3 py-3 text-sm text-red-200"
-          role="alert"
+          className="rounded-lg border border-red-500/60 bg-red-950/60 px-4 py-4 text-sm text-red-100 shadow-lg"
+          role="alertdialog"
+          aria-labelledby="join-error-title"
         >
-          <div className="flex items-start justify-between gap-2">
-            <span>{joinStartError}</span>
-            {onDismissJoinStartError ? (
-              <button
+          <p id="join-error-title" className="font-semibold text-red-50 mb-1">
+            Payment received — game did not start
+          </p>
+          <p className="mb-3">{joinStartError}</p>
+          <div className="flex flex-col gap-2 sm:flex-row">
+            {(pendingPaidEntry ?? loadPendingPaidEntry(address)) ? (
+              <Button
                 type="button"
+                onClick={handleContinuePendingPaid}
+                className="bg-amber-500 hover:bg-amber-400 text-black"
+                aria-label="Retry starting game with your existing payment"
+              >
+                Retry with same payment
+              </Button>
+            ) : null}
+            {onDismissJoinStartError ? (
+              <Button
+                type="button"
+                variant="outline"
                 onClick={onDismissJoinStartError}
-                className="shrink-0 text-red-300 underline text-xs focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-red-400 rounded"
+                className="border-red-400/50 text-red-100"
                 aria-label="Dismiss error"
               >
                 Dismiss
-              </button>
+              </Button>
             ) : null}
           </div>
+        </div>
+      ) : null}
+
+      {pendingPaidEntry && !joinStartError && !isJoiningAfterPayment ? (
+        <div
+          className="rounded-lg border border-amber-500/40 bg-amber-950/30 px-4 py-3 text-sm text-amber-100"
+          role="status"
+        >
+          <p className="font-medium text-amber-50">You have a paid entry waiting</p>
+          <p className="text-xs text-amber-200/80 mt-1 mb-3">
+            Your USDC payment is on-chain. Continue without paying again.
+          </p>
+          <Button
+            type="button"
+            onClick={handleContinuePendingPaid}
+            className="w-full bg-amber-500 hover:bg-amber-400 text-black"
+            aria-label="Continue paid game without paying again"
+          >
+            Continue paid game
+          </Button>
         </div>
       ) : null}
 
@@ -858,6 +933,23 @@ export default function GameEntry({
           )}
         </CardContent>
       </Card>
+
+      {isJoiningAfterPayment ? (
+        <div
+          className="fixed inset-0 z-50 flex items-center justify-center bg-black/80 px-4"
+          role="status"
+          aria-live="polite"
+          aria-label="Starting game after payment"
+        >
+          <div className="max-w-sm rounded-xl border border-amber-500/40 bg-zinc-900 px-6 py-8 text-center shadow-xl">
+            <Loader2 className="mx-auto h-10 w-10 animate-spin text-amber-400 mb-4" aria-hidden />
+            <p className="text-lg font-semibold text-white">Starting your game</p>
+            <p className="mt-2 text-sm text-zinc-300">
+              Confirming payment on-chain and joining the session…
+            </p>
+          </div>
+        </div>
+      ) : null}
     </div>
   );
 }

--- a/hooks/useGameSession.ts
+++ b/hooks/useGameSession.ts
@@ -1,6 +1,8 @@
 import { useState, useEffect, useCallback } from 'react';
 import { useBaseAccount } from './useBaseAccount';
 import type { PlayerModeChoice } from '@/types/game';
+import { retryWithBackoff } from '@/lib/game/retryWithBackoff';
+import { clearPendingPaidEntry } from '@/lib/game/pendingPaidEntry';
 
 export interface GameSessionPlayer {
   id: string;
@@ -137,7 +139,7 @@ export const useGameSession = (): UseGameSessionReturn => {
       }
 
       if (isPaidPlayer && !transactionHash) {
-        console.warn('⚠️ Paid game started without transaction hash - this may cause issues');
+        throw new Error('Payment transaction hash missing. Please retry or use Continue paid game.');
       }
 
       const currentPlayerId = playerId || `player_${Date.now()}_${Math.random().toString(36).substr(2, 9)}`;
@@ -145,31 +147,42 @@ export const useGameSession = (): UseGameSessionReturn => {
         setPlayerId(currentPlayerId);
       }
 
-      const sessionId = (await (await fetch('/api/game-session')).json()).session.session_id as string;
+      const modeParam = options?.playerMode ?? (isPaidPlayer ? 'paid_solo' : 'trial');
+      const sessionId = (
+        await (
+          await fetch(`/api/game-session?mode=${encodeURIComponent(modeParam)}`)
+        ).json()
+      ).session.session_id as string;
 
-      const entryResp = await fetch('/api/game-entry', {
-        method: 'POST',
-        headers: { 'Content-Type': 'application/json' },
-        body: JSON.stringify({
-          sessionId,
-          isTrial: !isPaidPlayer,
-          walletAddress: isPaidPlayer ? address : undefined,
-          paidTxHash: isPaidPlayer ? transactionHash : undefined,
-          walletUniversalAddress:
-            isPaidPlayer && options?.walletUniversalAddress
-              ? options.walletUniversalAddress
-              : undefined,
-        }),
+      const entryResp = await retryWithBackoff(async () => {
+        const resp = await fetch('/api/game-entry', {
+          method: 'POST',
+          headers: { 'Content-Type': 'application/json' },
+          body: JSON.stringify({
+            sessionId,
+            isTrial: !isPaidPlayer,
+            walletAddress: isPaidPlayer ? address : undefined,
+            paidTxHash: isPaidPlayer ? transactionHash : undefined,
+            walletUniversalAddress:
+              isPaidPlayer && options?.walletUniversalAddress
+                ? options.walletUniversalAddress
+                : undefined,
+          }),
+        });
+
+        if (!resp.ok) {
+          let msg = 'Entry not allowed';
+          try {
+            const err = await resp.json();
+            msg = (err as { error?: string }).error || msg;
+          } catch {
+            /* ignore */
+          }
+          throw new Error(msg);
+        }
+
+        return resp;
       });
-
-      if (!entryResp.ok) {
-        let msg = 'Entry not allowed';
-        try {
-          const err = await entryResp.json();
-          msg = (err as { error?: string }).error || msg;
-        } catch {}
-        throw new Error(msg);
-      }
 
       const { entryId, token, onChainSessionId } = await entryResp.json();
 
@@ -220,6 +233,7 @@ export const useGameSession = (): UseGameSessionReturn => {
       const data = (await response.json()) as Record<string, unknown>;
       applySessionPayload(data);
       saveEntryToken(token as string);
+      clearPendingPaidEntry();
       return data;
     },
     [playerId, address, applySessionPayload, saveEntryToken]

--- a/hooks/useGameSession.ts
+++ b/hooks/useGameSession.ts
@@ -148,11 +148,17 @@ export const useGameSession = (): UseGameSessionReturn => {
       }
 
       const modeParam = options?.playerMode ?? (isPaidPlayer ? 'paid_solo' : 'trial');
-      const sessionId = (
-        await (
-          await fetch(`/api/game-session?mode=${encodeURIComponent(modeParam)}`)
-        ).json()
-      ).session.session_id as string;
+      const sessionResp = await fetch(
+        `/api/game-session?mode=${encodeURIComponent(modeParam)}`
+      );
+      if (!sessionResp.ok) {
+        throw new Error(`Failed to fetch game session: ${sessionResp.statusText}`);
+      }
+      const sessionData = await sessionResp.json();
+      const sessionId = sessionData?.session?.session_id as string | undefined;
+      if (!sessionId) {
+        throw new Error('No active game session found');
+      }
 
       const entryResp = await retryWithBackoff(async () => {
         const resp = await fetch('/api/game-entry', {

--- a/lib/base-account/batchCalls.ts
+++ b/lib/base-account/batchCalls.ts
@@ -41,7 +41,7 @@ export const supportsAtomicBatch = async (
       method: 'wallet_getCapabilities',
       params: [address],
     })) as CapabilitiesMap;
-    const chainKey = String(base.id);
+    const chainKey = numberToHex(base.id);
     return Boolean(capabilities?.[chainKey]?.atomicBatch?.supported);
   } catch {
     return false;
@@ -62,7 +62,7 @@ const isBatchConfirmed = (status: CallsStatusResult): boolean => {
 
 const isBatchFailed = (status: CallsStatusResult): boolean => {
   const s = status.status;
-  if (s === 100 || s === 'PENDING' || s === 'pending') return false;
+  if (!s || s === 100 || s === 'PENDING' || s === 'pending') return false;
   return !isBatchConfirmed(status);
 };
 

--- a/lib/base-account/batchCalls.ts
+++ b/lib/base-account/batchCalls.ts
@@ -1,0 +1,169 @@
+import { base } from 'viem/chains';
+import { numberToHex, type Hex } from 'viem';
+import { BUILDER_CODE_DATA_SUFFIX } from '@/lib/blockchain/builderCode';
+
+export type BatchCallInput = {
+  to: `0x${string}`;
+  value: `0x${string}`;
+  data: `0x${string}`;
+};
+
+type WalletProvider = {
+  request: (args: {
+    method: string;
+    params?: object | readonly unknown[] | undefined;
+  }) => Promise<unknown>;
+};
+
+type CapabilitiesMap = Record<
+  string,
+  {
+    atomicBatch?: { supported?: boolean };
+  }
+>;
+
+type CallsStatusResult = {
+  status?: number | string;
+  receipts?: Array<{ transactionHash?: string }>;
+};
+
+const BATCH_POLL_INTERVAL_MS = 2_000;
+const BATCH_POLL_TIMEOUT_MS = 180_000;
+
+const sleep = (ms: number) => new Promise((resolve) => setTimeout(resolve, ms));
+
+export const supportsAtomicBatch = async (
+  provider: WalletProvider,
+  address: string
+): Promise<boolean> => {
+  try {
+    const capabilities = (await provider.request({
+      method: 'wallet_getCapabilities',
+      params: [address],
+    })) as CapabilitiesMap;
+    const chainKey = String(base.id);
+    return Boolean(capabilities?.[chainKey]?.atomicBatch?.supported);
+  } catch {
+    return false;
+  }
+};
+
+const extractLastTxHash = (status: CallsStatusResult): string | undefined => {
+  const receipts = status.receipts;
+  if (!receipts?.length) return undefined;
+  const last = receipts[receipts.length - 1];
+  return last?.transactionHash;
+};
+
+const isBatchConfirmed = (status: CallsStatusResult): boolean => {
+  const s = status.status;
+  return s === 200 || s === 'CONFIRMED' || s === 'confirmed';
+};
+
+const isBatchFailed = (status: CallsStatusResult): boolean => {
+  const s = status.status;
+  if (s === 100 || s === 'PENDING' || s === 'pending') return false;
+  return !isBatchConfirmed(status);
+};
+
+export const pollBatchCallsStatus = async (
+  provider: WalletProvider,
+  callsId: string
+): Promise<string | undefined> => {
+  const deadline = Date.now() + BATCH_POLL_TIMEOUT_MS;
+
+  while (Date.now() < deadline) {
+    try {
+      const status = (await provider.request({
+        method: 'wallet_getCallsStatus',
+        params: [callsId],
+      })) as CallsStatusResult;
+
+      if (isBatchConfirmed(status)) {
+        return extractLastTxHash(status);
+      }
+      if (isBatchFailed(status)) {
+        throw new Error('Batch transaction reverted on-chain');
+      }
+    } catch (err) {
+      if (err instanceof Error && err.message.includes('reverted')) {
+        throw err;
+      }
+      // Temporary polling errors — retry until timeout
+    }
+
+    await sleep(BATCH_POLL_INTERVAL_MS);
+  }
+
+  throw new Error('Batch transaction timed out waiting for confirmation');
+};
+
+export const sendAtomicBatchCalls = async (
+  provider: WalletProvider,
+  from: string,
+  calls: BatchCallInput[]
+): Promise<string | undefined> => {
+  const batchCalls = calls.map((call) => ({
+    to: call.to,
+    value: call.value ?? '0x0',
+    data: call.data,
+  }));
+
+  const callsId = (await provider.request({
+    method: 'wallet_sendCalls',
+    params: [
+      {
+        version: '2.0.0',
+        from,
+        chainId: numberToHex(base.id),
+        atomicRequired: true,
+        calls: batchCalls,
+        capabilities: {
+          dataSuffix: { value: BUILDER_CODE_DATA_SUFFIX, optional: true },
+        },
+      },
+    ],
+  })) as string;
+
+  if (!callsId || typeof callsId !== 'string') {
+    throw new Error('wallet_sendCalls did not return a callsId');
+  }
+
+  return pollBatchCallsStatus(provider, callsId);
+};
+
+export const sendSequentialTransactions = async (
+  provider: WalletProvider,
+  from: string,
+  calls: BatchCallInput[],
+  waitForReceipt: (hash: Hex) => Promise<{ status: string }>
+): Promise<string | undefined> => {
+  const results: string[] = [];
+
+  for (let i = 0; i < calls.length; i++) {
+    const call = calls[i];
+    const result = (await provider.request({
+      method: 'eth_sendTransaction',
+      params: [
+        {
+          from,
+          to: call.to,
+          value: call.value,
+          data: call.data,
+          chainId: numberToHex(base.id),
+        },
+      ],
+    })) as Hex;
+
+    results.push(result);
+
+    const receipt = await waitForReceipt(result);
+    if (receipt.status !== 'success') {
+      throw new Error(
+        `Transaction ${i + 1} of ${calls.length} reverted on-chain. Try again in a moment.`
+      );
+    }
+  }
+
+  return results.length > 0 ? results[results.length - 1] : undefined;
+};

--- a/lib/blockchain/verifyPaidTx.ts
+++ b/lib/blockchain/verifyPaidTx.ts
@@ -102,7 +102,7 @@ function decodePlayerJoinedPlayerFromLog(log: {
   return decodePlayerJoinedFromLog(log)?.player ?? null;
 }
 
-async function getReceiptAndTransaction(hash: Hash) {
+async function getReceiptAndTransaction(hash: Hash, attempt = 1, maxAttempts = 3) {
   const urls = getPaidVerificationRpcUrls();
   let lastMessage = 'All RPC endpoints failed';
 
@@ -133,6 +133,16 @@ async function getReceiptAndTransaction(hash: Hash) {
       lastMessage = e instanceof Error ? e.message : String(e);
       continue;
     }
+  }
+
+  const retryable =
+    lastMessage.toLowerCase().includes('pending') ||
+    lastMessage.toLowerCase().includes('not found') ||
+    lastMessage.toLowerCase().includes('timeout');
+
+  if (retryable && attempt < maxAttempts) {
+    await new Promise((r) => setTimeout(r, Math.min(1000 * 2 ** (attempt - 1), 8000)));
+    return getReceiptAndTransaction(hash, attempt + 1, maxAttempts);
   }
 
   throw new Error(lastMessage);

--- a/lib/game/pendingPaidEntry.ts
+++ b/lib/game/pendingPaidEntry.ts
@@ -1,0 +1,72 @@
+import type { PlayerModeChoice } from '@/types/game';
+
+const STORAGE_KEY = 'bm_pending_paid_entry';
+const MAX_AGE_MS = 24 * 60 * 60 * 1000;
+
+export type PendingPaidEntry = {
+  paidTxHash: string;
+  playerMode: PlayerModeChoice;
+  walletAddress: string;
+  walletUniversalAddress?: string;
+  savedAt: number;
+};
+
+const normalizeAddress = (addr: string): string => {
+  const trimmed = addr.trim();
+  return trimmed.startsWith('0x') ? trimmed.toLowerCase() : `0x${trimmed}`.toLowerCase();
+};
+
+const getSessionStorage = (): Storage | null => {
+  if (typeof globalThis === 'undefined') return null;
+  try {
+    return globalThis.sessionStorage ?? globalThis.window?.sessionStorage ?? null;
+  } catch {
+    return null;
+  }
+};
+
+export const savePendingPaidEntry = (entry: Omit<PendingPaidEntry, 'savedAt'>): void => {
+  const storage = getSessionStorage();
+  if (!storage) return;
+  try {
+    const payload: PendingPaidEntry = { ...entry, savedAt: Date.now() };
+    storage.setItem(STORAGE_KEY, JSON.stringify(payload));
+  } catch {
+    /* ignore quota / private mode */
+  }
+};
+
+export const loadPendingPaidEntry = (
+  walletAddress?: string | null
+): PendingPaidEntry | null => {
+  const storage = getSessionStorage();
+  if (!storage) return null;
+  try {
+    const raw = storage.getItem(STORAGE_KEY);
+    if (!raw) return null;
+    const parsed = JSON.parse(raw) as PendingPaidEntry;
+    if (!parsed?.paidTxHash || !parsed?.walletAddress) return null;
+    if (Date.now() - parsed.savedAt > MAX_AGE_MS) {
+      clearPendingPaidEntry();
+      return null;
+    }
+    if (walletAddress) {
+      const want = normalizeAddress(walletAddress);
+      const have = normalizeAddress(parsed.walletAddress);
+      if (want !== have) return null;
+    }
+    return parsed;
+  } catch {
+    return null;
+  }
+};
+
+export const clearPendingPaidEntry = (): void => {
+  const storage = getSessionStorage();
+  if (!storage) return;
+  try {
+    storage.removeItem(STORAGE_KEY);
+  } catch {
+    /* ignore */
+  }
+};

--- a/lib/game/retryWithBackoff.ts
+++ b/lib/game/retryWithBackoff.ts
@@ -1,0 +1,53 @@
+export type RetryOptions = {
+  maxAttempts?: number;
+  initialDelayMs?: number;
+  maxDelayMs?: number;
+  shouldRetry?: (error: unknown, attempt: number) => boolean;
+};
+
+const defaultShouldRetry = (error: unknown): boolean => {
+  const message =
+    error instanceof Error
+      ? error.message
+      : typeof error === 'string'
+        ? error
+        : '';
+  const lower = message.toLowerCase();
+  return (
+    lower.includes('pending') ||
+    lower.includes('could not load transaction') ||
+    lower.includes('network') ||
+    lower.includes('fetch') ||
+    lower.includes('timeout') ||
+    lower.includes('503') ||
+    lower.includes('502')
+  );
+};
+
+export const retryWithBackoff = async <T>(
+  fn: () => Promise<T>,
+  options: RetryOptions = {}
+): Promise<T> => {
+  const maxAttempts = options.maxAttempts ?? 5;
+  const initialDelayMs = options.initialDelayMs ?? 1_000;
+  const maxDelayMs = options.maxDelayMs ?? 16_000;
+  const shouldRetry = options.shouldRetry ?? defaultShouldRetry;
+
+  let lastError: unknown;
+  let delayMs = initialDelayMs;
+
+  for (let attempt = 1; attempt <= maxAttempts; attempt++) {
+    try {
+      return await fn();
+    } catch (error) {
+      lastError = error;
+      if (attempt >= maxAttempts || !shouldRetry(error, attempt)) {
+        throw error;
+      }
+      await new Promise((resolve) => setTimeout(resolve, delayMs));
+      delayMs = Math.min(delayMs * 2, maxDelayMs);
+    }
+  }
+
+  throw lastError;
+};

--- a/lib/transaction/batchTransactions.ts
+++ b/lib/transaction/batchTransactions.ts
@@ -2,6 +2,7 @@ import { Interface } from 'ethers';
 import { base } from 'viem/chains';
 import { numberToHex } from 'viem';
 import { getBaseAccountProvider } from '@/lib/base-account/sdk';
+import { pollBatchCallsStatus } from '@/lib/base-account/batchCalls';
 import { BUILDER_CODE_DATA_SUFFIX } from '@/lib/blockchain/builderCode';
 
 export interface BatchCall {
@@ -44,35 +45,42 @@ export async function sendBatchCalls(options: BatchTransactionOptions): Promise<
       value: call.value || '0'
     })));
 
-    const result = (await provider.request({
+    const callsId = (await provider.request({
       method: 'wallet_sendCalls',
       params: [
-      {
-        version: '2.0.0',
-        from,
-        chainId: numberToHex(base.id),
-        atomicRequired,
-        calls: calls.map((call) => ({
-          to: call.to,
-          data: call.data,
-          value: call.value || '0x0',
-        })),
-        ...(gasless
-          ? {
-              capabilities: {
-                dataSuffix: { value: BUILDER_CODE_DATA_SUFFIX, optional: true },
-              },
-            }
-          : {}),
-      },
-    ],
-    })) as { transactionHash?: string; hash?: string };
+        {
+          version: '2.0.0',
+          from,
+          chainId: numberToHex(base.id),
+          atomicRequired,
+          calls: calls.map((call) => ({
+            to: call.to,
+            data: call.data,
+            value: call.value || '0x0',
+          })),
+          ...(gasless
+            ? {
+                capabilities: {
+                  dataSuffix: { value: BUILDER_CODE_DATA_SUFFIX, optional: true },
+                },
+              }
+            : {}),
+        },
+      ],
+    })) as string;
 
-    console.log('Batch transaction result:', result);
+    if (!callsId || typeof callsId !== 'string') {
+      throw new Error('wallet_sendCalls did not return a callsId');
+    }
+
+    console.log('Batch submitted, callsId:', callsId);
+
+    const transactionHash = (await pollBatchCallsStatus(provider, callsId)) ?? '';
 
     return {
-      transactionHash: (result?.transactionHash || result?.hash || '') as string,
-      success: true
+      transactionHash,
+      success: Boolean(transactionHash),
+      ...(transactionHash ? {} : { error: 'Batch completed without a transaction hash' }),
     };
 
   } catch (error) {

--- a/lib/transaction/batchTransactions.ts
+++ b/lib/transaction/batchTransactions.ts
@@ -1,4 +1,6 @@
 import { Interface } from 'ethers';
+import { base } from 'viem/chains';
+import { numberToHex } from 'viem';
 import { getBaseAccountProvider } from '@/lib/base-account/sdk';
 import { BUILDER_CODE_DATA_SUFFIX } from '@/lib/blockchain/builderCode';
 
@@ -9,6 +11,7 @@ export interface BatchCall {
 }
 
 export interface BatchTransactionOptions {
+  from: string;
   calls: BatchCall[];
   atomicRequired?: boolean;
   gasless?: boolean;
@@ -27,7 +30,7 @@ export interface BatchTransactionResult {
  */
 export async function sendBatchCalls(options: BatchTransactionOptions): Promise<BatchTransactionResult> {
   const provider = getBaseAccountProvider();
-  const { calls, atomicRequired = true, gasless = true } = options;
+  const { from, calls, atomicRequired = true, gasless = true } = options;
 
   if (!calls || calls.length === 0) {
     throw new Error('No calls provided for batch transaction');
@@ -43,18 +46,26 @@ export async function sendBatchCalls(options: BatchTransactionOptions): Promise<
 
     const result = (await provider.request({
       method: 'wallet_sendCalls',
-      params: {
-        calls: calls.map(call => ({
+      params: [
+      {
+        version: '2.0.0',
+        from,
+        chainId: numberToHex(base.id),
+        atomicRequired,
+        calls: calls.map((call) => ({
           to: call.to,
           data: call.data,
-          value: call.value || '0x0'
+          value: call.value || '0x0',
         })),
-        atomicRequired,
-        gasless,
-        capabilities: {
-          dataSuffix: { value: BUILDER_CODE_DATA_SUFFIX, optional: true }
-        }
-      }
+        ...(gasless
+          ? {
+              capabilities: {
+                dataSuffix: { value: BUILDER_CODE_DATA_SUFFIX, optional: true },
+              },
+            }
+          : {}),
+      },
+    ],
     })) as { transactionHash?: string; hash?: string };
 
     console.log('Batch transaction result:', result);
@@ -83,7 +94,7 @@ export async function sendBatchCalls(options: BatchTransactionOptions): Promise<
  */
 export async function sendGameBatchCalls(
   gameActions: BatchCall[],
-  options: Omit<BatchTransactionOptions, 'calls'> = {}
+  options: Omit<BatchTransactionOptions, 'calls'>
 ): Promise<BatchTransactionResult> {
   return sendBatchCalls({
     calls: gameActions,
@@ -103,7 +114,7 @@ export async function sendGameBatchCalls(
 export async function sendSpendPermissionAndGameEntry(
   spendPermissionCall: BatchCall,
   gameEntryCall: BatchCall,
-  options: Omit<BatchTransactionOptions, 'calls'> = {}
+  options: Omit<BatchTransactionOptions, 'calls'>
 ): Promise<BatchTransactionResult> {
   return sendBatchCalls({
     calls: [spendPermissionCall, gameEntryCall],
@@ -121,7 +132,7 @@ export async function sendSpendPermissionAndGameEntry(
  */
 export async function sendMultipleGameRounds(
   gameRoundCalls: BatchCall[],
-  options: Omit<BatchTransactionOptions, 'calls'> = {}
+  options: Omit<BatchTransactionOptions, 'calls'>
 ): Promise<BatchTransactionResult> {
   if (gameRoundCalls.length === 0) {
     throw new Error('No game round calls provided');
@@ -151,7 +162,7 @@ export async function sendCompleteGameSetup(
   fundingCall: BatchCall,
   spendPermissionCall: BatchCall,
   gameEntryCall: BatchCall,
-  options: Omit<BatchTransactionOptions, 'calls'> = {}
+  options: Omit<BatchTransactionOptions, 'calls'>
 ): Promise<BatchTransactionResult> {
   return sendBatchCalls({
     calls: [fundingCall, spendPermissionCall, gameEntryCall],

--- a/package.json
+++ b/package.json
@@ -26,6 +26,7 @@
     "test-session-token-reuse": "tsx scripts/test-session-token-reuse.ts",
     "test:cdp-api": "tsx scripts/test-cdp-api.ts",
     "test:spacetime": "tsx scripts/test-spacetime-connection.ts",
+    "test:paid-start": "tsx --test tests/paid-game-start.test.ts",
     "test:spacetime-all": "tsx scripts/run-all-spacetime-tests.ts",
     "test:wallet-flow": "tsx scripts/test-wallet-identity-flow.ts",
     "test:trial-flow": "tsx scripts/test-trial-player-flow.ts",

--- a/script/DeployTriviaBattle.s.sol
+++ b/script/DeployTriviaBattle.s.sol
@@ -30,8 +30,8 @@ contract DeployTriviaBattle is Script {
     address constant BASE_MAINNET_CHAINLINK_ORACLE = BASE_MAINNET_KEYSTONE_FORWARDER;
 
     // Configuration constants
-    /// @dev Minimum is 10 minutes (contract MIN_SESSION_INTERVAL). Use a short interval so players can start new rounds after a session ends.
-    uint256 constant SESSION_INTERVAL = 10 minutes;
+    /// @dev Weekly settlement interval (7 days). In-game round timers are separate (API/Spacetime).
+    uint256 constant SESSION_INTERVAL = 7 days;
     uint256 constant ENTRY_FEE = 1e6; // 1 USDC (6 decimals)
 
     function run() external {

--- a/scripts/set-session-interval.sh
+++ b/scripts/set-session-interval.sh
@@ -1,0 +1,27 @@
+#!/usr/bin/env bash
+# Set TriviaBattle sessionInterval to 7 days (604800 seconds) on Base mainnet.
+# Requires: cast, PRIVATE_KEY env (contract owner), optional BASE_RPC_URL.
+set -euo pipefail
+
+CONTRACT="${TRIVIA_CONTRACT:-0xfF52Ed1DEb46C197aD7fce9DEC93ff9e987f8dB6}"
+RPC="${BASE_RPC_URL:-https://mainnet.base.org}"
+INTERVAL="${SESSION_INTERVAL_SEC:-604800}"
+
+if [[ -z "${PRIVATE_KEY:-}" ]]; then
+  echo "Error: set PRIVATE_KEY (contract owner) before running." >&2
+  exit 1
+fi
+
+echo "Contract: $CONTRACT"
+echo "RPC: $RPC"
+echo "Current sessionInterval:"
+cast call "$CONTRACT" "sessionInterval()(uint256)" --rpc-url "$RPC"
+
+echo "Sending setSessionInterval($INTERVAL)..."
+cast send "$CONTRACT" \
+  "setSessionInterval(uint256)" "$INTERVAL" \
+  --rpc-url "$RPC" \
+  --private-key "$PRIVATE_KEY"
+
+echo "Updated sessionInterval:"
+cast call "$CONTRACT" "sessionInterval()(uint256)" --rpc-url "$RPC"

--- a/tests/paid-game-start.test.ts
+++ b/tests/paid-game-start.test.ts
@@ -1,0 +1,140 @@
+/**
+ * Paid game start helpers — run with: npx tsx --test tests/paid-game-start.test.ts
+ */
+
+import assert from 'node:assert/strict';
+import { describe, it, beforeEach, afterEach } from 'node:test';
+import { retryWithBackoff } from '../lib/game/retryWithBackoff';
+import {
+  savePendingPaidEntry,
+  loadPendingPaidEntry,
+  clearPendingPaidEntry,
+} from '../lib/game/pendingPaidEntry';
+
+describe('retryWithBackoff', () => {
+  it('returns on first success', async () => {
+    let calls = 0;
+    const result = await retryWithBackoff(async () => {
+      calls += 1;
+      return 'ok';
+    });
+    assert.equal(result, 'ok');
+    assert.equal(calls, 1);
+  });
+
+  it('retries on retryable errors then succeeds', async () => {
+    let calls = 0;
+    const result = await retryWithBackoff(
+      async () => {
+        calls += 1;
+        if (calls < 3) {
+          throw new Error('Transaction not found (may still be pending)');
+        }
+        return 'verified';
+      },
+      { maxAttempts: 5, initialDelayMs: 1, maxDelayMs: 4 }
+    );
+    assert.equal(result, 'verified');
+    assert.equal(calls, 3);
+  });
+
+  it('throws immediately on non-retryable errors', async () => {
+    let calls = 0;
+    await assert.rejects(
+      () =>
+        retryWithBackoff(async () => {
+          calls += 1;
+          throw new Error('paidTxHash required for paid entry');
+        }),
+      /paidTxHash required/
+    );
+    assert.equal(calls, 1);
+  });
+});
+
+describe('pendingPaidEntry (sessionStorage)', () => {
+  const storage = new Map<string, string>();
+  let originalWindow: typeof globalThis.window | undefined;
+
+  beforeEach(() => {
+    storage.clear();
+    originalWindow = globalThis.window;
+    const fakeStorage = {
+      getItem: (key: string) => storage.get(key) ?? null,
+      setItem: (key: string, value: string) => {
+        storage.set(key, value);
+      },
+      removeItem: (key: string) => {
+        storage.delete(key);
+      },
+      clear: () => storage.clear(),
+      key: () => null,
+      length: 0,
+    };
+    (globalThis as { window?: Window; sessionStorage?: Storage }).window = {
+      sessionStorage: fakeStorage,
+    } as unknown as Window;
+    (globalThis as { sessionStorage?: Storage }).sessionStorage = fakeStorage;
+  });
+
+  afterEach(() => {
+    if (originalWindow === undefined) {
+      delete (globalThis as { window?: unknown }).window;
+    } else {
+      globalThis.window = originalWindow;
+    }
+  });
+
+  it('save, load, and clear for matching wallet', () => {
+    savePendingPaidEntry({
+      paidTxHash: '0x' + 'a'.repeat(64),
+      playerMode: 'paid_solo',
+      walletAddress: '0xAbCdEf1234567890123456789012345678901234',
+    });
+
+    const loaded = loadPendingPaidEntry('0xabcdef1234567890123456789012345678901234');
+    assert.ok(loaded);
+    assert.equal(loaded!.paidTxHash, '0x' + 'a'.repeat(64));
+    assert.equal(loaded!.playerMode, 'paid_solo');
+
+    clearPendingPaidEntry();
+    assert.equal(loadPendingPaidEntry('0xabcdef1234567890123456789012345678901234'), null);
+  });
+
+  it('returns null when wallet does not match', () => {
+    savePendingPaidEntry({
+      paidTxHash: '0x' + 'b'.repeat(64),
+      playerMode: 'paid_multiplayer',
+      walletAddress: '0x1111111111111111111111111111111111111111',
+    });
+
+    assert.equal(
+      loadPendingPaidEntry('0x2222222222222222222222222222222222222222'),
+      null
+    );
+  });
+});
+
+describe('batchCalls status helpers', () => {
+  it('extractLastTxHash uses final receipt in batch', async () => {
+    const { pollBatchCallsStatus } = await import('../lib/base-account/batchCalls');
+
+    const provider = {
+      request: async ({ method }: { method: string }) => {
+        if (method === 'wallet_getCallsStatus') {
+          return {
+            status: 200,
+            receipts: [
+              { transactionHash: '0x' + '1'.repeat(64) },
+              { transactionHash: '0x' + '2'.repeat(64) },
+            ],
+          };
+        }
+        throw new Error('unexpected');
+      },
+    };
+
+    const hash = await pollBatchCallsStatus(provider, 'calls-id-test');
+    assert.equal(hash, '0x' + '2'.repeat(64));
+  });
+});


### PR DESCRIPTION
## Summary
- Batch USDC approve + joinBattle into one wallet confirmation for Base Account users, with sequential fallback when atomic batch is unavailable.
- Retry paid tx verification after payment and add sessionStorage recovery so players can continue without paying twice if join fails.
- Improve post-payment UX with a joining overlay, prominent error panel, and continue-with-same-payment actions.
- Validate entry tokens before Spacetime session join and fetch game sessions using the correct paid mode.
- Set deploy script and owner script to a 7-day `sessionInterval` so the home payout timer and CRE gating match weekly settlement.

## Test plan
- [ ] Solo paid: one wallet confirmation starts the game (not play-mode screen)
- [ ] Multiplayer paid: routes to lobby after payment
- [ ] Refresh after payment shows Continue paid game without re-pay
- [ ] Retry with same payment works after transient verification failure
- [ ] Run `npm run test:paid-start`
- [ ] Run `./scripts/set-session-interval.sh` on mainnet and confirm home timer shows days/hours


Made with [Cursor](https://cursor.com)