### PR TITLE
Fix Base batch paid entry status handling

### DIFF
--- a/lib/base-account/batchCalls.ts
+++ b/lib/base-account/batchCalls.ts
@@ -24,13 +24,27 @@ type CapabilitiesMap = Record<
 
 type CallsStatusResult = {
   status?: number | string;
-  receipts?: Array<{ transactionHash?: string }>;
+  receipts?: CallsStatusReceipt | CallsStatusReceipt[];
 };
 
 const BATCH_POLL_INTERVAL_MS = 2_000;
 const BATCH_POLL_TIMEOUT_MS = 180_000;
 
 const sleep = (ms: number) => new Promise((resolve) => setTimeout(resolve, ms));
+
+type SendCallsResult =
+  | string
+  | {
+      id?: string;
+      batchId?: string;
+      callsId?: string;
+      result?: string | { id?: string; batchId?: string; callsId?: string };
+    };
+
+type CallsStatusReceipt = {
+  transactionHash?: string;
+  status?: string;
+};
 
 export const supportsAtomicBatch = async (
   provider: WalletProvider,
@@ -48,22 +62,63 @@ export const supportsAtomicBatch = async (
   }
 };
 
+const normalizeReceipts = (
+  receipts: CallsStatusResult['receipts']
+): CallsStatusReceipt[] => {
+  if (!receipts) return [];
+  return Array.isArray(receipts) ? receipts : [receipts];
+};
+
+export const extractCallsId = (result: SendCallsResult): string | undefined => {
+  if (typeof result === 'string') return result;
+
+  if (typeof result.result === 'string') return result.result;
+
+  return (
+    result.id ??
+    result.batchId ??
+    result.callsId ??
+    result.result?.id ??
+    result.result?.batchId ??
+    result.result?.callsId
+  );
+};
+
 const extractLastTxHash = (status: CallsStatusResult): string | undefined => {
   const receipts = status.receipts;
-  if (!receipts?.length) return undefined;
-  const last = receipts[receipts.length - 1];
+  const normalizedReceipts = normalizeReceipts(receipts);
+  if (normalizedReceipts.length === 0) return undefined;
+  const successfulReceipts = normalizedReceipts.filter((receipt) => receipt.status !== '0x0');
+  const candidates = successfulReceipts.length > 0 ? successfulReceipts : normalizedReceipts;
+  const last = candidates[candidates.length - 1];
   return last?.transactionHash;
 };
 
 const isBatchConfirmed = (status: CallsStatusResult): boolean => {
   const s = status.status;
-  return s === 200 || s === 'CONFIRMED' || s === 'confirmed';
+  if (typeof s === 'number') return s >= 200 && s < 300;
+  return s === 'CONFIRMED' || s === 'confirmed' || s === 'SUCCESS' || s === 'success';
 };
 
 const isBatchFailed = (status: CallsStatusResult): boolean => {
   const s = status.status;
-  if (!s || s === 100 || s === 'PENDING' || s === 'pending') return false;
+  if (!s) return false;
+  if (typeof s === 'number') return s < 100 || s >= 300;
+  if (s === 'PENDING' || s === 'pending') return false;
   return !isBatchConfirmed(status);
+};
+
+const getBatchFailureMessage = (status: CallsStatusResult): string => {
+  switch (status.status) {
+    case 400:
+      return 'Batch transaction failed before being included on-chain';
+    case 500:
+      return 'Batch transaction reverted on-chain';
+    case 600:
+      return 'Batch transaction partially reverted on-chain';
+    default:
+      return `Batch transaction failed with status ${String(status.status)}`;
+  }
 };
 
 export const pollBatchCallsStatus = async (
@@ -80,10 +135,12 @@ export const pollBatchCallsStatus = async (
       })) as CallsStatusResult;
 
       if (isBatchConfirmed(status)) {
-        return extractLastTxHash(status);
+        const txHash = extractLastTxHash(status);
+        if (txHash) return txHash;
+        // Some wallets report success before receipts are indexed. Keep polling for the hash.
       }
       if (isBatchFailed(status)) {
-        throw new Error('Batch transaction reverted on-chain');
+        throw new Error(getBatchFailureMessage(status));
       }
     } catch (err) {
       if (err instanceof Error && err.message.includes('reverted')) {
@@ -109,7 +166,7 @@ export const sendAtomicBatchCalls = async (
     data: call.data,
   }));
 
