### PR TITLE
Fix paid solo "Could not verify" and slow post-payment loading

### DIFF
--- a/app/api/save-paid-score/route.ts
+++ b/app/api/save-paid-score/route.ts
@@ -2,6 +2,7 @@ import { NextRequest, NextResponse } from 'next/server';
 import { spacetimeClient } from '@/lib/apis/spacetime';
 import { verifyEntryToken } from '@/lib/utils/jwt';
 import { finalizePaidScoreLedger } from '@/lib/game/paidScoreLedger';
+import { verifyScoreReceipt } from '@/lib/game/scoreReceipt';
 import { submitOnChainScore } from '@/lib/blockchain/submitOnChainScore';
 
 const MAX_GAME_SCORE = 3000;
@@ -17,7 +18,7 @@ const normalizeUsername = (username?: string): string | undefined => {
 export async function POST(req: NextRequest) {
   try {
     const body = await req.json();
-    const { walletAddress, finalScore, username, entryToken } = body;
+    const { walletAddress, finalScore, username, entryToken, scoreReceipt } = body;
 
     if (!entryToken || typeof entryToken !== 'string') {
       return NextResponse.json(
@@ -70,11 +71,34 @@ export async function POST(req: NextRequest) {
       normalizedWallet,
       finalScore,
     );
+
+    let authoritativeScore = finalScore;
+    let onChainSessionId = payload.onChainSessionId ?? '';
+
     if (!finalized.ok) {
-      return NextResponse.json({ error: finalized.error }, { status: 400 });
+      const receipt =
+        typeof scoreReceipt === 'string' && scoreReceipt.trim()
+          ? verifyScoreReceipt(scoreReceipt.trim(), payload.entryId, normalizedWallet)
+          : null;
+
+      if (!receipt || receipt.sc !== finalScore || receipt.av === 0) {
+        return NextResponse.json(
+          {
+            error:
+              finalized.error ??
+              'Score could not be verified. Play through at least one verified answer.',
+          },
+          { status: 400 },
+        );
+      }
+
+      authoritativeScore = receipt.sc;
+      onChainSessionId = receipt.ocs || onChainSessionId;
+    } else {
+      authoritativeScore = finalized.authoritativeScore;
+      onChainSessionId = finalized.onChainSessionId;
     }
 
-    const authoritativeScore = finalized.authoritativeScore;
     let spacetimeUpdated = false;
 
     await spacetimeClient.ensurePlayerDataReady();
@@ -97,7 +121,7 @@ export async function POST(req: NextRequest) {
     const onChainResult = await submitOnChainScore(
       normalizedWallet,
       authoritativeScore,
-      finalized.onChainSessionId,
+      onChainSessionId,
     );
 
     if (!onChainResult.ok) {
@@ -106,7 +130,7 @@ export async function POST(req: NextRequest) {
         {
           success: true,
           authoritativeScore,
-          onChainSessionId: finalized.onChainSessionId,
+          onChainSessionId,
           spacetimeUpdated,
           onChainSubmitted: false,
           onChainError: onChainResult.error,
@@ -120,7 +144,7 @@ export async function POST(req: NextRequest) {
     return NextResponse.json({
       success: true,
       authoritativeScore,
-      onChainSessionId: finalized.onChainSessionId,
+      onChainSessionId,
       spacetimeUpdated,
       onChainSubmitted: true,
       transactionHash: onChainResult.transactionHash,

--- a/app/api/verify-answer/route.ts
+++ b/app/api/verify-answer/route.ts
@@ -70,14 +70,15 @@ export async function POST(req: NextRequest) {
       }
 
       const onChainSessionId = payload.onChainSessionId ?? '';
-      const ledgerEntry = getPaidScoreLedgerEntry(payload.entryId);
-      if (!ledgerEntry && onChainSessionId) {
+      let ledgerEntry = getPaidScoreLedgerEntry(payload.entryId);
+      if (!ledgerEntry) {
         initPaidScoreLedger({
           entryId: payload.entryId,
           walletAddress: wallet,
           onChainSessionId,
           paidTxHash: payload.paidTxHash,
         });
+        ledgerEntry = getPaidScoreLedgerEntry(payload.entryId);
       }
 
       const advanced = advancePaidScore({

--- a/app/api/verify-answer/route.ts
+++ b/app/api/verify-answer/route.ts
@@ -1,14 +1,19 @@
 import { NextRequest, NextResponse } from 'next/server';
 import { verifyQuestionToken } from '@/lib/utils/questionToken';
 import { verifyEntryToken } from '@/lib/utils/jwt';
-import { addVerifiedAnswerScore } from '@/lib/game/paidScoreLedger';
+import {
+  addVerifiedAnswerScore,
+  getPaidScoreLedgerEntry,
+  initPaidScoreLedger,
+} from '@/lib/game/paidScoreLedger';
+import { advancePaidScore } from '@/lib/game/scoreReceipt';
 import { ScoringSystem } from '@/lib/game/scoring';
 import type { DifficultyLevel } from '@/types/game';
 
 export async function POST(req: NextRequest) {
   try {
     const body = await req.json();
-    const { questionToken, selectedAnswer, entryToken } = body;
+    const { questionToken, selectedAnswer, entryToken, scoreReceipt } = body;
 
     if (typeof questionToken !== 'string' || typeof selectedAnswer !== 'number') {
       return NextResponse.json(
@@ -45,6 +50,8 @@ export async function POST(req: NextRequest) {
     );
 
     let serverTotalScore: number | undefined;
+    let nextScoreReceipt: string | undefined;
+    let ledgerWarning: string | undefined;
 
     if (entryToken && typeof entryToken === 'string') {
       const payload = verifyEntryToken(entryToken);
@@ -61,15 +68,40 @@ export async function POST(req: NextRequest) {
           { status: 401 },
         );
       }
+
+      const onChainSessionId = payload.onChainSessionId ?? '';
+      const ledgerEntry = getPaidScoreLedgerEntry(payload.entryId);
+      if (!ledgerEntry && onChainSessionId) {
+        initPaidScoreLedger({
+          entryId: payload.entryId,
+          walletAddress: wallet,
+          onChainSessionId,
+          paidTxHash: payload.paidTxHash,
+        });
+      }
+
+      const advanced = advancePaidScore({
+        entryId: payload.entryId,
+        walletAddress: wallet,
+        onChainSessionId,
+        pointsEarned: isCorrect ? pointsEarned : 0,
+        previousReceipt:
+          typeof scoreReceipt === 'string' && scoreReceipt.trim() ? scoreReceipt.trim() : null,
+        ledgerTotalScore: ledgerEntry?.totalScore,
+        ledgerAnswersVerified: ledgerEntry?.answersVerified,
+      });
+      serverTotalScore = advanced.totalScore;
+      nextScoreReceipt = advanced.receipt;
+
       const ledgerResult = addVerifiedAnswerScore(
         payload.entryId,
         wallet,
         isCorrect ? pointsEarned : 0,
       );
       if (!ledgerResult.ok) {
-        return NextResponse.json({ error: ledgerResult.error }, { status: 400 });
+        ledgerWarning = ledgerResult.error;
+        console.warn('paidScoreLedger update failed (score receipt used):', ledgerResult.error);
       }
-      serverTotalScore = ledgerResult.totalScore;
     }
 
     return NextResponse.json({
@@ -78,6 +110,8 @@ export async function POST(req: NextRequest) {
       pointsEarned,
       timeSpent,
       serverTotalScore,
+      scoreReceipt: nextScoreReceipt,
+      ledgerWarning,
     });
   } catch (error) {
     console.error('verify-answer error:', error);

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -26,6 +26,7 @@ import { cn } from '@/lib/utils';
 import { isLobbySessionStatus } from '@/lib/utils/gameSessionStatus';
 import { ENTRY_FEE_USDC } from '@/lib/blockchain/contracts';
 import { useSessionCountdown } from '@/hooks/useSessionCountdown';
+import { retryWithBackoff } from '@/lib/game/retryWithBackoff';
 
 function HomePage() {
   const {
@@ -86,6 +87,9 @@ function HomePage() {
   const playerDisplayName = basename ?? (address ? `${address.slice(0, 6)}...${address.slice(-4)}` : 'Player');
   const [joinGameStartError, setJoinGameStartError] = useState<string | null>(null);
   const [isJoiningAfterPayment, setIsJoiningAfterPayment] = useState(false);
+  const [joinProgressMessage, setJoinProgressMessage] = useState('Confirming payment on-chain…');
+  const [verifyError, setVerifyError] = useState<string | null>(null);
+  const scoreReceiptRef = useRef<string | null>(null);
   const { trialStatus, incrementTrialGame } = useTrialStatus(address as string, entryToken ?? undefined);
   
   // Add contract USDC balance hook
@@ -150,6 +154,7 @@ function HomePage() {
             walletAddress: wallet,
             finalScore,
             entryToken,
+            scoreReceipt: scoreReceiptRef.current ?? undefined,
             username: basename ?? undefined,
           }),
         });
@@ -187,6 +192,7 @@ function HomePage() {
     setIsAnswered(false);
     setIsVerifying(false);
     setVerifiedCorrectAnswer(null);
+    setVerifyError(null);
     setStartTime(Date.now());
     setGameTimeRemaining(10);
     setAudioError(false);
@@ -288,14 +294,18 @@ function HomePage() {
     setJoinGameStartError(null);
     if (!isTrial) {
       setIsJoiningAfterPayment(true);
+      setJoinProgressMessage('Confirming payment on-chain…');
     }
     try {
       const data = await joinGame(!isTrial, paidTxHash, {
         playerMode,
         lobbyDurationSec: 180,
         walletUniversalAddress: walletUniversalAddress ?? undefined,
+        onProgress: (message) => setJoinProgressMessage(message),
       });
       lastGameWasPaidRef.current = !isTrial;
+      scoreReceiptRef.current = null;
+      setVerifyError(null);
       setIsTrialGame(isTrial);
       setCompletedAsTrial(false);
       setShowGameEntry(false);
@@ -349,36 +359,77 @@ function HomePage() {
   const handleAnswerSelect = async (answerIndex: number) => {
     if (isAnswered || !currentQuestion || gameTimeRemaining <= 0) return;
 
-    // Optimistically highlight the selected answer immediately
     setSelectedAnswer(answerIndex);
     setIsAnswered(true);
     setIsVerifying(true);
+    setVerifyError(null);
 
     try {
-      const res = await fetch('/api/verify-answer', {
-        method: 'POST',
-        headers: { 'Content-Type': 'application/json' },
-        body: JSON.stringify({
-          questionToken: currentQuestion.questionToken,
-          selectedAnswer: answerIndex,
-          entryToken: !isTrialGame ? entryToken ?? undefined : undefined,
-        }),
-      });
+      const data = await retryWithBackoff(
+        async () => {
+          const res = await fetch('/api/verify-answer', {
+            method: 'POST',
+            headers: { 'Content-Type': 'application/json' },
+            body: JSON.stringify({
+              questionToken: currentQuestion.questionToken,
+              selectedAnswer: answerIndex,
+              entryToken: !isTrialGame ? entryToken ?? undefined : undefined,
+              scoreReceipt: !isTrialGame ? scoreReceiptRef.current ?? undefined : undefined,
+            }),
+          });
 
-      if (res.ok) {
-        const data = await res.json();
-        setVerifiedCorrectAnswer(data.correctAnswer);
+          if (!res.ok) {
+            let msg = `Verification failed (${res.status})`;
+            try {
+              const err = (await res.json()) as { error?: string };
+              if (err.error) msg = err.error;
+            } catch {
+              /* ignore */
+            }
+            throw new Error(msg);
+          }
+
+          return res.json() as Promise<{
+            correctAnswer: number;
+            isCorrect: boolean;
+            pointsEarned: number;
+            serverTotalScore?: number;
+            scoreReceipt?: string;
+          }>;
+        },
+        {
+          maxAttempts: 3,
+          initialDelayMs: 500,
+          shouldRetry: (error) => {
+            const message = error instanceof Error ? error.message.toLowerCase() : '';
+            return (
+              message.includes('network') ||
+              message.includes('fetch') ||
+              message.includes('timeout') ||
+              message.includes('failed to verify')
+            );
+          },
+        },
+      );
+
+      setVerifiedCorrectAnswer(data.correctAnswer);
+      if (typeof data.scoreReceipt === 'string') {
+        scoreReceiptRef.current = data.scoreReceipt;
+      }
+      if (typeof data.serverTotalScore === 'number') {
+        setTotalScore(data.serverTotalScore);
         if (data.isCorrect && data.pointsEarned > 0) {
-          setScore(prev => prev + data.pointsEarned);
-          setTotalScore(prev => prev + data.pointsEarned);
+          setScore((prev) => prev + data.pointsEarned);
         }
-      } else {
-        // Verification failed (expired token, etc.) — treat as incorrect, no points
-        console.warn('Answer verification failed:', res.status);
+      } else if (data.isCorrect && data.pointsEarned > 0) {
+        setScore((prev) => prev + data.pointsEarned);
+        setTotalScore((prev) => prev + data.pointsEarned);
       }
     } catch (error) {
       console.error('Answer verification error:', error);
-      // Network error — treat as incorrect, no points
+      const message =
+        error instanceof Error ? error.message : 'Could not verify your answer. Please try again.';
+      setVerifyError(message);
     } finally {
       setIsVerifying(false);
     }
@@ -713,6 +764,7 @@ function HomePage() {
             sessionBusy={!canJoin}
             sessionTimeRemaining={timeRemaining}
             isJoiningAfterPayment={isJoiningAfterPayment}
+            joinProgressMessage={joinProgressMessage}
           />
           {/* Debug info */}
           {/* <div className="text-xs text-gray-500 text-center mt-2">
@@ -1002,7 +1054,7 @@ function HomePage() {
                 {isAnswered && !isVerifying && selectedAnswer === index && (
                   <span className="block mt-1 text-xs font-semibold">
                     {verifiedCorrectAnswer === null
-                      ? 'Could not verify'
+                      ? verifyError ?? 'Could not verify'
                       : verifiedCorrectAnswer === index
                         ? '✓ Correct'
                         : '✗ Incorrect'}
@@ -1011,6 +1063,25 @@ function HomePage() {
               </button>
             ))}
           </div>
+
+          {verifyError ? (
+            <div className="mb-4 rounded-lg border border-amber-500/40 bg-amber-950/30 px-4 py-3 text-center">
+              <p className="text-sm text-amber-200">{verifyError}</p>
+              <button
+                type="button"
+                onClick={() => {
+                  if (selectedAnswer === null) return;
+                  setIsAnswered(false);
+                  setVerifiedCorrectAnswer(null);
+                  void handleAnswerSelect(selectedAnswer);
+                }}
+                disabled={selectedAnswer === null || isVerifying}
+                className="mt-2 text-sm font-semibold text-amber-300 underline hover:text-amber-100"
+              >
+                Retry verification
+              </button>
+            </div>
+          ) : null}
 
           {/* Current Round Stats and Players */}
           <div className="text-center">

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -356,8 +356,8 @@ function HomePage() {
     }
   };
 
-  const handleAnswerSelect = async (answerIndex: number) => {
-    if (isAnswered || !currentQuestion || gameTimeRemaining <= 0) return;
+  const handleAnswerSelect = async (answerIndex: number, force = false) => {
+    if ((isAnswered && !force) || !currentQuestion || (gameTimeRemaining <= 0 && !force)) return;
 
     setSelectedAnswer(answerIndex);
     setIsAnswered(true);
@@ -406,7 +406,9 @@ function HomePage() {
               message.includes('network') ||
               message.includes('fetch') ||
               message.includes('timeout') ||
-              message.includes('failed to verify')
+              message.includes('verification failed') ||
+              message.includes('502') ||
+              message.includes('503')
             );
           },
         },
@@ -1073,7 +1075,7 @@ function HomePage() {
                   if (selectedAnswer === null) return;
                   setIsAnswered(false);
                   setVerifiedCorrectAnswer(null);
-                  void handleAnswerSelect(selectedAnswer);
+                  void handleAnswerSelect(selectedAnswer, true);
                 }}
                 disabled={selectedAnswer === null || isVerifying}
                 className="mt-2 text-sm font-semibold text-amber-300 underline hover:text-amber-100"

--- a/components/game/GameEntry.tsx
+++ b/components/game/GameEntry.tsx
@@ -48,6 +48,7 @@ interface GameEntryProps {
   sessionTimeRemaining?: number;
   /** Parent shows full-screen overlay while verifying payment + joining */
   isJoiningAfterPayment?: boolean;
+  joinProgressMessage?: string;
 }
 
 export default function GameEntry({
@@ -60,6 +61,7 @@ export default function GameEntry({
   sessionBusy = false,
   sessionTimeRemaining = 0,
   isJoiningAfterPayment = false,
+  joinProgressMessage = 'Confirming payment on-chain and joining the session…',
 }: GameEntryProps) {
   const isPaidMode = playerModeChoice === 'paid_solo' || playerModeChoice === 'paid_multiplayer';
   console.log('GameEntry received playerModeChoice:', playerModeChoice);
@@ -944,8 +946,9 @@ export default function GameEntry({
           <div className="max-w-sm rounded-xl border border-amber-500/40 bg-zinc-900 px-6 py-8 text-center shadow-xl">
             <Loader2 className="mx-auto h-10 w-10 animate-spin text-amber-400 mb-4" aria-hidden />
             <p className="text-lg font-semibold text-white">Starting your game</p>
-            <p className="mt-2 text-sm text-zinc-300">
-              Confirming payment on-chain and joining the session…
+            <p className="mt-2 text-sm text-zinc-300">{joinProgressMessage}</p>
+            <p className="mt-4 text-xs text-zinc-500">
+              This usually takes a few seconds. On busy networks it can take up to a minute.
             </p>
           </div>
         </div>

--- a/hooks/useGameSession.ts
+++ b/hooks/useGameSession.ts
@@ -31,6 +31,8 @@ export interface JoinGameOptions {
   lobbyDurationSec?: number;
   /** Passed to paid entry verification alongside sub-account `address`. */
   walletUniversalAddress?: string | null;
+  /** Optional progress callback for post-payment join UX */
+  onProgress?: (message: string) => void;
 }
 
 interface UseGameSessionReturn {
@@ -147,7 +149,12 @@ export const useGameSession = (): UseGameSessionReturn => {
         setPlayerId(currentPlayerId);
       }
 
+      const reportProgress = (message: string) => {
+        options?.onProgress?.(message);
+      };
+
       const modeParam = options?.playerMode ?? (isPaidPlayer ? 'paid_solo' : 'trial');
+      reportProgress('Connecting to game session…');
       const sessionResp = await fetch(
         `/api/game-session?mode=${encodeURIComponent(modeParam)}`
       );
@@ -160,6 +167,11 @@ export const useGameSession = (): UseGameSessionReturn => {
         throw new Error('No active game session found');
       }
 
+      reportProgress(
+        isPaidPlayer
+          ? 'Confirming your payment on-chain…'
+          : 'Starting your trial game…',
+      );
       const entryResp = await retryWithBackoff(async () => {
         const resp = await fetch('/api/game-entry', {
           method: 'POST',
@@ -188,9 +200,13 @@ export const useGameSession = (): UseGameSessionReturn => {
         }
 
         return resp;
+      }, {
+        maxAttempts: isPaidPlayer ? 8 : 5,
+        initialDelayMs: isPaidPlayer ? 750 : 1_000,
       });
 
       const { entryId, token, onChainSessionId } = await entryResp.json();
+      reportProgress('Payment confirmed — joining your game…');
 
       if (!isPaidPlayer) {
         // Trial: no Spacetime paid session needed
@@ -213,6 +229,7 @@ export const useGameSession = (): UseGameSessionReturn => {
         }
       }
 
+      reportProgress('Almost ready — loading your first question…');
       const response = await fetch('/api/game-session', {
         method: 'POST',
         headers: { 'Content-Type': 'application/json' },

--- a/lib/game/retryWithBackoff.ts
+++ b/lib/game/retryWithBackoff.ts
@@ -16,6 +16,10 @@ const defaultShouldRetry = (error: unknown): boolean => {
   return (
     lower.includes('pending') ||
     lower.includes('could not load transaction') ||
+    lower.includes('could not be verified') ||
+    lower.includes('transaction not found') ||
+    lower.includes('could not determine') ||
+    lower.includes('verification will retry') ||
     lower.includes('network') ||
     lower.includes('fetch') ||
     lower.includes('timeout') ||

--- a/lib/game/scoreReceipt.ts
+++ b/lib/game/scoreReceipt.ts
@@ -62,7 +62,7 @@ export const verifyScoreReceipt = (
     if (payload.sc < 0 || payload.av < 0 || !Number.isFinite(payload.sc)) return null;
 
     const elapsedMs = Date.now() - payload.iat;
-    if (elapsedMs > RECEIPT_TTL_MS || elapsedMs < 0) return null;
+    if (elapsedMs > RECEIPT_TTL_MS || elapsedMs < -30_000) return null;
 
     return payload;
   } catch {
@@ -83,12 +83,13 @@ export const advancePaidScore = (params: {
   let baseScore = 0;
   let baseAnswers = 0;
 
-  if (params.previousReceipt) {
-    const verified = verifyScoreReceipt(params.previousReceipt, params.entryId, wallet);
-    if (verified) {
-      baseScore = verified.sc;
-      baseAnswers = verified.av;
-    }
+  const verified = params.previousReceipt
+    ? verifyScoreReceipt(params.previousReceipt, params.entryId, wallet)
+    : null;
+
+  if (verified) {
+    baseScore = verified.sc;
+    baseAnswers = verified.av;
   } else if (
     typeof params.ledgerTotalScore === 'number' &&
     typeof params.ledgerAnswersVerified === 'number'

--- a/lib/game/scoreReceipt.ts
+++ b/lib/game/scoreReceipt.ts
@@ -1,0 +1,112 @@
+import crypto from 'crypto';
+
+/**
+ * HMAC-signed cumulative score receipt for paid games.
+ * Survives serverless cold starts where the in-memory paidScoreLedger is empty.
+ */
+
+export type ScoreReceiptPayload = {
+  /** entryId from JWT */
+  eid: string;
+  /** wallet address (lowercase) */
+  wal: string;
+  /** cumulative score */
+  sc: number;
+  /** verified answer count */
+  av: number;
+  /** on-chain session id */
+  ocs: string;
+  /** issued at ms */
+  iat: number;
+};
+
+const RECEIPT_TTL_MS = 3 * 60 * 60 * 1000;
+
+function getSecret(): Buffer {
+  const secret = process.env.ENTRY_TOKEN_SECRET;
+  if (!secret) {
+    throw new Error('ENTRY_TOKEN_SECRET is required for score receipts');
+  }
+  return Buffer.from(secret);
+}
+
+function hmacSign(payload: string): string {
+  return crypto.createHmac('sha256', getSecret()).update(payload).digest('base64url');
+}
+
+export const signScoreReceipt = (payload: ScoreReceiptPayload): string => {
+  const payloadStr = Buffer.from(JSON.stringify(payload)).toString('base64url');
+  const sig = hmacSign(payloadStr);
+  return `${payloadStr}.${sig}`;
+};
+
+export const verifyScoreReceipt = (
+  token: string,
+  entryId: string,
+  walletAddress: string,
+): ScoreReceiptPayload | null => {
+  try {
+    const dotIdx = token.lastIndexOf('.');
+    if (dotIdx === -1) return null;
+
+    const payloadStr = token.slice(0, dotIdx);
+    const sig = token.slice(dotIdx + 1);
+    if (hmacSign(payloadStr) !== sig) return null;
+
+    const payload = JSON.parse(
+      Buffer.from(payloadStr, 'base64url').toString(),
+    ) as ScoreReceiptPayload;
+
+    const wallet = walletAddress.trim().toLowerCase();
+    if (payload.eid !== entryId || payload.wal !== wallet) return null;
+    if (payload.sc < 0 || payload.av < 0 || !Number.isFinite(payload.sc)) return null;
+
+    const elapsedMs = Date.now() - payload.iat;
+    if (elapsedMs > RECEIPT_TTL_MS || elapsedMs < 0) return null;
+
+    return payload;
+  } catch {
+    return null;
+  }
+};
+
+export const advancePaidScore = (params: {
+  entryId: string;
+  walletAddress: string;
+  onChainSessionId: string;
+  pointsEarned: number;
+  previousReceipt?: string | null;
+  ledgerTotalScore?: number;
+  ledgerAnswersVerified?: number;
+}): { totalScore: number; answersVerified: number; receipt: string } => {
+  const wallet = params.walletAddress.trim().toLowerCase();
+  let baseScore = 0;
+  let baseAnswers = 0;
+
+  if (params.previousReceipt) {
+    const verified = verifyScoreReceipt(params.previousReceipt, params.entryId, wallet);
+    if (verified) {
+      baseScore = verified.sc;
+      baseAnswers = verified.av;
+    }
+  } else if (
+    typeof params.ledgerTotalScore === 'number' &&
+    typeof params.ledgerAnswersVerified === 'number'
+  ) {
+    baseScore = params.ledgerTotalScore;
+    baseAnswers = params.ledgerAnswersVerified;
+  }
+
+  const totalScore = baseScore + params.pointsEarned;
+  const answersVerified = baseAnswers + 1;
+  const receipt = signScoreReceipt({
+    eid: params.entryId,
+    wal: wallet,
+    sc: totalScore,
+    av: answersVerified,
+    ocs: params.onChainSessionId,
+    iat: Date.now(),
+  });
+
+  return { totalScore, answersVerified, receipt };
+};

--- a/tests/score-receipt.test.ts
+++ b/tests/score-receipt.test.ts
@@ -88,4 +88,28 @@ describe('scoreReceipt', () => {
     assert.equal(third.totalScore, 140);
     assert.equal(third.answersVerified, 3);
   });
+
+  it('falls back to ledger when previous receipt fails verification', () => {
+    const staleReceipt = signScoreReceipt({
+      eid: entryId,
+      wal: wallet.toLowerCase(),
+      sc: 999,
+      av: 99,
+      ocs: onChainSessionId,
+      iat: Date.now() - 4 * 60 * 60 * 1000,
+    });
+
+    const advanced = advancePaidScore({
+      entryId,
+      walletAddress: wallet,
+      onChainSessionId,
+      pointsEarned: 40,
+      previousReceipt: staleReceipt,
+      ledgerTotalScore: 80,
+      ledgerAnswersVerified: 1,
+    });
+
+    assert.equal(advanced.totalScore, 120);
+    assert.equal(advanced.answersVerified, 2);
+  });
 });

--- a/tests/score-receipt.test.ts
+++ b/tests/score-receipt.test.ts
@@ -1,0 +1,91 @@
+/**
+ * Score receipt helpers — run with: npx tsx --test tests/score-receipt.test.ts
+ */
+
+import assert from 'node:assert/strict';
+import { describe, it, before, after } from 'node:test';
+import {
+  advancePaidScore,
+  signScoreReceipt,
+  verifyScoreReceipt,
+} from '../lib/game/scoreReceipt';
+
+const ORIGINAL_SECRET = process.env.ENTRY_TOKEN_SECRET;
+
+before(() => {
+  process.env.ENTRY_TOKEN_SECRET = 'test-secret-for-score-receipts';
+});
+
+after(() => {
+  if (ORIGINAL_SECRET === undefined) {
+    delete process.env.ENTRY_TOKEN_SECRET;
+  } else {
+    process.env.ENTRY_TOKEN_SECRET = ORIGINAL_SECRET;
+  }
+});
+
+describe('scoreReceipt', () => {
+  const entryId = 'entry-123';
+  const wallet = '0xabcdef1234567890123456789012345678901234';
+  const onChainSessionId = '42';
+
+  it('signs and verifies a receipt', () => {
+    const receipt = signScoreReceipt({
+      eid: entryId,
+      wal: wallet.toLowerCase(),
+      sc: 120,
+      av: 2,
+      ocs: onChainSessionId,
+      iat: Date.now(),
+    });
+
+    const verified = verifyScoreReceipt(receipt, entryId, wallet);
+    assert.ok(verified);
+    assert.equal(verified!.sc, 120);
+    assert.equal(verified!.av, 2);
+  });
+
+  it('rejects tampered receipts', () => {
+    const receipt = signScoreReceipt({
+      eid: entryId,
+      wal: wallet.toLowerCase(),
+      sc: 50,
+      av: 1,
+      ocs: onChainSessionId,
+      iat: Date.now(),
+    });
+    const tampered = receipt.slice(0, -4) + 'xxxx';
+    assert.equal(verifyScoreReceipt(tampered, entryId, wallet), null);
+  });
+
+  it('advances cumulative score across answers', () => {
+    const first = advancePaidScore({
+      entryId,
+      walletAddress: wallet,
+      onChainSessionId,
+      pointsEarned: 80,
+    });
+    assert.equal(first.totalScore, 80);
+    assert.equal(first.answersVerified, 1);
+
+    const second = advancePaidScore({
+      entryId,
+      walletAddress: wallet,
+      onChainSessionId,
+      pointsEarned: 0,
+      previousReceipt: first.receipt,
+    });
+    assert.equal(second.totalScore, 80);
+    assert.equal(second.answersVerified, 2);
+
+    const third = advancePaidScore({
+      entryId,
+      walletAddress: wallet,
+      onChainSessionId,
+      pointsEarned: 60,
+      previousReceipt: second.receipt,
+    });
+    assert.equal(third.totalScore, 140);
+    assert.equal(third.answersVerified, 3);
+  });
+});


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Problem

After paying 1 USDC for solo mode, players experienced:
1. A long, opaque "Starting your game" loading screen with no feedback
2. Answer selections showing **"Could not verify"** with 0 points — even though payment succeeded

## Root cause

Paid answer scoring relied on an **in-memory ledger** (`paidScoreLedger`) that is lost across Vercel/serverless function instances. When `/api/game-entry` initialized the ledger on one instance and `/api/verify-answer` ran on another, verification failed with "No active paid game session" — blocking the entire response (including correct/incorrect feedback).

## Fix

### Serverless-safe paid scoring
- Added HMAC-signed **score receipts** (`lib/game/scoreReceipt.ts`) that travel with the client between answers
- `/api/verify-answer` always returns correct/incorrect feedback when the question token is valid; ledger updates are best-effort
- `/api/save-paid-score` accepts score receipts as a fallback when the in-memory ledger is unavailable

### Better UX
- Post-payment join shows **step-by-step progress** ("Confirming payment…", "Joining game…", etc.)
- More aggressive retries for pending on-chain payment verification (8 attempts, broader retry patterns)
- Answer verification retries automatically on network errors, with a **Retry verification** button and clearer error text

### Review follow-ups (latest commit)
- Fixed **Retry verification** button via `force` param (React closure bug)
- Fixed `shouldRetry` string matching for transient errors
- Score receipt clock-skew grace + ledger fallback when receipt is stale
- Ledger init no longer gated on `onChainSessionId`

## Testing
- `npx tsx --test tests/score-receipt.test.ts` — 4 tests pass
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-64736505-0cdd-4fbc-b6a2-8e4e3f522d7f"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-64736505-0cdd-4fbc-b6a2-8e4e3f522d7f"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

