### PR TITLE
Fix quiz scoring, answer verification, and song title display

### DIFF
--- a/app/api/grove-questions/route.ts
+++ b/app/api/grove-questions/route.ts
@@ -1,6 +1,8 @@
 import { NextRequest, NextResponse } from 'next/server';
 import type { DifficultyLevel } from '@/types/game';
 import { logger } from '@/lib/utils/logger';
+import { signQuestionToken } from '@/lib/utils/questionToken';
+import { parseArtistAndTitle } from '@/lib/grove/parseMetadata';
 import {
   hasUploadedGroveTriviaFiles,
   listGroveAudioByPrefix,
@@ -51,6 +53,23 @@ const getTimeLimit = (difficulty: DifficultyLevel): number => {
   }
 };
 
+const normalizeTrackMetadata = (file: GroveFileEntry): GroveFileEntry => {
+  if (file.artistName !== 'Unknown') {
+    return file;
+  }
+
+  const parsed = parseArtistAndTitle(file.name);
+  if (parsed.artistName === 'Unknown') {
+    return file;
+  }
+
+  return {
+    ...file,
+    artistName: parsed.artistName,
+    songTitle: parsed.songTitle,
+  };
+};
+
 const loadAudioFiles = (prefix: string): { files: GroveFileEntry[]; source: string } => {
   if (hasUploadedGroveTriviaFiles()) {
     const groveFiles = listGroveAudioByPrefix(prefix);
@@ -77,7 +96,8 @@ export async function GET(req: NextRequest) {
 
     logger.debug(`🌳 Fetching questions from Grove: folder=${folder}, mode=${mode}, count=${count}`);
 
-    const { files, source } = loadAudioFiles(folder);
+    const { files: rawFiles, source } = loadAudioFiles(folder);
+    const files = rawFiles.map(normalizeTrackMetadata);
 
     if (files.length < choices) {
       return NextResponse.json(
@@ -106,18 +126,21 @@ export async function GET(req: NextRequest) {
       const options = shuffle([correctText, ...distractors]).slice(0, choices);
       const correctIndex = options.indexOf(correctText);
       const audioUrl = resolveGroveAudioUrl(correct);
+      const qId = `grove_${Date.now()}_${i}`;
+      const correctAns = correctIndex >= 0 ? correctIndex : 0;
+      const timeLimit = getTimeLimit(difficulty);
 
       questions.push({
-        id: `grove_${Date.now()}_${i}`,
+        id: qId,
         type: mode,
         question:
           mode === 'name-that-tune'
             ? 'What song is this?'
             : `Who performs "${correct.songTitle}"?`,
         options,
-        correctAnswer: correctIndex >= 0 ? correctIndex : 0,
+        questionToken: signQuestionToken(qId, correctAns, timeLimit, difficulty),
         audioUrl,
-        timeLimit: getTimeLimit(difficulty),
+        timeLimit,
         difficulty,
         metadata: {
           artistName: correct.artistName,

--- a/app/api/storacha-questions/route.ts
+++ b/app/api/storacha-questions/route.ts
@@ -1,6 +1,7 @@
 import { NextRequest, NextResponse } from 'next/server';
 import { storachaStorage } from '@/lib/apis/storacha';
 import type { DifficultyLevel } from '@/types/game';
+import { signQuestionToken } from '@/lib/utils/questionToken';
 
 type Mode = 'name-that-tune' | 'artist-match';
 
@@ -164,16 +165,20 @@ export async function GET(req: NextRequest) {
       // Always use local files for faster loading
       audioUrl = correct.path;
 
+      const qId = `st_${Date.now()}_${i}`;
+      const correctAns = correctIndex >= 0 ? correctIndex : 0;
+      const tl = getTimeLimit(difficulty);
+
       questions.push({
-        id: `st_${Date.now()}_${i}`,
+        id: qId,
         type: mode,
         question: mode === 'name-that-tune' 
           ? 'What song is this?' 
           : `Who performs "${correct.songTitle}"?`,
         options,
-        correctAnswer: correctIndex >= 0 ? correctIndex : 0,
+        questionToken: signQuestionToken(qId, correctAns, tl, difficulty),
         audioUrl,
-        timeLimit: getTimeLimit(difficulty),
+        timeLimit: tl,
         difficulty,
         metadata: {
           artistName: correct.artistName,

--- a/app/api/supabase-questions/route.ts
+++ b/app/api/supabase-questions/route.ts
@@ -2,6 +2,7 @@ import { NextRequest, NextResponse } from 'next/server';
 import { spacetimeClient } from '@/lib/apis/spacetime';
 import { lighthouseStorage } from '@/lib/apis/lighthouse';
 import type { DifficultyLevel } from '@/types/game';
+import { signQuestionToken } from '@/lib/utils/questionToken';
 
 type Mode = 'name-that-tune' | 'artist-match';
 
@@ -148,16 +149,20 @@ export async function GET(req: NextRequest) {
       // Always use local files for faster loading
       audioUrl = correct.path;
 
+      const qId = `sb_${Date.now()}_${i}`;
+      const correctAns = correctIndex >= 0 ? correctIndex : 0;
+      const tl = getTimeLimit(difficulty);
+
       questions.push({
-        id: `sb_${Date.now()}_${i}`,
+        id: qId,
         type: mode,
         question: mode === 'name-that-tune' 
           ? 'What song is this?' 
           : `Who performs "${correct.songTitle}"?`,
         options,
-        correctAnswer: correctIndex >= 0 ? correctIndex : 0,
+        questionToken: signQuestionToken(qId, correctAns, tl, difficulty),
         audioUrl,
-        timeLimit: getTimeLimit(difficulty),
+        timeLimit: tl,
         difficulty,
         metadata: {
           artistName: correct.artistName,

--- a/app/game/page.tsx
+++ b/app/game/page.tsx
@@ -668,10 +668,12 @@ export default function Game() {
               <div 
                 key={index}
                 className={`bg-[#ffffff] box-border content-stretch flex flex-col gap-3 h-[96px] items-start justify-start p-[16px] relative rounded-2xl shrink-0 w-full transition-colors ${
-                  selectedAnswer === index && verifiedCorrectAnswer !== null
-                    ? index === verifiedCorrectAnswer
-                      ? 'bg-green-200 border-2 border-green-500'
-                      : 'bg-red-200 border-2 border-red-500'
+                  selectedAnswer === index && isAnswered && !isVerifying
+                    ? verifiedCorrectAnswer === null
+                      ? 'bg-amber-100 border-2 border-amber-500'
+                      : index === verifiedCorrectAnswer
+                        ? 'bg-green-200 border-2 border-green-500'
+                        : 'bg-red-200 border-2 border-red-500'
                     : isAnswered || timeRemaining <= 0
                     ? 'cursor-not-allowed opacity-50'
                     : 'cursor-pointer hover:bg-[#f0f0f0]'

--- a/app/game/page.tsx
+++ b/app/game/page.tsx
@@ -668,12 +668,14 @@ export default function Game() {
               <div 
                 key={index}
                 className={`bg-[#ffffff] box-border content-stretch flex flex-col gap-3 h-[96px] items-start justify-start p-[16px] relative rounded-2xl shrink-0 w-full transition-colors ${
-                  selectedAnswer === index && isAnswered && !isVerifying
-                    ? verifiedCorrectAnswer === null
-                      ? 'bg-amber-100 border-2 border-amber-500'
-                      : index === verifiedCorrectAnswer
-                        ? 'bg-green-200 border-2 border-green-500'
-                        : 'bg-red-200 border-2 border-red-500'
+                  selectedAnswer === index && isAnswered
+                    ? isVerifying
+                      ? 'bg-purple-100 border-2 border-purple-500 animate-pulse'
+                      : verifiedCorrectAnswer === null
+                        ? 'bg-amber-100 border-2 border-amber-500'
+                        : index === verifiedCorrectAnswer
+                          ? 'bg-green-200 border-2 border-green-500'
+                          : 'bg-red-200 border-2 border-red-500'
                     : isAnswered || timeRemaining <= 0
                     ? 'cursor-not-allowed opacity-50'
                     : 'cursor-pointer hover:bg-[#f0f0f0]'

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -939,9 +939,11 @@ function HomePage() {
                         ? 'bg-purple-600 text-white animate-pulse'
                         : 'bg-gray-700 text-gray-400'
                       : selectedAnswer === index
-                        ? verifiedCorrectAnswer === index
-                          ? 'bg-green-600 text-white'
-                          : 'bg-red-600 text-white'
+                        ? verifiedCorrectAnswer === null
+                          ? 'bg-amber-600 text-white'
+                          : verifiedCorrectAnswer === index
+                            ? 'bg-green-600 text-white'
+                            : 'bg-red-600 text-white'
                         : 'bg-gray-700 text-gray-400'
                     : gameTimeRemaining <= 0
                     ? 'bg-gray-800 text-gray-500 cursor-not-allowed'
@@ -949,9 +951,13 @@ function HomePage() {
                 }`}
               >
                 <span>{option}</span>
-                {isAnswered && !isVerifying && selectedAnswer === index && verifiedCorrectAnswer !== null && (
+                {isAnswered && !isVerifying && selectedAnswer === index && (
                   <span className="block mt-1 text-xs font-semibold">
-                    {verifiedCorrectAnswer === index ? '✓ Correct' : '✗ Incorrect'}
+                    {verifiedCorrectAnswer === null
+                      ? 'Could not verify'
+                      : verifiedCorrectAnswer === index
+                        ? '✓ Correct'
+                        : '✗ Incorrect'}
                   </span>
                 )}
               </button>

--- a/components/game/HighScoreDisplay.tsx
+++ b/components/game/HighScoreDisplay.tsx
@@ -148,12 +148,6 @@ export default function HighScoreDisplay({
         isNewHighScore: finalIsHigh,
         rank: finalRank,
       });
-
-      if (finalIsHigh) {
-        setShowConfetti(true);
-        const timer = setTimeout(() => setShowConfetti(false), 4000);
-        return () => clearTimeout(timer);
-      }
     }
   }, [
     isTrialGame,
@@ -164,6 +158,13 @@ export default function HighScoreDisplay({
     backendRank,
     submissionResult,
   ]);
+
+  useEffect(() => {
+    if (currentScore <= 0) return;
+    setShowConfetti(true);
+    const timer = setTimeout(() => setShowConfetti(false), 4000);
+    return () => clearTimeout(timer);
+  }, [currentScore]);
 
   const getRankIcon = (rank: number) => {
     switch (rank) {

--- a/lib/grove-files.ts
+++ b/lib/grove-files.ts
@@ -171,8 +171,8 @@ export const GROVE_FILES: Record<string, GroveFileEntry> = {
   'Justin Beiber-DAISIES.mp3': {
     name: 'Justin Beiber-DAISIES.mp3',
     path: 'Global_Top_100/Justin Beiber-DAISIES.mp3',
-    artistName: 'Justin Beiber',
-    songTitle: 'DAISIES',
+    artistName: 'Unknown',
+    songTitle: 'Justin Beiber-DAISIES',
     storageKey: 'f87909d747f4f192240633387f86988ee51d66c5e423ce9a475b87d4412fe5c6',
     gatewayUrl: 'https://api.grove.storage/f87909d747f4f192240633387f86988ee51d66c5e423ce9a475b87d4412fe5c6',
     uri: 'lens://f87909d747f4f192240633387f86988ee51d66c5e423ce9a475b87d4412fe5c6',
@@ -180,8 +180,8 @@ export const GROVE_FILES: Record<string, GroveFileEntry> = {
   'Justin Beiber-YUKON.mp3': {
     name: 'Justin Beiber-YUKON.mp3',
     path: 'Global_Top_100/Justin Beiber-YUKON.mp3',
-    artistName: 'Justin Beiber',
-    songTitle: 'YUKON',
+    artistName: 'Unknown',
+    songTitle: 'Justin Beiber-YUKON',
     storageKey: '553760e5d882edba8fc8202f780cda92a70bdc412d19486a06d1d4855d83437a',
     gatewayUrl: 'https://api.grove.storage/553760e5d882edba8fc8202f780cda92a70bdc412d19486a06d1d4855d83437a',
     uri: 'lens://553760e5d882edba8fc8202f780cda92a70bdc412d19486a06d1d4855d83437a',

--- a/lib/grove-files.ts
+++ b/lib/grove-files.ts
@@ -171,8 +171,8 @@ export const GROVE_FILES: Record<string, GroveFileEntry> = {
   'Justin Beiber-DAISIES.mp3': {
     name: 'Justin Beiber-DAISIES.mp3',
     path: 'Global_Top_100/Justin Beiber-DAISIES.mp3',
-    artistName: 'Unknown',
-    songTitle: 'Justin Beiber-DAISIES',
+    artistName: 'Justin Beiber',
+    songTitle: 'DAISIES',
     storageKey: 'f87909d747f4f192240633387f86988ee51d66c5e423ce9a475b87d4412fe5c6',
     gatewayUrl: 'https://api.grove.storage/f87909d747f4f192240633387f86988ee51d66c5e423ce9a475b87d4412fe5c6',
     uri: 'lens://f87909d747f4f192240633387f86988ee51d66c5e423ce9a475b87d4412fe5c6',
@@ -180,8 +180,8 @@ export const GROVE_FILES: Record<string, GroveFileEntry> = {
   'Justin Beiber-YUKON.mp3': {
     name: 'Justin Beiber-YUKON.mp3',
     path: 'Global_Top_100/Justin Beiber-YUKON.mp3',
-    artistName: 'Unknown',
-    songTitle: 'Justin Beiber-YUKON',
+    artistName: 'Justin Beiber',
+    songTitle: 'YUKON',
     storageKey: '553760e5d882edba8fc8202f780cda92a70bdc412d19486a06d1d4855d83437a',
     gatewayUrl: 'https://api.grove.storage/553760e5d882edba8fc8202f780cda92a70bdc412d19486a06d1d4855d83437a',
     uri: 'lens://553760e5d882edba8fc8202f780cda92a70bdc412d19486a06d1d4855d83437a',

--- a/lib/grove/parseMetadata.ts
+++ b/lib/grove/parseMetadata.ts
@@ -18,5 +18,13 @@ export const parseArtistAndTitle = (
     };
   }
 
+  const hyphen = base.match(/^(.+?)\s*-\s*(.+)$/);
+  if (hyphen) {
+    return {
+      artistName: hyphen[1]!.trim(),
+      songTitle: hyphen[2]!.trim(),
+    };
+  }
+
   return { artistName: 'Unknown', songTitle: base.trim() || 'Unknown' };
 };

--- a/lib/utils/questionToken.ts
+++ b/lib/utils/questionToken.ts
@@ -9,10 +9,10 @@ import crypto from 'crypto';
  * and compares the answer server-side.
  */
 
-// Allow enough time for a full round after batch question load.
+// Enough time for a full round after batch question load (~15 questions).
 // Single-question fetches still get at least 90s; cap at 10 minutes.
 const getMaxAnswerTimeMs = (timeLimitSeconds: number): number =>
-  Math.min(600_000, Math.max(90_000, timeLimitSeconds * 60 * 1000));
+  Math.min(600_000, Math.max(90_000, timeLimitSeconds * 15 * 1000));
 
 interface QuestionTokenPayload {
   /** Question identifier */
@@ -77,7 +77,7 @@ export interface VerifiedQuestion {
 /**
  * Verify and decode a question token.
  *
- * Returns null if the token is invalid, tampered, or expired (>30s old).
+ * Returns null if the token is invalid, tampered, or expired.
  */
 export function verifyQuestionToken(token: string): VerifiedQuestion | null {
   try {

--- a/lib/utils/questionToken.ts
+++ b/lib/utils/questionToken.ts
@@ -9,10 +9,10 @@ import crypto from 'crypto';
  * and compares the answer server-side.
  */
 
-// 30s window is safe because questions are fetched one at a time.
-// If batching is added later, each question's token must be signed individually
-// at serve time so iat reflects when the player actually sees the question.
-const MAX_ANSWER_TIME_SECONDS = 30;
+// Allow enough time for a full round after batch question load.
+// Single-question fetches still get at least 90s; cap at 10 minutes.
+const getMaxAnswerTimeMs = (timeLimitSeconds: number): number =>
+  Math.min(600_000, Math.max(90_000, timeLimitSeconds * 60 * 1000));
 
 interface QuestionTokenPayload {
   /** Question identifier */
@@ -95,9 +95,10 @@ export function verifyQuestionToken(token: string): VerifiedQuestion | null {
       Buffer.from(payloadStr, 'base64url').toString(),
     );
 
-    // Check expiration — reject answers submitted more than 30s after question served
+    // Check expiration — reject answers submitted after the allowed window
     const elapsedMs = Date.now() - payload.iat;
-    if (elapsedMs > MAX_ANSWER_TIME_SECONDS * 1000) return null;
+    const maxAnswerMs = getMaxAnswerTimeMs(payload.tl);
+    if (elapsedMs > maxAnswerMs) return null;
     if (elapsedMs < 0) return null; // clock skew / replay
 
     return {

--- a/scripts/upload-to-grove.ts
+++ b/scripts/upload-to-grove.ts
@@ -26,15 +26,24 @@ const buildManifestFromDisk = (): Record<string, GroveFileEntry> => {
     .sort();
 
   for (const name of fileNames) {
-    if (!manifest[name]) {
-      const { artistName, songTitle } = parseArtistAndTitle(name);
+    const { artistName, songTitle } = parseArtistAndTitle(name);
+    const existing = manifest[name];
+
+    if (!existing) {
       manifest[name] = {
         name,
         path: `Global_Top_100/${name}`,
         artistName,
         songTitle,
       };
+      continue;
     }
+
+    manifest[name] = {
+      ...existing,
+      artistName,
+      songTitle,
+    };
   }
 
   return manifest;


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Problem

After merging #88, the trivia game had four related issues:

1. **Correct answers showed red** — Grove (the primary question source) returned questions without signed `questionToken`s, so `/api/verify-answer` always failed. The UI treated a failed verification as incorrect (red highlight).
2. **Score stayed at 0** — Points are only awarded after successful server verification, so every answer scored zero.
3. **Artist names in answer options** — Files like `Justin Beiber-YUKON.mp3` were not parsed correctly, so answer choices showed `Justin Beiber-YUKON` instead of just `YUKON`.
4. **No confetti on completion** — Confetti only fired for #1 on the paid leaderboard; with a score of 0 it never triggered. Trial games were also excluded.

## Fix

- **Sign question tokens** in `grove-questions` (and `supabase-questions` / `storacha-questions` fallbacks), matching the pattern already used by `lighthouse-questions` and `spacetime-questions`.
- **Normalize track metadata** at question generation time and improve `parseArtistAndTitle` to handle `Artist-Title` hyphen filenames.
- **Token expiry** uses a 15× time-limit multiplier (min 90s, max 10 min) — enough for batch rounds without a 10-minute single-question window.
- **Safer UI feedback** — amber highlight when verification fails; purple pulse on `/game` while verifying.
- **Confetti** — celebrate any final score greater than zero (trial and paid).

## PR review follow-ups

- Tightened `getMaxAnswerTimeMs` per security review (15× multiplier instead of 60×).
- Fixed `/game` answer card to pulse purple during verification (matches main page).
- Reverted manual `grove-files.ts` edits; `upload-to-grove.ts` now re-parses metadata from filenames on each run.

## Testing

- `parseArtistAndTitle('Justin Beiber-YUKON.mp3')` → `{ artistName: 'Justin Beiber', songTitle: 'YUKON' }`
- `signQuestionToken` / `verifyQuestionToken` round-trip verified
- `npm run build` passes
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-62306790-d930-40e2-9f78-8c4d22d0cf1b"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-62306790-d930-40e2-9f78-8c4d22d0cf1b"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