-  const callsId = (await provider.request({
+  const result = (await provider.request({
     method: 'wallet_sendCalls',
     params: [
       {
@@ -123,7 +180,9 @@ export const sendAtomicBatchCalls = async (
         },
       },
     ],
-  })) as string;
+  })) as SendCallsResult;
+
+  const callsId = extractCallsId(result);
 
   if (!callsId || typeof callsId !== 'string') {
     throw new Error('wallet_sendCalls did not return a callsId');

--- a/lib/base-account/batchCalls.ts
+++ b/lib/base-account/batchCalls.ts
@@ -32,14 +32,18 @@ const BATCH_POLL_TIMEOUT_MS = 180_000;
 
 const sleep = (ms: number) => new Promise((resolve) => setTimeout(resolve, ms));
 
-type SendCallsResult =
+export type SendCallsResult =
   | string
   | {
-      id?: string;
-      batchId?: string;
-      callsId?: string;
-      result?: string | { id?: string; batchId?: string; callsId?: string };
-    };
+      id?: unknown;
+      batchId?: unknown;
+      callsId?: unknown;
+      result?: unknown;
+    }
+  | null
+  | undefined;
+
+type SendCallsObject = Exclude<SendCallsResult, string | null | undefined>;
 
 type CallsStatusReceipt = {
   transactionHash?: string;
@@ -70,18 +74,42 @@ const normalizeReceipts = (
 };
 
 export const extractCallsId = (result: SendCallsResult): string | undefined => {
+  if (!result) return undefined;
   if (typeof result === 'string') return result;
+
+  if (typeof result !== 'object') return undefined;
+
+  const getStringValue = (
+    source: SendCallsObject | undefined,
+    key: keyof SendCallsObject
+  ): string | undefined => {
+    const value = source?.[key];
+    return typeof value === 'string' ? value : undefined;
+  };
 
   if (typeof result.result === 'string') return result.result;
 
+  const innerResult =
+    typeof result.result === 'object' && result.result !== null
+      ? (result.result as SendCallsObject)
+      : undefined;
+
   return (
-    result.id ??
-    result.batchId ??
-    result.callsId ??
-    result.result?.id ??
-    result.result?.batchId ??
-    result.result?.callsId
+    getStringValue(result, 'id') ??
+    getStringValue(result, 'batchId') ??
+    getStringValue(result, 'callsId') ??
+    getStringValue(innerResult, 'id') ??
+    getStringValue(innerResult, 'batchId') ??
+    getStringValue(innerResult, 'callsId')
   );
+};
+
+const getNumericStatus = (status: CallsStatusResult['status']): number => {
+  if (typeof status === 'number') return status;
+  if (typeof status === 'string' && /^\d+$/.test(status.trim())) {
+    return Number.parseInt(status, 10);
+  }
+  return Number.NaN;
 };
 
 const extractLastTxHash = (status: CallsStatusResult): string | undefined => {
@@ -96,20 +124,22 @@ const extractLastTxHash = (status: CallsStatusResult): string | undefined => {
 
 const isBatchConfirmed = (status: CallsStatusResult): boolean => {
   const s = status.status;
-  if (typeof s === 'number') return s >= 200 && s < 300;
+  const numericStatus = getNumericStatus(s);
+  if (!Number.isNaN(numericStatus)) return numericStatus >= 200 && numericStatus < 300;
   return s === 'CONFIRMED' || s === 'confirmed' || s === 'SUCCESS' || s === 'success';
 };
 
 const isBatchFailed = (status: CallsStatusResult): boolean => {
   const s = status.status;
   if (!s) return false;
-  if (typeof s === 'number') return s < 100 || s >= 300;
+  const numericStatus = getNumericStatus(s);
+  if (!Number.isNaN(numericStatus)) return numericStatus < 100 || numericStatus >= 300;
   if (s === 'PENDING' || s === 'pending') return false;
   return !isBatchConfirmed(status);
 };
 
 const getBatchFailureMessage = (status: CallsStatusResult): string => {
-  switch (status.status) {
+  switch (getNumericStatus(status.status)) {
     case 400:
       return 'Batch transaction failed before being included on-chain';
     case 500:

--- a/lib/transaction/batchTransactions.ts
+++ b/lib/transaction/batchTransactions.ts
@@ -2,7 +2,7 @@ import { Interface } from 'ethers';
 import { base } from 'viem/chains';
 import { numberToHex } from 'viem';
 import { getBaseAccountProvider } from '@/lib/base-account/sdk';
-import { pollBatchCallsStatus } from '@/lib/base-account/batchCalls';
+import { extractCallsId, pollBatchCallsStatus } from '@/lib/base-account/batchCalls';
 import { BUILDER_CODE_DATA_SUFFIX } from '@/lib/blockchain/builderCode';
 
 export interface BatchCall {
@@ -45,7 +45,7 @@ export async function sendBatchCalls(options: BatchTransactionOptions): Promise<
       value: call.value || '0'
     })));
 
-    const callsId = (await provider.request({
+    const sendCallsResult = await provider.request({
       method: 'wallet_sendCalls',
       params: [
         {
@@ -67,7 +67,9 @@ export async function sendBatchCalls(options: BatchTransactionOptions): Promise<
             : {}),
         },
       ],
-    })) as string;
+    });
+
+    const callsId = extractCallsId(sendCallsResult as Parameters<typeof extractCallsId>[0]);
 
     if (!callsId || typeof callsId !== 'string') {
       throw new Error('wallet_sendCalls did not return a callsId');

--- a/lib/transaction/batchTransactions.ts
+++ b/lib/transaction/batchTransactions.ts
@@ -2,7 +2,11 @@ import { Interface } from 'ethers';
 import { base } from 'viem/chains';
 import { numberToHex } from 'viem';
 import { getBaseAccountProvider } from '@/lib/base-account/sdk';
-import { extractCallsId, pollBatchCallsStatus } from '@/lib/base-account/batchCalls';
+import {
+  extractCallsId,
+  pollBatchCallsStatus,
+  type SendCallsResult,
+} from '@/lib/base-account/batchCalls';
 import { BUILDER_CODE_DATA_SUFFIX } from '@/lib/blockchain/builderCode';
 
 export interface BatchCall {
@@ -69,7 +73,7 @@ export async function sendBatchCalls(options: BatchTransactionOptions): Promise<
       ],
     });
 
-    const callsId = extractCallsId(sendCallsResult as Parameters<typeof extractCallsId>[0]);
+    const callsId = extractCallsId(sendCallsResult as SendCallsResult);
 
     if (!callsId || typeof callsId !== 'string') {
       throw new Error('wallet_sendCalls did not return a callsId');

--- a/tests/paid-game-start.test.ts
+++ b/tests/paid-game-start.test.ts
@@ -137,4 +137,59 @@ describe('batchCalls status helpers', () => {
     const hash = await pollBatchCallsStatus(provider, 'calls-id-test');
     assert.equal(hash, '0x' + '2'.repeat(64));
   });
+
+  it('pollBatchCallsStatus accepts a single atomic receipt object', async () => {
+    const { pollBatchCallsStatus } = await import('../lib/base-account/batchCalls');
+
+    const provider = {
+      request: async ({ method }: { method: string }) => {
+        if (method === 'wallet_getCallsStatus') {
+          return {
+            status: 200,
+            atomic: true,
+            receipts: { transactionHash: '0x' + '3'.repeat(64), status: '0x1' },
+          };
+        }
+        throw new Error('unexpected');
+      },
+    };
+
+    const hash = await pollBatchCallsStatus(provider, 'calls-id-test');
+    assert.equal(hash, '0x' + '3'.repeat(64));
+  });
+
+  it('sendAtomicBatchCalls accepts object-shaped sendCalls ids', async () => {
+    const { sendAtomicBatchCalls } = await import('../lib/base-account/batchCalls');
+    const callsId = '0x' + '4'.repeat(64);
+    const txHash = '0x' + '5'.repeat(64);
+
+    const provider = {
+      request: async ({ method }: { method: string }) => {
+        if (method === 'wallet_sendCalls') {
+          return { batchId: callsId, status: 'pending' };
+        }
+        if (method === 'wallet_getCallsStatus') {
+          return {
+            status: 201,
+            atomic: true,
+            receipts: [{ transactionHash: txHash, status: '0x1' }],
+          };
+        }
+        throw new Error('unexpected');
+      },
+    };
+
+    const hash = await sendAtomicBatchCalls(
+      provider,
+      '0x1111111111111111111111111111111111111111',
+      [
+        {
+          to: '0x2222222222222222222222222222222222222222',
+          value: '0x0',
+          data: '0x',
+        },
+      ]
+    );
+    assert.equal(hash, txHash);
+  });
 });

