### PR TITLE
Fix empty weekly leaderboard with hybrid chain + SpacetimeDB merge

### DIFF
--- a/app/api/high-scores/route.ts
+++ b/app/api/high-scores/route.ts
@@ -85,7 +85,7 @@ export async function POST(req: NextRequest) {
       id: `weekly_${walletAddress.toLowerCase()}`,
       playerName: playerName || matched?.username || walletAddress,
       walletAddress: walletAddress.toLowerCase(),
-      score: matched?.bestScore ?? score,
+      score: matched ? Math.max(matched.bestScore, score) : score,
       timestamp: Date.now(),
       isGuest: false,
       playerType: 'paid',

--- a/app/api/high-scores/route.ts
+++ b/app/api/high-scores/route.ts
@@ -1,5 +1,6 @@
 import { NextRequest, NextResponse } from 'next/server';
-import { spacetimeClient } from '@/lib/apis/spacetime';
+import { getWeeklyLeaderboardEntries } from '@/lib/game/weeklyLeaderboardServer';
+import { computeRankForScore } from '@/lib/game/weeklyLeaderboard';
 
 interface HighScore {
   id: string;
@@ -13,32 +14,38 @@ interface HighScore {
   username?: string;
 }
 
-// In-memory storage for high scores (in production, this would be in SpaceTimeDB)
-let highScores: HighScore[] = [];
+const toHighScoreRow = (entry: {
+  walletAddress: string;
+  username?: string;
+  bestScore: number;
+}): HighScore => ({
+  id: `weekly_${entry.walletAddress}`,
+  playerName: entry.username ?? entry.walletAddress,
+  walletAddress: entry.walletAddress,
+  score: entry.bestScore,
+  timestamp: Date.now(),
+  isGuest: false,
+  playerType: 'paid',
+  username: entry.username,
+});
 
 export async function GET(req: NextRequest) {
   try {
     const { searchParams } = new URL(req.url);
-    const limit = parseInt(searchParams.get('limit') || '10');
-    
-    // Initialize SpacetimeDB connection
-    await spacetimeClient.initialize();
-    
-    // Filter for paid players only, sort by score (highest to lowest), limit to top 10
-    const paidScoresOnly = highScores.filter(score => score.playerType === 'paid');
-    const topScores = paidScoresOnly
-      .sort((a, b) => b.score - a.score)
-      .slice(0, Math.min(limit, 10)); // Ensure max 10 entries
-    
+    const limit = parseInt(searchParams.get('limit') || '10', 10);
+
+    const { entries } = await getWeeklyLeaderboardEntries(Math.min(limit, 10));
+    const highScores = entries.map(toHighScoreRow);
+
     return NextResponse.json({
-      highScores: topScores,
-      totalScores: highScores.length
+      highScores,
+      totalScores: highScores.length,
     });
   } catch (error) {
     console.error('Error fetching high scores:', error);
     return NextResponse.json(
       { error: 'Failed to fetch high scores' },
-      { status: 500 }
+      { status: 500 },
     );
   }
 }
@@ -46,57 +53,60 @@ export async function GET(req: NextRequest) {
 export async function POST(req: NextRequest) {
   try {
     const body = await req.json();
-    const { playerName, score, isGuest = false, guestId, playerType = 'paid', walletAddress } = body;
+    const {
+      playerName,
+      score,
+      isGuest = false,
+      guestId,
+      walletAddress,
+    } = body;
 
-    if (!playerName || typeof score !== 'number') {
+    if (isGuest) {
       return NextResponse.json(
-        { error: 'Player name and score are required' },
-        { status: 400 }
+        { error: 'Trial scores are not stored on the paid weekly leaderboard' },
+        { status: 400 },
       );
     }
 
-    // Initialize SpacetimeDB connection
-    await spacetimeClient.initialize();
-
-    const newScore: HighScore = {
-      id: `score_${Date.now()}_${Math.random().toString(36).substr(2, 9)}`,
-      playerName,
-      walletAddress: walletAddress || undefined,
-      score,
-      timestamp: Date.now(),
-      isGuest,
-      guestId,
-      playerType: isGuest ? 'trial' : 'paid',
-      username: playerName // Store username if provided
-    };
-
-    // Add to high scores (in-memory for now)
-    highScores.push(newScore);
-    
-    // Keep only top 100 scores to prevent memory issues
-    if (highScores.length > 100) {
-      highScores = highScores
-        .sort((a, b) => b.score - a.score)
-        .slice(0, 100);
+    if (!walletAddress || typeof score !== 'number') {
+      return NextResponse.json(
+        { error: 'walletAddress and score are required for rank lookup' },
+        { status: 400 },
+      );
     }
 
-    // Check if this is a new high score
-    const sortedScores = [...highScores].sort((a, b) => b.score - a.score);
-    const isNewHighScore = sortedScores[0]?.id === newScore.id;
-    const rank = sortedScores.findIndex(s => s.id === newScore.id) + 1;
+    const { entries } = await getWeeklyLeaderboardEntries(100);
+    const rank = computeRankForScore(entries, walletAddress, score);
+    const matched = entries.find(
+      (e) => e.walletAddress.toLowerCase() === walletAddress.toLowerCase(),
+    );
+
+    const row: HighScore = {
+      id: `weekly_${walletAddress.toLowerCase()}`,
+      playerName: playerName || matched?.username || walletAddress,
+      walletAddress: walletAddress.toLowerCase(),
+      score: matched?.bestScore ?? score,
+      timestamp: Date.now(),
+      isGuest: false,
+      playerType: 'paid',
+      username: playerName || matched?.username,
+    };
+
+    const isNewHighScore = rank === 1;
 
     return NextResponse.json({
       success: true,
-      score: newScore,
+      score: row,
       isNewHighScore,
       rank,
-      totalScores: highScores.length
+      totalScores: entries.length,
+      note: 'Paid scores persist via /api/save-paid-score; this endpoint returns weekly rank only.',
     });
   } catch (error) {
-    console.error('Error adding high score:', error);
+    console.error('Error resolving high score rank:', error);
     return NextResponse.json(
-      { error: 'Failed to add high score' },
-      { status: 500 }
+      { error: 'Failed to resolve score rank' },
+      { status: 500 },
     );
   }
 }

--- a/app/api/save-paid-score/route.ts
+++ b/app/api/save-paid-score/route.ts
@@ -3,7 +3,7 @@ import { spacetimeClient } from '@/lib/apis/spacetime';
 import { verifyEntryToken } from '@/lib/utils/jwt';
 import { finalizePaidScoreLedger } from '@/lib/game/paidScoreLedger';
 import { verifyScoreReceipt } from '@/lib/game/scoreReceipt';
-import { submitOnChainScore } from '@/lib/blockchain/submitOnChainScore';
+import { submitOnChainScoreWithRetry } from '@/lib/blockchain/submitOnChainScore';
 
 const MAX_GAME_SCORE = 3000;
 
@@ -104,9 +104,13 @@ export async function POST(req: NextRequest) {
     await spacetimeClient.ensurePlayerDataReady();
 
     if (spacetimeClient.isConfigured()) {
+      const sessionIdNumeric = onChainSessionId
+        ? Number(onChainSessionId)
+        : 0;
       await spacetimeClient.recordPaidGameScore(
         normalizedWallet,
         authoritativeScore,
+        sessionIdNumeric,
         displayUsername,
       );
       spacetimeUpdated = true;
@@ -118,14 +122,19 @@ export async function POST(req: NextRequest) {
       }
     }
 
-    const onChainResult = await submitOnChainScore(
+    const onChainResult = await submitOnChainScoreWithRetry(
       normalizedWallet,
       authoritativeScore,
       onChainSessionId,
     );
 
     if (!onChainResult.ok) {
-      console.warn('On-chain score submission failed:', onChainResult.error);
+      console.warn('On-chain score submission failed:', {
+        wallet: normalizedWallet,
+        score: authoritativeScore,
+        sessionId: onChainSessionId,
+        error: onChainResult.error,
+      });
       return NextResponse.json(
         {
           success: true,

--- a/app/game/page.tsx
+++ b/app/game/page.tsx
@@ -11,6 +11,7 @@ import PlayerCount from '@/components/game/PlayerCount';
 import GameEntry from '@/components/game/GameEntry';
 import GuestModeEntry from '@/components/game/GuestModeEntry';
 import HighScoreDisplay from '@/components/game/HighScoreDisplay';
+import { useWeeklyLeaderboard } from '@/hooks/useWeeklyLeaderboard';
 import { PlayerActivityMonitor } from '@/components/game/CDPEventMonitor';
 import type { TriviaQuestion, GameStartOptions } from '@/types/game';
 import { ASSETS } from '@/lib/config/assets';
@@ -49,7 +50,11 @@ export default function Game() {
   const [showGuestMode, setShowGuestMode] = useState(true);
   const [pendingGuestSync, setPendingGuestSync] = useState<{score: number, gameData: any} | null>(null);
   const timerTriggeredRef = useRef(false);
-  const [highScores, setHighScores] = useState<Array<{score: number}>>([]);
+  const { entries: weeklyLeaderboardEntries } = useWeeklyLeaderboard(10);
+  const weeklyHighScore =
+    weeklyLeaderboardEntries.length > 0
+      ? Math.max(...weeklyLeaderboardEntries.map((e) => e.bestScore))
+      : 0;
   const [selectedPlayer, setSelectedPlayer] = useState<ActivePlayer | null>(null);
   const [showPlayerProfile, setShowPlayerProfile] = useState(false);
   const [sessionIsTrial, setSessionIsTrial] = useState(false);
@@ -310,24 +315,11 @@ export default function Game() {
       setSessionIsTrial(isTrial);
       paidScoreSavedRef.current = false;
       setGameStarted(true);
-      fetchHighScores();
       loadRandomQuestion();
     } catch (err) {
       console.error('Error joining game:', err);
     }
   };
-
-  const fetchHighScores = useCallback(async () => {
-    try {
-      const response = await fetch('/api/high-scores?limit=10');
-      if (response.ok) {
-        const data = await response.json();
-        setHighScores(data.highScores || []);
-      }
-    } catch (error) {
-      console.error('Failed to fetch high scores:', error);
-    }
-  }, []);
 
   const handleGuestStart = async (name: string) => {
     setGuestName(name);
@@ -337,7 +329,6 @@ export default function Game() {
     await GuestSessionManager.createGuestPlayer(name);
     setShowGuestMode(false);
     setGameStarted(true);
-    fetchHighScores(); // Fetch high scores when game starts
     loadRandomQuestion();
   };
 
@@ -487,7 +478,7 @@ export default function Game() {
                 onShare={() => console.log('Game completion shared!')}
               />
               
-              {highScores.length > 0 && totalScore >= Math.max(...highScores.map(s => s.score)) && (
+              {weeklyHighScore > 0 && totalScore >= weeklyHighScore && (
                 <ComposeCastButton
                   achievementType="high-score"
                   score={totalScore}
@@ -570,16 +561,16 @@ export default function Game() {
           </div>
 
           {/* High Score Indicator */}
-          {highScores.length > 0 && (
+          {weeklyHighScore > 0 && (
             <div className="absolute left-1/2 -translate-x-1/2 top-[110px]">
               <div className="bg-yellow-500 text-black text-[10px] px-3 py-1 rounded-full border border-yellow-300 font-bold animate-pulse">
-                🏆 HIGH SCORE: {Math.max(...highScores.map(s => s.score))} USDC
+                🏆 HIGH SCORE: {weeklyHighScore.toLocaleString()} pts
               </div>
             </div>
           )}
 
           {/* You're in the Lead Indicator */}
-          {highScores.length > 0 && totalScore >= Math.max(...highScores.map(s => s.score)) && totalScore > 0 && (
+          {weeklyHighScore > 0 && totalScore >= weeklyHighScore && totalScore > 0 && (
             <div className="absolute left-1/2 -translate-x-1/2 top-[140px]">
               <div className="bg-green-500 text-white text-[10px] px-3 py-1 rounded-full border border-green-300 font-bold animate-bounce">
                 👑 YOU WIN!

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -138,7 +138,7 @@ function HomePage() {
     }
   }, [searchParams]);
 
-  // Persist paid run to Spacetime (TOP EARNERS / bestScore). Trial scores never call this.
+  // Persist paid run to Spacetime (weekly top scores). Trial scores never call this.
   useEffect(() => {
     if (!gameCompleted || !lastGameWasPaidRef.current || !address || !entryToken) return;
     if (paidScoreSavedRef.current) return;
@@ -1298,10 +1298,10 @@ function HomePage() {
             </div>
           </div>
           
-          {/* Container for the TOP EARNERS section */}
+          {/* Container for the weekly top scores section */}
           <div className="flex flex-col items-center w-full">
             <h2 className="text-white text-lg font-['Audiowide:Regular',_sans-serif] mb-1">
-              TOP EARNERS
+              TOP SCORES
             </h2>
             <p className="text-gray-400 text-[10px] font-['Audiowide:Regular',_sans-serif] mb-3 text-center max-w-[328px]">
               Paid games only — resets each week after payout

--- a/components/leaderboard/LiveRankings.tsx
+++ b/components/leaderboard/LiveRankings.tsx
@@ -1,58 +1,58 @@
 'use client';
 
-import { useState, useEffect } from 'react';
+import { useMemo, useEffect } from 'react';
 import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card';
 import { Badge } from '@/components/ui/badge';
-import { Trophy, Medal, Award, TrendingUp, Clock, Target } from 'lucide-react';
+import { Trophy, Medal, Award, TrendingUp, Clock, Target, Loader2 } from 'lucide-react';
 import { BaseAvatar } from '@/components/identity/BaseAvatar';
 import { BaseName } from '@/components/identity/BaseName';
 import type { LeaderboardEntry } from '@/types/game';
 import { useMiniAppProfile } from '@/hooks/useMiniAppProfile';
+import { useLeaderboardLive } from '@/hooks/useLeaderboardLive';
 
 interface LiveRankingsProps {
-  entries: LeaderboardEntry[];
+  entries?: LeaderboardEntry[];
   currentPlayerAddress?: string;
   refreshInterval?: number;
+  limit?: number;
   className?: string;
 }
 
 export default function LiveRankings({
-  entries,
+  entries: entriesProp,
   currentPlayerAddress,
-  refreshInterval = 5000,
+  refreshInterval = 30000,
+  limit = 10,
   className = '',
 }: LiveRankingsProps) {
-  const [displayEntries, setDisplayEntries] = useState<LeaderboardEntry[]>([]);
-  const [isUpdating, setIsUpdating] = useState(false);
+  const {
+    leaderboardEntries: liveEntries,
+    sessionCounter,
+    isLoading,
+    refresh,
+  } = useLeaderboardLive(limit, { type: 'paid' });
+
   const { user: currentUserProfile } = useMiniAppProfile();
 
   useEffect(() => {
-    // Filter for paid players only, sort by total score in descending order, take top 10
-    const paidPlayersOnly = entries.filter(entry => !entry.isTrialPlayer);
-    const sortedEntries = paidPlayersOnly
+    if (!refreshInterval || entriesProp) return;
+    const interval = setInterval(() => {
+      void refresh();
+    }, refreshInterval);
+    return () => clearInterval(interval);
+  }, [refreshInterval, refresh, entriesProp]);
+
+  const displayEntries = useMemo(() => {
+    const source = entriesProp ?? liveEntries;
+    return source
+      .filter((entry) => !entry.isTrialPlayer)
       .sort((a, b) => b.totalScore - a.totalScore)
-      .slice(0, 10) // Top 10 only
+      .slice(0, limit)
       .map((entry, index) => ({
         ...entry,
-        rank: index + 1 // Reassign ranks based on sorted position
+        rank: index + 1,
       }));
-    
-    setDisplayEntries(sortedEntries);
-  }, [entries]);
-
-  useEffect(() => {
-    if (!refreshInterval) return;
-
-    const interval = setInterval(() => {
-      setIsUpdating(true);
-      // Simulate real-time updates - in production this would fetch from server
-      setTimeout(() => {
-        setIsUpdating(false);
-      }, 500);
-    }, refreshInterval);
-
-    return () => clearInterval(interval);
-  }, [refreshInterval]);
+  }, [entriesProp, liveEntries, limit]);
 
   const getRankIcon = (rank: number) => {
     switch (rank) {
@@ -110,13 +110,15 @@ export default function LiveRankings({
         <CardTitle className="flex items-center justify-between">
           <div className="flex items-center space-x-2">
             <TrendingUp className="h-6 w-6 text-blue-500" />
-            <span>Top 10 Leaderboard</span>
+            <span>Top {limit} Leaderboard</span>
           </div>
-          {isUpdating && (
-            <div className="flex items-center space-x-2 text-sm text-gray-500">
-              <div className="w-2 h-2 bg-green-500 rounded-full animate-pulse" />
-              <span>Updating...</span>
-            </div>
+          {sessionCounter > 0 && (
+            <span className="text-xs text-gray-500 font-normal">
+              Week {sessionCounter}
+            </span>
+          )}
+          {isLoading && !entriesProp && (
+            <Loader2 className="h-4 w-4 animate-spin text-gray-400" />
           )}
         </CardTitle>
       </CardHeader>

--- a/hooks/useLeaderboardLive.ts
+++ b/hooks/useLeaderboardLive.ts
@@ -1,107 +1,87 @@
-import { useState, useEffect } from 'react';
-import { useSpacetime } from '@/components/providers/SpacetimeProvider';
+import { useMemo } from 'react';
+import { useWeeklyLeaderboard } from '@/hooks/useWeeklyLeaderboard';
+import type { LeaderboardEntry } from '@/types/game';
 import type { PlayerStats } from '@/lib/spacetime/database';
 
 interface UseLeaderboardOptions {
-  /**
-   * Enable real-time updates via WebSocket subscriptions
-   * @default true (always realtime with new SDK)
-   */
   realtime?: boolean;
-  /**
-   * Type of leaderboard: 'paid' (prize-eligible) or 'trial'
-   * @default 'paid'
-   */
   type?: 'paid' | 'trial';
-  /**
-   * Polling interval - deprecated, new SDK uses WebSocket by default
-   * @deprecated
-   */
   pollInterval?: number;
 }
 
+const mapToLeaderboardEntry = (
+  entry: {
+    walletAddress: string;
+    username?: string;
+    bestScore: number;
+    totalEarnings?: number;
+  },
+  rank: number,
+): LeaderboardEntry => ({
+  rank,
+  playerAddress: entry.walletAddress,
+  playerName: entry.username,
+  totalScore: entry.bestScore,
+  gamesPlayed: 1,
+  averageScore: entry.bestScore,
+  totalEarnings: entry.totalEarnings ?? 0,
+  lastPlayed: Date.now(),
+  isTrialPlayer: false,
+});
+
 /**
- * Hook to fetch leaderboard data with real-time updates
- * 
- * @example
- * // Paid player leaderboard with real-time updates
- * const { stats, isLoading } = useLeaderboardLive(10);
- * 
- * @example
- * // Trial player leaderboard
- * const { stats } = useLeaderboardLive(10, { type: 'trial' });
+ * Weekly paid leaderboard with real-time SpacetimeDB merge.
+ * Trial type falls back to guest_players via Spacetime cache (legacy shape).
  */
 export function useLeaderboardLive(
   limit: number = 10,
-  options: UseLeaderboardOptions = {}
+  options: UseLeaderboardOptions = {},
 ) {
   const { type = 'paid' } = options;
-  const { connection, isConnected, error: connectionError } = useSpacetime();
-  
-  const [stats, setStats] = useState<PlayerStats[]>([]);
-  const [isLoading, setIsLoading] = useState(true);
-  const [error, setError] = useState<Error | null>(null);
-  const [lastUpdated, setLastUpdated] = useState<number>(0);
-
-  useEffect(() => {
-    if (!isConnected || !connection) {
-      setIsLoading(false);
-      return;
-    }
-
-    try {
-      // Subscribe to player_stats table changes
-      const updateLeaderboard = () => {
-        const playerTypeTag = type === 'paid' ? 'Paid' : 'Trial';
-        const leaderboard = Array.from(connection.db.player_stats.iter())
-          .filter((s: PlayerStats) => s.playerType.tag === playerTypeTag)
-          .sort((a: PlayerStats, b: PlayerStats) => b.bestScore - a.bestScore)
-          .slice(0, limit);
-
-        setStats(leaderboard);
-        setLastUpdated(Date.now());
-        setIsLoading(false);
-      };
-
-      // Initial update
-      updateLeaderboard();
-
-      const onTableChange = () => {
-        updateLeaderboard();
-      };
-
-      connection.db.player_stats.onInsert(onTableChange);
-      connection.db.player_stats.onUpdate(onTableChange);
-      connection.db.player_stats.onDelete(onTableChange);
-
-      return () => {
-        connection.db.player_stats.removeOnInsert(onTableChange);
-        connection.db.player_stats.removeOnUpdate(onTableChange);
-        connection.db.player_stats.removeOnDelete(onTableChange);
-      };
-    } catch (err) {
-      console.error('Error setting up leaderboard subscription:', err);
-      setError(err instanceof Error ? err : new Error('Failed to load leaderboard'));
-      setIsLoading(false);
-    }
-  }, [connection, isConnected, limit, type]);
-
-  useEffect(() => {
-    if (connectionError) {
-      setError(connectionError);
-      setIsLoading(false);
-    }
-  }, [connectionError]);
-
-  return {
-    stats,
+  const {
+    entries: weeklyEntries,
+    sessionCounter,
     isLoading,
     error,
     lastUpdated,
-    refresh: () => {
-      setLastUpdated(Date.now());
-    },
-    isRealtime: true, // Always realtime with new SDK
+    refresh,
+  } = useWeeklyLeaderboard(limit);
+
+  const stats: PlayerStats[] = useMemo(() => {
+    if (type !== 'paid') return [];
+    return weeklyEntries.map(
+      (entry, index) =>
+        ({
+          walletAddress: entry.walletAddress,
+          bestScore: entry.bestScore,
+          totalScore: entry.bestScore,
+          totalGames: 1,
+          averageScore: entry.bestScore,
+          playerType: { tag: 'Paid' as const },
+          rank: index + 1,
+        }) as unknown as PlayerStats,
+    );
+  }, [weeklyEntries, type]);
+
+  const leaderboardEntries: LeaderboardEntry[] = useMemo(
+    () =>
+      type === 'paid'
+        ? weeklyEntries.map((entry, index) =>
+            mapToLeaderboardEntry(entry, index + 1),
+          )
+        : [],
+    [weeklyEntries, type],
+  );
+
+  return {
+    stats,
+    leaderboardEntries,
+    sessionCounter,
+    isLoading,
+    error: error ? new Error(error) : null,
+    lastUpdated,
+    refresh,
+    isRealtime: true,
     type,
   };
 }

--- a/hooks/useWeeklyLeaderboard.ts
+++ b/hooks/useWeeklyLeaderboard.ts
@@ -1,111 +1,30 @@
 'use client';
 
 import { useState, useEffect, useCallback } from 'react';
-import { decodeFunctionResult, encodeFunctionData } from 'viem';
-import { TRIVIA_ABI, TRIVIA_CONTRACT_ADDRESS } from '@/lib/blockchain/contracts';
 import { useSpacetime } from '@/components/providers/SpacetimeProvider';
 import type { Player } from '@/lib/spacetime/database';
+import {
+  type WeeklyLeaderboardEntry,
+  fetchWeeklyScoresFromChain,
+  mergeWeeklyLeaderboardEntries,
+  enrichWeeklyEntriesWithMetadata,
+} from '@/lib/game/weeklyLeaderboard';
 
-const BASE_RPC_URL = process.env.NEXT_PUBLIC_BASE_RPC_URL || 'https://mainnet.base.org';
+export type { WeeklyLeaderboardEntry };
 
-export interface WeeklyLeaderboardEntry {
-  walletAddress: string;
-  username?: string;
-  avatarUrl?: string;
-  bestScore: number;
-  sessionCounter: number;
-}
-
-type JsonRpcResponse = {
-  id: number;
-  result?: string;
-  error?: { message: string };
-};
-
-/** Batch multiple eth_call requests into a single HTTP round-trip. */
-const rpcBatchEthCall = async (callData: `0x${string}`[]): Promise<string[]> => {
-  if (callData.length === 0) return [];
-
-  const payload = callData.map((data, index) => ({
-    jsonrpc: '2.0',
-    id: index + 1,
-    method: 'eth_call',
-    params: [{ to: TRIVIA_CONTRACT_ADDRESS, data }, 'latest'],
+const toSpacetimeRows = (players: Player[]) =>
+  players.map((p) => ({
+    walletAddress: p.walletAddress,
+    username: p.username,
+    avatarUrl: p.avatarUrl,
+    weeklySessionId: p.weeklySessionId,
+    weeklyBestScore: p.weeklyBestScore,
+    totalEarnings: p.totalEarnings,
   }));
-
-  const res = await fetch(BASE_RPC_URL, {
-    method: 'POST',
-    headers: { 'Content-Type': 'application/json' },
-    body: JSON.stringify(payload),
-  });
-  const json = (await res.json()) as JsonRpcResponse[];
-  const sorted = [...json].sort((a, b) => a.id - b.id);
-
-  return sorted.map((item, index) => {
-    if (item.error) {
-      throw new Error(item.error.message || `RPC batch call ${index + 1} failed`);
-    }
-    return item.result ?? '0x';
-  });
-};
-
-const fetchWeeklyScoresFromChain = async (): Promise<{
-  sessionCounter: number;
-  entries: WeeklyLeaderboardEntry[];
-}> => {
-  const sessionCounterData = encodeFunctionData({
-    abi: TRIVIA_ABI,
-    functionName: 'sessionCounter',
-  });
-  const playersListData = encodeFunctionData({
-    abi: TRIVIA_ABI,
-    functionName: 'getCurrentPlayers',
-  });
-
-  const [sessionCounterRaw, playersRaw] = await rpcBatchEthCall([
-    sessionCounterData,
-    playersListData,
-  ]);
-  const sessionCounter = Number(BigInt(sessionCounterRaw));
-
-  let players: `0x${string}`[] = [];
-  if (playersRaw && playersRaw !== '0x') {
-    players = decodeFunctionResult({
-      abi: TRIVIA_ABI,
-      functionName: 'getCurrentPlayers',
-      data: playersRaw as `0x${string}`,
-    }) as `0x${string}`[];
-  }
-
-  if (players.length === 0) {
-    return { sessionCounter, entries: [] };
-  }
-
-  const scoreCallData = players.map((player) =>
-    encodeFunctionData({
-      abi: TRIVIA_ABI,
-      functionName: 'getPlayerScore',
-      args: [player],
-    }),
-  );
-
-  const scoreRaws = await rpcBatchEthCall(scoreCallData);
-
-  const entries = players
-    .map((player, index) => ({
-      walletAddress: player.toLowerCase(),
-      bestScore: Number(BigInt(scoreRaws[index] ?? '0x0')),
-      sessionCounter,
-    }))
-    .filter((entry) => entry.bestScore > 0)
-    .sort((a, b) => b.bestScore - a.bestScore);
-
-  return { sessionCounter, entries };
-};
 
 /**
  * Weekly leaderboard tied to the on-chain session counter.
- * Resets automatically when a new session opens after prize distribution.
+ * Merges on-chain scores with SpacetimeDB weekly session scores.
  */
 export const useWeeklyLeaderboard = (limit: number = 10) => {
   const { connection, isConnected } = useSpacetime();
@@ -115,25 +34,24 @@ export const useWeeklyLeaderboard = (limit: number = 10) => {
   const [error, setError] = useState<string | null>(null);
   const [lastUpdated, setLastUpdated] = useState(0);
 
-  const mergePlayerMetadata = useCallback(
-    (chainEntries: WeeklyLeaderboardEntry[]): WeeklyLeaderboardEntry[] => {
-      if (!connection || !isConnected) {
-        return chainEntries.slice(0, limit);
-      }
+  const buildMergedEntries = useCallback(
+    (
+      counter: number,
+      chainScores: Map<string, number>,
+    ): WeeklyLeaderboardEntry[] => {
+      const spacetimePlayers =
+        connection && isConnected
+          ? toSpacetimeRows(Array.from(connection.db.players.iter()) as Player[])
+          : [];
 
-      const playersByWallet = new Map<string, Player>();
-      for (const player of Array.from(connection.db.players.iter()) as Player[]) {
-        playersByWallet.set(player.walletAddress.toLowerCase(), player);
-      }
+      const merged = mergeWeeklyLeaderboardEntries(
+        counter,
+        chainScores,
+        spacetimePlayers,
+        limit,
+      );
 
-      return chainEntries.slice(0, limit).map((entry) => {
-        const player = playersByWallet.get(entry.walletAddress.toLowerCase());
-        return {
-          ...entry,
-          username: player?.username ?? entry.username,
-          avatarUrl: player?.avatarUrl,
-        };
-      });
+      return enrichWeeklyEntriesWithMetadata(merged, spacetimePlayers, limit);
     },
     [connection, isConnected, limit],
   );
@@ -141,10 +59,10 @@ export const useWeeklyLeaderboard = (limit: number = 10) => {
   const refresh = useCallback(async () => {
     try {
       setError(null);
-      const { sessionCounter: counter, entries: chainEntries } =
+      const { sessionCounter: counter, chainScores } =
         await fetchWeeklyScoresFromChain();
       setSessionCounter(counter);
-      setEntries(mergePlayerMetadata(chainEntries));
+      setEntries(buildMergedEntries(counter, chainScores));
       setLastUpdated(Date.now());
     } catch (err) {
       console.error('Error fetching weekly leaderboard:', err);
@@ -152,7 +70,7 @@ export const useWeeklyLeaderboard = (limit: number = 10) => {
     } finally {
       setIsLoading(false);
     }
-  }, [mergePlayerMetadata]);
+  }, [buildMergedEntries]);
 
   useEffect(() => {
     void refresh();
@@ -166,7 +84,13 @@ export const useWeeklyLeaderboard = (limit: number = 10) => {
     if (!connection || !isConnected) return;
 
     const handlePlayerChange = () => {
-      setEntries((prev) => mergePlayerMetadata(prev));
+      setEntries((prev) => {
+        if (sessionCounter === 0) return prev;
+        const chainScores = new Map(
+          prev.map((e) => [e.walletAddress.toLowerCase(), e.bestScore]),
+        );
+        return buildMergedEntries(sessionCounter, chainScores);
+      });
     };
 
     connection.db.players.onInsert(handlePlayerChange);
@@ -176,7 +100,7 @@ export const useWeeklyLeaderboard = (limit: number = 10) => {
       connection.db.players.removeOnInsert(handlePlayerChange);
       connection.db.players.removeOnUpdate(handlePlayerChange);
     };
-  }, [connection, isConnected, mergePlayerMetadata]);
+  }, [connection, isConnected, sessionCounter, buildMergedEntries]);
 
   return {
     entries,

--- a/lib/apis/spacetime.ts
+++ b/lib/apis/spacetime.ts
@@ -458,17 +458,24 @@ class SpacetimeDBClient {
   async recordPaidGameScore(
     walletAddress: string,
     gameScore: number,
+    onChainSessionId: number | string,
     username?: string,
   ): Promise<void> {
     if (!this.connection) return;
+
+    const sessionId =
+      typeof onChainSessionId === 'string'
+        ? BigInt(onChainSessionId || '0')
+        : BigInt(onChainSessionId);
 
     try {
       await this.connection.reducers.recordPaidGameScore({
         walletAddress,
         gameScore,
+        onChainSessionId: sessionId,
         username: username ?? undefined,
       });
-      console.log(`✅ Recorded paid game score: ${walletAddress} (+${gameScore})`);
+      console.log(`✅ Recorded paid game score: ${walletAddress} (+${gameScore}) session ${sessionId}`);
     } catch (error) {
       console.error('❌ Failed to record paid game score:', error);
       throw error;
@@ -718,6 +725,18 @@ class SpacetimeDBClient {
         gamesPlayed: p.gamesPlayed,
         bestScore: p.bestScore,
       }));
+  }
+
+  /** Paid weekly leaderboard rows from local Spacetime cache (no chain merge). */
+  getWeeklyPlayersFromCache(sessionCounter: number, limit: number = 10): Player[] {
+    if (!this.connection) return [];
+    const sessionId = BigInt(sessionCounter);
+    return (Array.from(this.connection.db.players.iter()) as Player[])
+      .filter(
+        (p) => p.weeklySessionId === sessionId && p.weeklyBestScore > 0,
+      )
+      .sort((a, b) => b.weeklyBestScore - a.weeklyBestScore)
+      .slice(0, limit);
   }
 
   // ============================================================================

--- a/lib/blockchain/submitOnChainScore.ts
+++ b/lib/blockchain/submitOnChainScore.ts
@@ -25,6 +25,55 @@ export type SubmitOnChainScoreResult =
   | { ok: true; transactionHash: `0x${string}`; sessionCounter: bigint }
   | { ok: false; error: string };
 
+const sleep = (ms: number) => new Promise((resolve) => setTimeout(resolve, ms));
+
+const isRetryableOnChainError = (error: string): boolean => {
+  const lower = error.toLowerCase();
+  return (
+    lower.includes('timeout') ||
+    lower.includes('rate limit') ||
+    lower.includes('network') ||
+    lower.includes('econnreset') ||
+    lower.includes('nonce') ||
+    lower.includes('replacement transaction underpriced')
+  );
+};
+
+/**
+ * Submit with one retry (~2s) on transient RPC / nonce failures.
+ */
+export async function submitOnChainScoreWithRetry(
+  walletAddress: string,
+  score: number,
+  expectedSessionId?: string,
+): Promise<SubmitOnChainScoreResult> {
+  const first = await submitOnChainScore(walletAddress, score, expectedSessionId);
+  if (first.ok || !isRetryableOnChainError(first.error)) {
+    if (!first.ok) {
+      console.warn('[submitOnChainScore] failed', {
+        walletAddress,
+        score,
+        expectedSessionId,
+        error: first.error,
+      });
+    }
+    return first;
+  }
+
+  console.warn('[submitOnChainScore] retrying after transient error:', first.error);
+  await sleep(2000);
+  const second = await submitOnChainScore(walletAddress, score, expectedSessionId);
+  if (!second.ok) {
+    console.warn('[submitOnChainScore] retry failed', {
+      walletAddress,
+      score,
+      expectedSessionId,
+      error: second.error,
+    });
+  }
+  return second;
+}
+
 /**
  * Submit a player's latest score for the active on-chain session via owner wallet.
  */

--- a/lib/game/weeklyLeaderboard.ts
+++ b/lib/game/weeklyLeaderboard.ts
@@ -35,6 +35,15 @@ const normalizeRpcBatchResponse = (json: unknown): JsonRpcResponse[] => {
   return [json as JsonRpcResponse];
 };
 
+const safeBigIntFromHex = (hex: string | undefined): bigint => {
+  if (!hex || hex === '0x') return BigInt(0);
+  try {
+    return BigInt(hex);
+  } catch {
+    return BigInt(0);
+  }
+};
+
 /** Batch multiple eth_call requests into a single HTTP round-trip. */
 export const rpcBatchEthCall = async (
   callData: `0x${string}`[],
@@ -53,6 +62,7 @@ export const rpcBatchEthCall = async (
     method: 'POST',
     headers: { 'Content-Type': 'application/json' },
     body: JSON.stringify(payload.length === 1 ? payload[0] : payload),
+    cache: 'no-store',
   });
 
   const json = await res.json();
@@ -84,7 +94,7 @@ export const fetchWeeklyScoresFromChain = async (): Promise<{
     sessionCounterData,
     playersListData,
   ]);
-  const sessionCounter = Number(BigInt(sessionCounterRaw));
+  const sessionCounter = Number(safeBigIntFromHex(sessionCounterRaw));
 
   let players: `0x${string}`[] = [];
   if (playersRaw && playersRaw !== '0x') {
@@ -112,7 +122,7 @@ export const fetchWeeklyScoresFromChain = async (): Promise<{
 
   players.forEach((player, index) => {
     const wallet = player.toLowerCase();
-    const score = Number(BigInt(scoreRaws[index] ?? '0x0'));
+    const score = Number(safeBigIntFromHex(scoreRaws[index]));
     if (score > 0) {
       chainScores.set(wallet, score);
     }

--- a/lib/game/weeklyLeaderboard.ts
+++ b/lib/game/weeklyLeaderboard.ts
@@ -1,0 +1,212 @@
+import { decodeFunctionResult, encodeFunctionData } from 'viem';
+import { TRIVIA_ABI, TRIVIA_CONTRACT_ADDRESS } from '@/lib/blockchain/contracts';
+
+export interface WeeklyLeaderboardEntry {
+  walletAddress: string;
+  username?: string;
+  avatarUrl?: string;
+  bestScore: number;
+  totalEarnings?: number;
+  sessionCounter: number;
+}
+
+export interface SpacetimePlayerWeeklyRow {
+  walletAddress: string;
+  username?: string | null;
+  avatarUrl?: string | null;
+  weeklySessionId: bigint;
+  weeklyBestScore: number;
+  totalEarnings?: number;
+}
+
+type JsonRpcResponse = {
+  id: number;
+  result?: string;
+  error?: { message: string };
+};
+
+const BASE_RPC_URL =
+  process.env.NEXT_PUBLIC_BASE_RPC_URL ||
+  process.env.BASE_RPC_URL ||
+  'https://mainnet.base.org';
+
+const normalizeRpcBatchResponse = (json: unknown): JsonRpcResponse[] => {
+  if (Array.isArray(json)) return json as JsonRpcResponse[];
+  return [json as JsonRpcResponse];
+};
+
+/** Batch multiple eth_call requests into a single HTTP round-trip. */
+export const rpcBatchEthCall = async (
+  callData: `0x${string}`[],
+  rpcUrl: string = BASE_RPC_URL,
+): Promise<string[]> => {
+  if (callData.length === 0) return [];
+
+  const payload = callData.map((data, index) => ({
+    jsonrpc: '2.0',
+    id: index + 1,
+    method: 'eth_call',
+    params: [{ to: TRIVIA_CONTRACT_ADDRESS, data }, 'latest'],
+  }));
+
+  const res = await fetch(rpcUrl, {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify(payload.length === 1 ? payload[0] : payload),
+  });
+
+  const json = await res.json();
+  const items = normalizeRpcBatchResponse(json);
+  const sorted = [...items].sort((a, b) => a.id - b.id);
+
+  return sorted.map((item, index) => {
+    if (item.error) {
+      throw new Error(item.error.message || `RPC batch call ${index + 1} failed`);
+    }
+    return item.result ?? '0x';
+  });
+};
+
+export const fetchWeeklyScoresFromChain = async (): Promise<{
+  sessionCounter: number;
+  chainScores: Map<string, number>;
+}> => {
+  const sessionCounterData = encodeFunctionData({
+    abi: TRIVIA_ABI,
+    functionName: 'sessionCounter',
+  });
+  const playersListData = encodeFunctionData({
+    abi: TRIVIA_ABI,
+    functionName: 'getCurrentPlayers',
+  });
+
+  const [sessionCounterRaw, playersRaw] = await rpcBatchEthCall([
+    sessionCounterData,
+    playersListData,
+  ]);
+  const sessionCounter = Number(BigInt(sessionCounterRaw));
+
+  let players: `0x${string}`[] = [];
+  if (playersRaw && playersRaw !== '0x') {
+    players = decodeFunctionResult({
+      abi: TRIVIA_ABI,
+      functionName: 'getCurrentPlayers',
+      data: playersRaw as `0x${string}`,
+    }) as `0x${string}`[];
+  }
+
+  const chainScores = new Map<string, number>();
+  if (players.length === 0) {
+    return { sessionCounter, chainScores };
+  }
+
+  const scoreCallData = players.map((player) =>
+    encodeFunctionData({
+      abi: TRIVIA_ABI,
+      functionName: 'getPlayerScore',
+      args: [player],
+    }),
+  );
+
+  const scoreRaws = await rpcBatchEthCall(scoreCallData);
+
+  players.forEach((player, index) => {
+    const wallet = player.toLowerCase();
+    const score = Number(BigInt(scoreRaws[index] ?? '0x0'));
+    if (score > 0) {
+      chainScores.set(wallet, score);
+    }
+  });
+
+  return { sessionCounter, chainScores };
+};
+
+/** Merge on-chain scores with SpacetimeDB weekly session scores. */
+export const mergeWeeklyLeaderboardEntries = (
+  sessionCounter: number,
+  chainScores: Map<string, number>,
+  spacetimePlayers: SpacetimePlayerWeeklyRow[],
+  limit: number,
+): WeeklyLeaderboardEntry[] => {
+  const sessionId = BigInt(sessionCounter);
+  const merged = new Map<string, WeeklyLeaderboardEntry>();
+
+  for (const [wallet, score] of chainScores) {
+    merged.set(wallet, {
+      walletAddress: wallet,
+      bestScore: score,
+      sessionCounter,
+    });
+  }
+
+  for (const player of spacetimePlayers) {
+    if (player.weeklySessionId !== sessionId || player.weeklyBestScore <= 0) {
+      continue;
+    }
+    const wallet = player.walletAddress.toLowerCase();
+    const existing = merged.get(wallet);
+    const bestScore = Math.max(existing?.bestScore ?? 0, player.weeklyBestScore);
+    merged.set(wallet, {
+      walletAddress: wallet,
+      username: player.username ?? existing?.username,
+      avatarUrl: player.avatarUrl ?? existing?.avatarUrl,
+      bestScore,
+      totalEarnings: player.totalEarnings ?? existing?.totalEarnings,
+      sessionCounter,
+    });
+  }
+
+  return [...merged.values()]
+    .filter((entry) => entry.bestScore > 0)
+    .sort((a, b) => b.bestScore - a.bestScore)
+    .slice(0, limit);
+};
+
+export const enrichWeeklyEntriesWithMetadata = (
+  entries: WeeklyLeaderboardEntry[],
+  spacetimePlayers: SpacetimePlayerWeeklyRow[],
+  limit: number,
+): WeeklyLeaderboardEntry[] => {
+  const playersByWallet = new Map(
+    spacetimePlayers.map((p) => [p.walletAddress.toLowerCase(), p]),
+  );
+
+  return entries.slice(0, limit).map((entry) => {
+    const player = playersByWallet.get(entry.walletAddress.toLowerCase());
+    return {
+      ...entry,
+      username: player?.username ?? entry.username ?? undefined,
+      avatarUrl: player?.avatarUrl ?? entry.avatarUrl ?? undefined,
+      totalEarnings: player?.totalEarnings ?? entry.totalEarnings,
+    };
+  });
+};
+
+export const computeRankForScore = (
+  entries: WeeklyLeaderboardEntry[],
+  walletAddress: string,
+  score: number,
+): number => {
+  const normalized = walletAddress.toLowerCase();
+  const withCurrent = [...entries];
+  const existingIdx = withCurrent.findIndex(
+    (e) => e.walletAddress.toLowerCase() === normalized,
+  );
+  if (existingIdx >= 0) {
+    withCurrent[existingIdx] = {
+      ...withCurrent[existingIdx],
+      bestScore: Math.max(withCurrent[existingIdx].bestScore, score),
+    };
+  } else if (score > 0) {
+    withCurrent.push({
+      walletAddress: normalized,
+      bestScore: score,
+      sessionCounter: entries[0]?.sessionCounter ?? 0,
+    });
+  }
+  withCurrent.sort((a, b) => b.bestScore - a.bestScore);
+  const rankIdx = withCurrent.findIndex(
+    (e) => e.walletAddress.toLowerCase() === normalized,
+  );
+  return rankIdx >= 0 ? rankIdx + 1 : withCurrent.length + 1;
+};

--- a/lib/game/weeklyLeaderboardServer.ts
+++ b/lib/game/weeklyLeaderboardServer.ts
@@ -1,0 +1,42 @@
+import { spacetimeClient } from '@/lib/apis/spacetime';
+import type { Player } from '@/lib/spacetime/database';
+import {
+  type WeeklyLeaderboardEntry,
+  fetchWeeklyScoresFromChain,
+  mergeWeeklyLeaderboardEntries,
+  enrichWeeklyEntriesWithMetadata,
+} from '@/lib/game/weeklyLeaderboard';
+
+const toSpacetimeRows = (players: Player[]) =>
+  players.map((p) => ({
+    walletAddress: p.walletAddress,
+    username: p.username,
+    avatarUrl: p.avatarUrl,
+    weeklySessionId: p.weeklySessionId,
+    weeklyBestScore: p.weeklyBestScore,
+    totalEarnings: p.totalEarnings,
+  }));
+
+/** Server-side hybrid weekly leaderboard (chain + SpacetimeDB cache). */
+export const getWeeklyLeaderboardEntries = async (
+  limit: number = 10,
+): Promise<{ sessionCounter: number; entries: WeeklyLeaderboardEntry[] }> => {
+  await spacetimeClient.ensurePlayerDataReady();
+
+  const { sessionCounter, chainScores } = await fetchWeeklyScoresFromChain();
+  const players = spacetimeClient.isConfigured()
+    ? spacetimeClient.getAllPlayers()
+    : [];
+
+  const merged = mergeWeeklyLeaderboardEntries(
+    sessionCounter,
+    chainScores,
+    toSpacetimeRows(players),
+    limit,
+  );
+
+  return {
+    sessionCounter,
+    entries: enrichWeeklyEntriesWithMetadata(merged, toSpacetimeRows(players), limit),
+  };
+};

--- a/lib/game/weeklyLeaderboardServer.ts
+++ b/lib/game/weeklyLeaderboardServer.ts
@@ -21,7 +21,9 @@ const toSpacetimeRows = (players: Player[]) =>
 export const getWeeklyLeaderboardEntries = async (
   limit: number = 10,
 ): Promise<{ sessionCounter: number; entries: WeeklyLeaderboardEntry[] }> => {
-  await spacetimeClient.ensurePlayerDataReady();
+  if (process.env.SPACETIME_HOST && process.env.SPACETIME_MODULE) {
+    await spacetimeClient.ensurePlayerDataReady();
+  }
 
   const { sessionCounter, chainScores } = await fetchWeeklyScoresFromChain();
   const players = spacetimeClient.isConfigured()

--- a/lib/spacetime/players_table.ts
+++ b/lib/spacetime/players_table.ts
@@ -21,6 +21,8 @@ export default __t.row({
   trialGamesRemaining: __t.u32().name("trial_games_remaining"),
   trialCompleted: __t.bool().name("trial_completed"),
   walletConnected: __t.bool().name("wallet_connected"),
+  weeklySessionId: __t.u64().name("weekly_session_id"),
+  weeklyBestScore: __t.u32().name("weekly_best_score"),
   createdAt: __t.timestamp().name("created_at"),
   updatedAt: __t.timestamp().name("updated_at"),
 });

--- a/lib/spacetime/record_paid_game_score_reducer.ts
+++ b/lib/spacetime/record_paid_game_score_reducer.ts
@@ -13,5 +13,6 @@ import {
 export default {
   walletAddress: __t.string(),
   gameScore: __t.u32(),
+  onChainSessionId: __t.u64(),
   username: __t.option(__t.string()),
 };

--- a/lib/spacetime/types.ts
+++ b/lib/spacetime/types.ts
@@ -184,6 +184,8 @@ export const Player = __t.object("Player", {
   trialGamesRemaining: __t.u32(),
   trialCompleted: __t.bool(),
   walletConnected: __t.bool(),
+  weeklySessionId: __t.u64(),
+  weeklyBestScore: __t.u32(),
   createdAt: __t.timestamp(),
   updatedAt: __t.timestamp(),
 });

--- a/spacetime-module/beat-me/src/lib.rs
+++ b/spacetime-module/beat-me/src/lib.rs
@@ -219,6 +219,10 @@ pub struct Player {
     pub trial_games_remaining: u32,
     pub trial_completed: bool,
     pub wallet_connected: bool,
+    /// On-chain TriviaBattle sessionCounter for the current weekly period.
+    pub weekly_session_id: u64,
+    /// Best score for the current weekly session (resets when sessionCounter changes).
+    pub weekly_best_score: u32,
     pub created_at: Timestamp,
     pub updated_at: Timestamp,
 }
@@ -1147,6 +1151,8 @@ pub fn create_player(ctx: &ReducerContext, wallet_address: String, username: Opt
             trial_games_remaining: 1,
             trial_completed: false,
             wallet_connected: true,
+            weekly_session_id: 0,
+            weekly_best_score: 0,
             created_at: ctx.timestamp,
             updated_at: ctx.timestamp,
         });
@@ -1247,18 +1253,32 @@ fn apply_username_if_available(
         return;
     }
     let name_owned = trimmed.to_string();
-    if let Some(existing) = ctx.db.players().username().find(&name_owned) {
-        if existing.wallet_address != wallet_address {
-            log::warn!(
-                "Username '{}' already taken by {}, skipping for {}",
-                name_owned,
-                existing.wallet_address,
-                wallet_address
-            );
-            return;
-        }
+    let username_taken = ctx
+        .db
+        .players()
+        .iter()
+        .any(|p| p.username.as_deref() == Some(trimmed) && p.wallet_address != wallet_address);
+    if username_taken {
+        log::warn!(
+            "Username '{}' already taken, skipping for {}",
+            name_owned,
+            wallet_address
+        );
+        return;
     }
     player.username = Some(name_owned);
+}
+
+fn apply_weekly_score(player: &mut Player, on_chain_session_id: u64, game_score: u32) {
+    if on_chain_session_id == 0 {
+        return;
+    }
+    if player.weekly_session_id == on_chain_session_id {
+        player.weekly_best_score = std::cmp::max(player.weekly_best_score, game_score);
+    } else {
+        player.weekly_session_id = on_chain_session_id;
+        player.weekly_best_score = game_score;
+    }
 }
 
 /// Atomically record a completed paid game score (server-side accumulation).
@@ -1267,6 +1287,7 @@ pub fn record_paid_game_score(
     ctx: &ReducerContext,
     wallet_address: String,
     game_score: u32,
+    on_chain_session_id: u64,
     username: Option<String>,
 ) {
     log::info!(
@@ -1279,6 +1300,7 @@ pub fn record_paid_game_score(
         player.total_score = player.total_score.saturating_add(game_score);
         player.games_played = player.games_played.saturating_add(1);
         player.best_score = std::cmp::max(player.best_score, game_score);
+        apply_weekly_score(&mut player, on_chain_session_id, game_score);
         apply_username_if_available(ctx, &wallet_address, &mut player, username);
         player.updated_at = ctx.timestamp;
         ctx.db.players().wallet_address().update(player);
@@ -1295,6 +1317,16 @@ pub fn record_paid_game_score(
             trial_games_remaining: 0,
             trial_completed: true,
             wallet_connected: true,
+            weekly_session_id: if on_chain_session_id > 0 {
+                on_chain_session_id
+            } else {
+                0
+            },
+            weekly_best_score: if on_chain_session_id > 0 {
+                game_score
+            } else {
+                0
+            },
             created_at: ctx.timestamp,
             updated_at: ctx.timestamp,
         };
@@ -1344,6 +1376,8 @@ pub fn update_player_stats(
             trial_games_remaining: 0,
             trial_completed: true,
             wallet_connected: true,
+            weekly_session_id: 0,
+            weekly_best_score: 0,
             created_at: ctx.timestamp,
             updated_at: ctx.timestamp,
         };

--- a/spacetime-module/beat-me/src/lib.rs
+++ b/spacetime-module/beat-me/src/lib.rs
@@ -1253,6 +1253,8 @@ fn apply_username_if_available(
         return;
     }
     let name_owned = trimmed.to_string();
+    // Option<String> unique columns are not FilterableValue in SpacetimeDB 2.1,
+    // so .username().find() cannot be used; scan until schema uses plain String.
     let username_taken = ctx
         .db
         .players()
@@ -1275,7 +1277,7 @@ fn apply_weekly_score(player: &mut Player, on_chain_session_id: u64, game_score:
     }
     if player.weekly_session_id == on_chain_session_id {
         player.weekly_best_score = std::cmp::max(player.weekly_best_score, game_score);
-    } else {
+    } else if on_chain_session_id > player.weekly_session_id {
         player.weekly_session_id = on_chain_session_id;
         player.weekly_best_score = game_score;
     }


### PR DESCRIPTION
## Summary
- Merge on-chain weekly session scores with SpacetimeDB `weekly_best_score` so players appear on the leaderboard even when on-chain `submitScores` fails
- Add `weekly_session_id` / `weekly_best_score` to the Player table and pass session ID through `save-paid-score`
- Replace in-memory `/api/high-scores` with persisted hybrid reads; rewire `useLeaderboardLive` / `LiveRankings`; rename homepage label to TOP SCORES

## Test plan
- [ ] Publish SpacetimeDB module to `beat-me` on maincloud (`npm run spacetime:publish:maincloud`)
- [ ] Play a paid game and confirm `save-paid-score` updates SpacetimeDB weekly fields
- [ ] Verify homepage TopEarners shows players when `onChainSubmitted: false`
- [ ] Confirm `/api/high-scores` returns persisted scores after server restart
- [ ] Verify post-game HighScoreDisplay includes current player in merged list


Made with [Cursor](https://cursor.com)