--- a/tests/paid-game-start.test.ts
+++ b/tests/paid-game-start.test.ts
@@ -192,4 +192,40 @@ describe('batchCalls status helpers', () => {
     );
     assert.equal(hash, txHash);
   });
+
+  it('extractCallsId ignores unexpected response payloads', async () => {
+    const { extractCallsId } = await import('../lib/base-account/batchCalls');
+
+    assert.equal(extractCallsId(null), undefined);
+    assert.equal(extractCallsId(undefined), undefined);
+    assert.equal(extractCallsId(123 as never), undefined);
+    assert.equal(extractCallsId({ id: 123 }), undefined);
+    assert.equal(extractCallsId({ result: { callsId: '0xabc' } }), '0xabc');
+  });
+
+  it('pollBatchCallsStatus treats numeric string statuses correctly', async () => {
+    const { pollBatchCallsStatus } = await import('../lib/base-account/batchCalls');
+    const txHash = '0x' + '6'.repeat(64);
+    let calls = 0;
+
+    const provider = {
+      request: async ({ method }: { method: string }) => {
+        if (method === 'wallet_getCallsStatus') {
+          calls += 1;
+          if (calls === 1) {
+            return { status: '100' };
+          }
+          return {
+            status: '200',
+            atomic: true,
+            receipts: [{ transactionHash: txHash, status: '0x1' }],
+          };
+        }
+        throw new Error('unexpected');
+      },
+    };
+
+    const hash = await pollBatchCallsStatus(provider, 'calls-id-test');
+    assert.equal(hash, txHash);
+  });
 });


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary
- Handle object-shaped `wallet_sendCalls` responses as well as string ids.
- Defensively parse unexpected/null send-call RPC payloads without throwing.
- Interpret EIP-5792/Base `wallet_getCallsStatus` numeric status families, including numeric string statuses.
- Normalize single-receipt and array-receipt status payloads and keep polling confirmed batches until a transaction hash is available.
- Export the shared `SendCallsResult` type for cleaner consumers.
- Add focused paid-entry batch helper tests for PR review edge cases.

## Testing
- `npm run test:paid-start`
- `npm exec tsc -- --noEmit --pretty false`
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-47696e77-a10e-4e2d-b00e-0bed093b96ed"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-47696e77-a10e-4e2d-b00e-0bed093b96ed"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

