### PR TITLE
Fix confetti celebration and weekly leaderboard ranking accuracy

### DIFF
--- a/app/api/high-scores/route.ts
+++ b/app/api/high-scores/route.ts
@@ -1,6 +1,6 @@
 import { NextRequest, NextResponse } from 'next/server';
 import { getWeeklyLeaderboardEntries } from '@/lib/game/weeklyLeaderboardServer';
-import { computeRankForScore } from '@/lib/game/weeklyLeaderboard';
+import { computeRankForScore, isNewWeeklyLeader } from '@/lib/game/weeklyLeaderboard';
 
 interface HighScore {
   id: string;
@@ -85,14 +85,14 @@ export async function POST(req: NextRequest) {
       id: `weekly_${walletAddress.toLowerCase()}`,
       playerName: playerName || matched?.username || walletAddress,
       walletAddress: walletAddress.toLowerCase(),
-      score: matched ? Math.max(matched.bestScore, score) : score,
+      score,
       timestamp: Date.now(),
       isGuest: false,
       playerType: 'paid',
       username: playerName || matched?.username,
     };
 
-    const isNewHighScore = rank === 1;
+    const isNewHighScore = isNewWeeklyLeader(entries, walletAddress, score);
 
     return NextResponse.json({
       success: true,

--- a/app/game/page.tsx
+++ b/app/game/page.tsx
@@ -60,6 +60,7 @@ export default function Game() {
   const [sessionIsTrial, setSessionIsTrial] = useState(false);
   const { address } = useBaseAccount();
   const paidScoreSavedRef = useRef(false);
+  const [paidScoreSaved, setPaidScoreSaved] = useState(false);
   const [verifiedCorrectAnswer, setVerifiedCorrectAnswer] = useState<number | null>(null);
   const [isVerifying, setIsVerifying] = useState(false);
 
@@ -314,6 +315,7 @@ export default function Game() {
       await joinGame(!isTrial, paidTxHash, { playerMode: playerMode ?? 'paid_solo' });
       setSessionIsTrial(isTrial);
       paidScoreSavedRef.current = false;
+      setPaidScoreSaved(false);
       setGameStarted(true);
       loadRandomQuestion();
     } catch (err) {
@@ -363,6 +365,7 @@ export default function Game() {
     if (!gameCompleted || isGuestMode || sessionIsTrial || !address || !entryToken) return;
     if (paidScoreSavedRef.current) return;
     paidScoreSavedRef.current = true;
+    setPaidScoreSaved(false);
     const wallet = address;
     const finalScore = totalScore;
     void (async () => {
@@ -372,9 +375,15 @@ export default function Game() {
           headers: { 'Content-Type': 'application/json' },
           body: JSON.stringify({ walletAddress: wallet, finalScore, entryToken }),
         });
-        if (!res.ok) paidScoreSavedRef.current = false;
+        if (!res.ok) {
+          paidScoreSavedRef.current = false;
+          setPaidScoreSaved(false);
+          return;
+        }
+        setPaidScoreSaved(true);
       } catch {
         paidScoreSavedRef.current = false;
+        setPaidScoreSaved(false);
       }
     })();
   }, [gameCompleted, isGuestMode, sessionIsTrial, address, totalScore, entryToken]);
@@ -457,6 +466,7 @@ export default function Game() {
               walletAddress={
                 !isGuestMode && !sessionIsTrial && address ? address : undefined
               }
+              scoreSaved={!isGuestMode && !sessionIsTrial && paidScoreSaved}
               className="w-full"
             />
           </div>
@@ -501,6 +511,7 @@ export default function Game() {
                 setTotalScore(0);
                 setGameCompleted(false);
                 paidScoreSavedRef.current = false;
+      setPaidScoreSaved(false);
                 setGameStarted(false); // Reset to entry screen
               }}
               className="bg-blue-500 hover:bg-blue-600 text-white px-4 py-2 rounded-lg"

--- a/app/game/page.tsx
+++ b/app/game/page.tsx
@@ -511,7 +511,7 @@ export default function Game() {
                 setTotalScore(0);
                 setGameCompleted(false);
                 paidScoreSavedRef.current = false;
-      setPaidScoreSaved(false);
+                setPaidScoreSaved(false);
                 setGameStarted(false); // Reset to entry screen
               }}
               className="bg-blue-500 hover:bg-blue-600 text-white px-4 py-2 rounded-lg"

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -78,6 +78,7 @@ function HomePage() {
   const timerTriggeredRef = useRef(false);
   const lastGameWasPaidRef = useRef(false);
   const paidScoreSavedRef = useRef(false);
+  const [paidScoreSaved, setPaidScoreSaved] = useState(false);
   const countdownStartedAtRef = useRef<number | null>(null);
   const [isCountdownActive, setIsCountdownActive] = useState(false);
   const [paidScoreWarning, setPaidScoreWarning] = useState<string | null>(null);
@@ -143,6 +144,7 @@ function HomePage() {
     if (!gameCompleted || !lastGameWasPaidRef.current || !address || !entryToken) return;
     if (paidScoreSavedRef.current) return;
     paidScoreSavedRef.current = true;
+    setPaidScoreSaved(false);
     const finalScore = totalScore;
     const wallet = address.toLowerCase();
     void (async () => {
@@ -160,11 +162,13 @@ function HomePage() {
         });
         if (!res.ok) {
           paidScoreSavedRef.current = false;
+          setPaidScoreSaved(false);
           const errText = await res.text();
           console.error('save-paid-score failed', errText);
           return;
         }
         const data = await res.json();
+        setPaidScoreSaved(true);
         if (data.authoritativeScore != null) {
           console.log('Paid score submitted:', data.authoritativeScore, 'tx', data.transactionHash);
         }
@@ -180,6 +184,7 @@ function HomePage() {
         refreshWeeklyLeaderboard();
       } catch (e) {
         paidScoreSavedRef.current = false;
+        setPaidScoreSaved(false);
         console.error('save-paid-score error', e);
       }
     })();
@@ -347,6 +352,7 @@ function HomePage() {
       setGameCompleted(false);
       setCompletedAsTrial(false);
       paidScoreSavedRef.current = false;
+    setPaidScoreSaved(false);
       lastGameWasPaidRef.current = false;
       setScore(0);
       setTotalScore(0);
@@ -554,6 +560,7 @@ function HomePage() {
 
   const handlePlayAgain = () => {
     paidScoreSavedRef.current = false;
+    setPaidScoreSaved(false);
     setGameCompleted(false);
     setGameStarted(false);
     setShowGameEntry(true);
@@ -650,6 +657,7 @@ function HomePage() {
           setCurrentRound(1);
           setQuestionNumberInRound(1);
           paidScoreSavedRef.current = false;
+    setPaidScoreSaved(false);
           // Start gameplay
           setGameStarted(true);
           loadRandomQuestion();
@@ -860,6 +868,7 @@ function HomePage() {
                   isGuest={isGuestMode}
                   isTrialGame={completedAsTrial}
                   walletAddress={!completedAsTrial && address ? address : undefined}
+                  scoreSaved={!completedAsTrial && paidScoreSaved}
                   className="w-full"
                 />
               </div>

--- a/components/game/GameScoreCard.tsx
+++ b/components/game/GameScoreCard.tsx
@@ -53,11 +53,13 @@ export default function GameScoreCard({
         });
         if (!res.ok) {
           paidScoreSavedRef.current = false;
+          setPaidScoreSaved(false);
           return;
         }
         setPaidScoreSaved(true);
       } catch {
         paidScoreSavedRef.current = false;
+        setPaidScoreSaved(false);
       }
     })();
   }, [isTrialGame, walletAddress, finalScore, entryToken]);

--- a/components/game/GameScoreCard.tsx
+++ b/components/game/GameScoreCard.tsx
@@ -1,6 +1,6 @@
 'use client';
 
-import { useEffect, useRef } from 'react';
+import { useEffect, useRef, useState } from 'react';
 import { Trophy, ArrowLeft } from 'lucide-react';
 import { Button } from '@/components/ui/button';
 import HighScoreDisplay from './HighScoreDisplay';
@@ -37,11 +37,13 @@ export default function GameScoreCard({
   className = '',
 }: GameScoreCardProps) {
   const paidScoreSavedRef = useRef(false);
+  const [paidScoreSaved, setPaidScoreSaved] = useState(false);
 
   useEffect(() => {
     if (isTrialGame || !walletAddress || !entryToken || !Number.isFinite(finalScore) || finalScore < 0) return;
     if (paidScoreSavedRef.current) return;
     paidScoreSavedRef.current = true;
+    setPaidScoreSaved(false);
     void (async () => {
       try {
         const res = await fetch('/api/save-paid-score', {
@@ -49,7 +51,11 @@ export default function GameScoreCard({
           headers: { 'Content-Type': 'application/json' },
           body: JSON.stringify({ walletAddress, finalScore, entryToken }),
         });
-        if (!res.ok) paidScoreSavedRef.current = false;
+        if (!res.ok) {
+          paidScoreSavedRef.current = false;
+          return;
+        }
+        setPaidScoreSaved(true);
       } catch {
         paidScoreSavedRef.current = false;
       }
@@ -120,6 +126,7 @@ export default function GameScoreCard({
             guestId={guestId}
             isTrialGame={isTrialGame}
             walletAddress={!isTrialGame ? walletAddress : undefined}
+            scoreSaved={!isTrialGame && paidScoreSaved}
             className="w-full"
           />
         </div>

--- a/components/game/HighScoreDisplay.tsx
+++ b/components/game/HighScoreDisplay.tsx
@@ -1,18 +1,25 @@
 'use client';
 
-import { useState, useEffect, useMemo } from 'react';
+import { useState, useEffect, useMemo, useRef } from 'react';
 import { Trophy, Medal, Award, Crown, Coins, CheckCircle } from 'lucide-react';
 import { useHighScores } from '@/hooks/useHighScores';
 import { useWeeklyLeaderboard } from '@/hooks/useWeeklyLeaderboard';
 import { usePlayerWinnings } from '@/hooks/usePlayerWinnings';
 import { Badge } from '@/components/ui/badge';
+import { Skeleton } from '@/components/ui/skeleton';
 import { useBaseAccount } from '@/hooks/useBaseAccount';
 import ClaimWinningsButton from '@/components/game/ClaimWinningsButton';
 import { BaseName } from '@/components/identity/BaseName';
 import ComposeCastButton from '@/components/social/ComposeCastButton';
 import { Confetti } from '@neoconfetti/react';
+import {
+  computeRankForScore,
+  isNewWeeklyLeader,
+  type WeeklyLeaderboardEntry,
+} from '@/lib/game/weeklyLeaderboard';
 
 const LEADERBOARD_LIMIT = 10;
+const CONFETTI_DURATION_MS = 8000;
 
 interface HighScoreDisplayProps {
   currentScore: number;
@@ -22,99 +29,119 @@ interface HighScoreDisplayProps {
   isTrialGame?: boolean;
   /** Paid games only: ties score to wallet for high-scores API (not used for trial). */
   walletAddress?: string;
+  /** Set when /api/save-paid-score has completed so rank lookup uses fresh data. */
+  scoreSaved?: boolean;
   className?: string;
 }
 
-export default function HighScoreDisplay({ 
-  currentScore, 
-  playerName, 
-  isGuest, 
+const mergeLatestPlayerScore = (
+  entries: WeeklyLeaderboardEntry[],
+  wallet: string,
+  latestScore: number,
+  playerName?: string,
+): WeeklyLeaderboardEntry[] => {
+  const normalized = wallet.toLowerCase();
+  const existingIdx = entries.findIndex(
+    (e) => e.walletAddress.toLowerCase() === normalized,
+  );
+
+  if (existingIdx >= 0) {
+    const updated = [...entries];
+    updated[existingIdx] = {
+      ...updated[existingIdx],
+      bestScore: latestScore,
+      username: playerName || updated[existingIdx].username,
+    };
+    return updated.sort((a, b) => b.bestScore - a.bestScore).slice(0, LEADERBOARD_LIMIT);
+  }
+
+  return [
+    ...entries,
+    {
+      walletAddress: normalized,
+      username: playerName?.includes('...') ? undefined : playerName,
+      bestScore: latestScore,
+      sessionCounter: entries[0]?.sessionCounter ?? 0,
+    },
+  ]
+    .sort((a, b) => b.bestScore - a.bestScore)
+    .slice(0, LEADERBOARD_LIMIT);
+};
+
+export default function HighScoreDisplay({
+  currentScore,
+  playerName,
+  isGuest,
   guestId,
   isTrialGame = false,
   walletAddress,
-  className = '' 
+  scoreSaved = false,
+  className = '',
 }: HighScoreDisplayProps) {
   const { submitScore } = useHighScores();
-  const { entries: topEarners, isLoading: leaderboardLoading } = useWeeklyLeaderboard(LEADERBOARD_LIMIT);
+  const {
+    entries: topEarners,
+    isLoading: leaderboardLoading,
+    isRefreshing,
+    refresh,
+  } = useWeeklyLeaderboard(LEADERBOARD_LIMIT);
   const { address, isConnected } = useBaseAccount();
   const { winnings, markAsClaimed, refreshWinnings } = usePlayerWinnings();
   const [hasSubmitted, setHasSubmitted] = useState(false);
   const [backendRank, setBackendRank] = useState<number | null>(null);
-  const [submissionResult, setSubmissionResult] = useState<{
-    isNewHighScore: boolean;
-    rank: number;
-  } | null>(null);
+  const [backendIsNewLeader, setBackendIsNewLeader] = useState(false);
   const [showConfetti, setShowConfetti] = useState(false);
+  const confettiLockedRef = useRef(false);
 
   const normalizedWallet = walletAddress?.toLowerCase();
 
   const leaderboardEntries = useMemo(() => {
     if (isTrialGame) return [];
 
-    const entries = [...topEarners];
     if (!normalizedWallet || currentScore <= 0) {
-      return entries.slice(0, LEADERBOARD_LIMIT);
+      return topEarners.slice(0, LEADERBOARD_LIMIT);
     }
 
-    const existingIdx = entries.findIndex(
-      (e) => e.walletAddress.toLowerCase() === normalizedWallet
-    );
-
-    if (existingIdx >= 0) {
-      const updated = [...entries];
-      updated[existingIdx] = {
-        ...updated[existingIdx],
-        bestScore: Math.max(updated[existingIdx].bestScore, currentScore),
-        username: playerName || updated[existingIdx].username,
-      };
-      return updated
-        .sort((a, b) => b.bestScore - a.bestScore)
-        .slice(0, LEADERBOARD_LIMIT);
-    }
-
-    const merged = [
-      ...entries,
-      {
-        walletAddress: normalizedWallet,
-        username: playerName?.includes('...') ? undefined : playerName,
-        bestScore: currentScore,
-        sessionCounter: 0,
-      },
-    ]
-      .sort((a, b) => b.bestScore - a.bestScore)
-      .slice(0, LEADERBOARD_LIMIT);
-
-    return merged;
+    return mergeLatestPlayerScore(topEarners, normalizedWallet, currentScore, playerName);
   }, [isTrialGame, topEarners, normalizedWallet, currentScore, playerName]);
 
   const playerRank = useMemo(() => {
-    if (isTrialGame || currentScore <= 0) return null;
-    const idx = leaderboardEntries.findIndex(
-      (e) => e.walletAddress.toLowerCase() === normalizedWallet
-    );
-    return idx >= 0 ? idx + 1 : null;
-  }, [isTrialGame, currentScore, leaderboardEntries, normalizedWallet]);
+    if (isTrialGame || currentScore <= 0 || !normalizedWallet) return null;
+    return computeRankForScore(topEarners, normalizedWallet, currentScore);
+  }, [isTrialGame, currentScore, normalizedWallet, topEarners]);
 
   const isOnLeaderboard =
     !leaderboardLoading && playerRank !== null && playerRank <= LEADERBOARD_LIMIT;
-  const currentHighScore = leaderboardEntries[0]?.bestScore ?? 0;
-  const isHighestScore = !isTrialGame && !leaderboardLoading && playerRank === 1;
-  const shouldCelebrate =
-    !isTrialGame && currentScore > 0 && isHighestScore && !leaderboardLoading;
+  const leadingScore = leaderboardEntries[0]?.bestScore ?? 0;
+  const isWeeklyLeader =
+    !isTrialGame &&
+    !leaderboardLoading &&
+    playerRank === 1 &&
+    currentScore >= leadingScore;
+  const isNewLeader =
+    !isTrialGame &&
+    currentScore > 0 &&
+    normalizedWallet &&
+    isNewWeeklyLeader(topEarners, normalizedWallet, currentScore);
+  const rankReady = !isTrialGame && (scoreSaved || hasSubmitted) && !leaderboardLoading;
 
   const handleClaimSuccess = () => {
     markAsClaimed();
     refreshWinnings();
   };
 
-  // Paid games only: submit to high-scores API. Trial/practice never hits the leaderboard.
   useEffect(() => {
-    if (currentScore <= 0 || hasSubmitted) return;
+    if (!scoreSaved) return;
+    void refresh();
+  }, [scoreSaved, refresh]);
 
-    if (isTrialGame) {
-      setHasSubmitted(true);
+  useEffect(() => {
+    if (currentScore <= 0 || hasSubmitted || isTrialGame) {
+      if (isTrialGame && !hasSubmitted) setHasSubmitted(true);
       return;
     }
+
+    if (!scoreSaved) return;
 
     const submitCurrentScore = async () => {
       const result = await submitScore(
@@ -122,14 +149,17 @@ export default function HighScoreDisplay({
         currentScore,
         isGuest,
         guestId,
-        walletAddress
+        walletAddress,
       );
       if (result) {
         setBackendRank(result.rank);
+        setBackendIsNewLeader(result.isNewHighScore);
         setHasSubmitted(true);
+        void refresh();
       }
     };
-    submitCurrentScore();
+
+    void submitCurrentScore();
   }, [
     currentScore,
     playerName,
@@ -138,47 +168,29 @@ export default function HighScoreDisplay({
     walletAddress,
     isTrialGame,
     hasSubmitted,
+    scoreSaved,
     submitScore,
+    refresh,
   ]);
 
   useEffect(() => {
-    if (!isTrialGame && hasSubmitted && !leaderboardLoading && !submissionResult) {
-      const finalIsHigh = isHighestScore;
-      const finalRank = playerRank ?? backendRank ?? 11;
-      setSubmissionResult({
-        isNewHighScore: finalIsHigh,
-        rank: finalRank,
-      });
-    }
-  }, [
-    isTrialGame,
-    hasSubmitted,
-    leaderboardLoading,
-    isHighestScore,
-    playerRank,
-    backendRank,
-    submissionResult,
-  ]);
+    if (!rankReady || confettiLockedRef.current) return;
+    if (!isNewLeader && !backendIsNewLeader) return;
 
-  useEffect(() => {
-    if (!shouldCelebrate) {
-      setShowConfetti(false);
-      return;
-    }
-
+    confettiLockedRef.current = true;
     const startDelay = setTimeout(() => {
       setShowConfetti(true);
     }, 400);
 
     const hideTimer = setTimeout(() => {
       setShowConfetti(false);
-    }, 7500);
+    }, CONFETTI_DURATION_MS);
 
     return () => {
       clearTimeout(startDelay);
       clearTimeout(hideTimer);
     };
-  }, [shouldCelebrate]);
+  }, [rankReady, isNewLeader, backendIsNewLeader]);
 
   const getRankIcon = (rank: number) => {
     switch (rank) {
@@ -193,32 +205,36 @@ export default function HighScoreDisplay({
     }
   };
 
-  const formatScore = (score: number) => {
-    return score.toLocaleString();
-  };
+  const formatScore = (score: number) => score.toLocaleString();
 
-  // Component to display player name with fallback priority:
-  // 1. Username (if set)
-  // 2. Basename (if available)  
-  // 3. Shortened wallet address
-  const PlayerDisplayName = ({ walletAddress, username, isGuest }: { walletAddress?: string; username?: string; isGuest?: boolean }) => {
-    if (isGuest) {
+  const PlayerDisplayName = ({
+    walletAddress: entryWallet,
+    username,
+    isGuest: entryIsGuest,
+  }: {
+    walletAddress?: string;
+    username?: string;
+    isGuest?: boolean;
+  }) => {
+    if (entryIsGuest) {
       return <span>{username || 'Guest'}</span>;
     }
-    
+
     if (username) {
       return <span>{username}</span>;
     }
-    if (walletAddress) {
-      return (
-        <BaseName
-          address={walletAddress as `0x${string}`}
-        />
-      );
+    if (entryWallet) {
+      return <BaseName address={entryWallet as `0x${string}`} />;
     }
-    
+
     return <span>Unknown Player</span>;
   };
+
+  const displayRank = rankReady ? (playerRank ?? backendRank) : null;
+  const showNewLeaderBanner =
+    rankReady && (backendIsNewLeader || isNewLeader) && displayRank === 1;
+  const showLeaderboardSkeleton =
+    (leaderboardLoading || isRefreshing) && leaderboardEntries.length === 0;
 
   return (
     <div className={`bg-white rounded-lg p-4 shadow-lg border ${className} relative overflow-visible`}>
@@ -228,9 +244,9 @@ export default function HighScoreDisplay({
           aria-hidden="true"
         >
           <Confetti
-            particleCount={350}
-            force={0.85}
-            duration={6000}
+            particleCount={400}
+            force={0.75}
+            duration={CONFETTI_DURATION_MS - 500}
             colors={['#FFC700', '#FFD700', '#FF0000', '#A855F7', '#EC4899', '#10B981', '#FFFFFF']}
             particleShape="mix"
             stageHeight={900}
@@ -247,58 +263,56 @@ export default function HighScoreDisplay({
             Practice run — this score is not added to the paid leaderboard.
           </p>
         )}
-        
-        {/* Current Player Status */}
+
         <div className="bg-blue-50 border border-blue-200 rounded-lg p-3 mb-3">
           <div className="flex items-center justify-between">
             <div>
               <p className="text-sm font-medium text-blue-800">
                 {playerName} {isGuest && '(Guest)'}
               </p>
-              <p className="text-lg font-bold text-blue-900">
-                {formatScore(currentScore)}
-              </p>
+              <p className="text-lg font-bold text-blue-900">{formatScore(currentScore)}</p>
             </div>
             <div className="text-right">
-              {!isTrialGame && isHighestScore && currentScore > 0 && (
+              {isWeeklyLeader && currentScore > 0 && (
                 <div className="flex items-center text-yellow-600 mb-1">
                   <Crown className="h-4 w-4 mr-1" />
-                  <span className="text-xs font-bold">HIGHEST SCORE!</span>
+                  <span className="text-xs font-bold">#1 THIS WEEK</span>
                 </div>
               )}
               <p className="text-sm text-blue-600">
                 {isTrialGame
                   ? 'Rank: — (practice)'
-                  : playerRank
-                    ? `Rank: #${playerRank}${isOnLeaderboard ? ' · Top 10' : ''}`
-                    : leaderboardLoading
-                      ? 'Rank: updating...'
+                  : !rankReady
+                    ? 'Rank: updating...'
+                    : displayRank
+                      ? `Rank: #${displayRank}${isOnLeaderboard ? ' · Top 10' : ''}`
                       : 'Rank: —'}
               </p>
             </div>
           </div>
         </div>
 
-        {/* Submission Result */}
-        {submissionResult && (
-          <div className={`mb-3 p-3 rounded-lg ${
-            submissionResult.isNewHighScore 
-              ? 'bg-yellow-50 border border-yellow-200' 
-              : 'bg-green-50 border border-green-200'
-          }`}>
+        {rankReady && (
+          <div
+            className={`mb-3 p-3 rounded-lg ${
+              showNewLeaderBanner
+                ? 'bg-yellow-50 border border-yellow-200'
+                : 'bg-green-50 border border-green-200'
+            }`}
+          >
             <div className="flex items-center">
-              {submissionResult.isNewHighScore ? (
+              {showNewLeaderBanner ? (
                 <>
                   <Crown className="h-5 w-5 text-yellow-600 mr-2" />
                   <span className="text-sm font-bold text-yellow-800">
-                    🎉 NEW HIGH SCORE! Rank #{submissionResult.rank}
+                    🎉 NEW #1 ON THE WEEKLY BOARD! Rank #{displayRank}
                   </span>
                 </>
               ) : (
                 <>
                   <Award className="h-5 w-5 text-green-600 mr-2" />
                   <span className="text-sm font-bold text-green-800">
-                    Score submitted! Rank #{submissionResult.rank}
+                    Score submitted! Rank #{displayRank ?? '—'}
                   </span>
                 </>
               )}
@@ -306,7 +320,6 @@ export default function HighScoreDisplay({
           </div>
         )}
 
-        {/* Claim Winnings Section - Only for connected paid players */}
         {isConnected && !isGuest && (
           <div className="mb-3">
             {!isTrialGame ? (
@@ -318,11 +331,11 @@ export default function HighScoreDisplay({
                   </div>
                   <Badge variant="secondary" className="bg-yellow-500/20 text-yellow-700 border-yellow-500/30">
                     <Crown className="h-3 w-3 mr-1" />
-                    {isTrialGame ? 'Trial Player' : 'Paid Player'}
+                    Paid Player
                   </Badge>
                 </div>
-                
-                {!isTrialGame && winnings.hasWinnings && !winnings.hasClaimed ? (
+
+                {winnings.hasWinnings && !winnings.hasClaimed ? (
                   <div className="space-y-2">
                     <div className="flex items-center justify-between">
                       <span className="text-sm text-gray-600">Your Winnings:</span>
@@ -331,9 +344,7 @@ export default function HighScoreDisplay({
                       </span>
                     </div>
                     {winnings.rank && (
-                      <div className="text-xs text-gray-500">
-                        Prize Rank: #{winnings.rank}
-                      </div>
+                      <div className="text-xs text-gray-500">Prize Rank: #{winnings.rank}</div>
                     )}
                     <ClaimWinningsButton
                       winningAmount={winnings.winningAmount}
@@ -341,20 +352,18 @@ export default function HighScoreDisplay({
                       disabled={winnings.hasClaimed}
                     />
                   </div>
-                ) : !isTrialGame && winnings.hasClaimed ? (
+                ) : winnings.hasClaimed ? (
                   <div className="flex items-center gap-2 text-green-600 justify-center p-3">
                     <CheckCircle className="h-4 w-4" />
                     <span className="text-sm font-medium">
                       Winnings Claimed: {Number(winnings.winningAmount) / 1000000} USDC
                     </span>
                   </div>
-                ) : !isTrialGame ? (
-                  <div className="text-sm text-gray-600">
-                    {winnings.sessionActive ? 'Session still active - winnings will be calculated after completion' : 'No winnings to claim for this session'}
-                  </div>
                 ) : (
                   <div className="text-sm text-gray-600">
-                    Trial players are not eligible for prize distribution
+                    {winnings.sessionActive
+                      ? 'Session still active - winnings will be calculated after completion'
+                      : 'No winnings to claim for this session'}
                   </div>
                 )}
               </div>
@@ -372,39 +381,50 @@ export default function HighScoreDisplay({
           </div>
         )}
 
-        {isOnLeaderboard && !isTrialGame && currentScore > 0 && (
+        {isOnLeaderboard && !isTrialGame && currentScore > 0 && rankReady && (
           <div className="mb-3 flex justify-center">
             <ComposeCastButton
-              achievementType={playerRank === 1 ? 'high-score' : 'game-complete'}
+              achievementType={showNewLeaderBanner ? 'high-score' : 'game-complete'}
               score={currentScore}
-              rank={playerRank ?? undefined}
+              rank={displayRank ?? undefined}
               className="w-full"
             />
           </div>
         )}
 
-        {/* Current High Score */}
-        {currentHighScore > 0 && (
+        {leadingScore > 0 && (
           <div className="bg-yellow-50 border border-yellow-200 rounded-lg p-3 mb-3">
             <div className="flex items-center justify-between">
               <div className="flex items-center">
                 <Crown className="h-5 w-5 text-yellow-600 mr-2" />
-                <span className="text-sm font-medium text-yellow-800">Current High Score</span>
+                <span className="text-sm font-medium text-yellow-800">Leading Score</span>
               </div>
               <span className="text-lg font-bold text-yellow-900">
-                {formatScore(currentHighScore)}
+                {formatScore(leadingScore)}
               </span>
             </div>
           </div>
         )}
       </div>
 
-      {/* Top Scores List */}
       <div>
-        <h4 className="text-sm font-semibold text-gray-700 mb-2">Top {LEADERBOARD_LIMIT} (Paid)</h4>
+        <h4 className="text-sm font-semibold text-gray-700 mb-2">
+          Top {LEADERBOARD_LIMIT} (Paid)
+          {isRefreshing && leaderboardEntries.length > 0 && (
+            <span className="ml-2 text-xs font-normal text-gray-400">Updating…</span>
+          )}
+        </h4>
         <div className="space-y-2">
-          {leaderboardLoading && leaderboardEntries.length === 0 ? (
-            <p className="text-sm text-gray-500 text-center py-2">Loading leaderboard...</p>
+          {showLeaderboardSkeleton ? (
+            Array.from({ length: 3 }).map((_, index) => (
+              <div key={`skeleton-${index}`} className="flex items-center justify-between p-2">
+                <div className="flex items-center gap-2 flex-1">
+                  <Skeleton className="h-4 w-4 rounded-full" />
+                  <Skeleton className="h-4 w-32" />
+                </div>
+                <Skeleton className="h-4 w-12" />
+              </div>
+            ))
           ) : leaderboardEntries.length === 0 ? (
             <p className="text-sm text-gray-500 text-center py-2">No scores yet — be the first!</p>
           ) : (

--- a/components/leaderboard/TopEarners.tsx
+++ b/components/leaderboard/TopEarners.tsx
@@ -3,7 +3,7 @@
 import { useWeeklyLeaderboard } from '@/hooks/useWeeklyLeaderboard';
 import Image from 'next/image';
 import { ASSETS } from '@/lib/config/assets';
-import { Loader2 } from 'lucide-react';
+import { Skeleton } from '@/components/ui/skeleton';
 import { BaseName } from '@/components/identity/BaseName';
 
 interface TopEarnersProps {
@@ -17,7 +17,7 @@ export default function TopEarners({
   className = '',
   currentWalletAddress,
 }: TopEarnersProps) {
-  const { entries, sessionCounter, isLoading, error } = useWeeklyLeaderboard(limit);
+  const { entries, sessionCounter, isLoading, isRefreshing, error } = useWeeklyLeaderboard(limit);
 
   const formatScore = (score: number) => score.toLocaleString();
 
@@ -53,10 +53,19 @@ export default function TopEarners({
     );
   }
 
-  if (isLoading) {
+  if (isLoading && entries.length === 0) {
     return (
-      <div className="flex justify-center items-center p-8">
-        <Loader2 className="h-6 w-6 text-white animate-spin" />
+      <div className={`w-full space-y-3 p-2 ${className}`}>
+        {Array.from({ length: 3 }).map((_, index) => (
+          <div key={`top-earner-skeleton-${index}`} className="flex items-center justify-between">
+            <div className="flex items-center gap-4">
+              <Skeleton className="h-4 w-5 bg-white/20" />
+              <Skeleton className="h-9 w-9 rounded-full bg-white/20" />
+              <Skeleton className="h-4 w-28 bg-white/20" />
+            </div>
+            <Skeleton className="h-4 w-16 bg-white/20" />
+          </div>
+        ))}
       </div>
     );
   }
@@ -66,6 +75,9 @@ export default function TopEarners({
       {sessionCounter > 0 && (
         <p className="text-gray-500 text-[10px] font-['Audiowide:Regular',_sans-serif] mb-2 text-center">
           Week {sessionCounter} — resets after payout
+          {isRefreshing && entries.length > 0 && (
+            <span className="ml-1 text-purple-300">· updating</span>
+          )}
         </p>
       )}
       {entries.map((earner, index) => {

--- a/hooks/useWeeklyLeaderboard.ts
+++ b/hooks/useWeeklyLeaderboard.ts
@@ -1,6 +1,6 @@
 'use client';
 
-import { useState, useEffect, useCallback } from 'react';
+import { useState, useEffect, useCallback, useRef } from 'react';
 import { useSpacetime } from '@/components/providers/SpacetimeProvider';
 import type { Player } from '@/lib/spacetime/database';
 import {
@@ -31,8 +31,10 @@ export const useWeeklyLeaderboard = (limit: number = 10) => {
   const [entries, setEntries] = useState<WeeklyLeaderboardEntry[]>([]);
   const [sessionCounter, setSessionCounter] = useState<number>(0);
   const [isLoading, setIsLoading] = useState(true);
+  const [isRefreshing, setIsRefreshing] = useState(false);
   const [error, setError] = useState<string | null>(null);
   const [lastUpdated, setLastUpdated] = useState(0);
+  const hasLoadedRef = useRef(false);
 
   const buildMergedEntries = useCallback(
     (
@@ -59,16 +61,21 @@ export const useWeeklyLeaderboard = (limit: number = 10) => {
   const refresh = useCallback(async () => {
     try {
       setError(null);
+      if (hasLoadedRef.current) {
+        setIsRefreshing(true);
+      }
       const { sessionCounter: counter, chainScores } =
         await fetchWeeklyScoresFromChain();
       setSessionCounter(counter);
       setEntries(buildMergedEntries(counter, chainScores));
       setLastUpdated(Date.now());
+      hasLoadedRef.current = true;
     } catch (err) {
       console.error('Error fetching weekly leaderboard:', err);
       setError(err instanceof Error ? err.message : 'Failed to load weekly leaderboard');
     } finally {
       setIsLoading(false);
+      setIsRefreshing(false);
     }
   }, [buildMergedEntries]);
 
@@ -76,7 +83,7 @@ export const useWeeklyLeaderboard = (limit: number = 10) => {
     void refresh();
     const interval = setInterval(() => {
       void refresh();
-    }, 30000);
+    }, 15000);
     return () => clearInterval(interval);
   }, [refresh]);
 
@@ -84,13 +91,7 @@ export const useWeeklyLeaderboard = (limit: number = 10) => {
     if (!connection || !isConnected) return;
 
     const handlePlayerChange = () => {
-      setEntries((prev) => {
-        if (sessionCounter === 0) return prev;
-        const chainScores = new Map(
-          prev.map((e) => [e.walletAddress.toLowerCase(), e.bestScore]),
-        );
-        return buildMergedEntries(sessionCounter, chainScores);
-      });
+      void refresh();
     };
 
     connection.db.players.onInsert(handlePlayerChange);
@@ -100,12 +101,13 @@ export const useWeeklyLeaderboard = (limit: number = 10) => {
       connection.db.players.removeOnInsert(handlePlayerChange);
       connection.db.players.removeOnUpdate(handlePlayerChange);
     };
-  }, [connection, isConnected, sessionCounter, buildMergedEntries]);
+  }, [connection, isConnected, refresh]);
 
   return {
     entries,
     sessionCounter,
     isLoading,
+    isRefreshing,
     error,
     lastUpdated,
     refresh,

--- a/lib/game/weeklyLeaderboard.ts
+++ b/lib/game/weeklyLeaderboard.ts
@@ -131,7 +131,12 @@ export const fetchWeeklyScoresFromChain = async (): Promise<{
   return { sessionCounter, chainScores };
 };
 
-/** Merge on-chain scores with SpacetimeDB weekly session scores. */
+/**
+ * Merge on-chain scores with SpacetimeDB weekly session scores.
+ * Weekly ranking uses each player's **latest** score (not best-of-week).
+ * On-chain scores are authoritative when present; Spacetime fills gaps while
+ * a submission is still propagating.
+ */
 export const mergeWeeklyLeaderboardEntries = (
   sessionCounter: number,
   chainScores: Map<string, number>,
@@ -154,14 +159,23 @@ export const mergeWeeklyLeaderboardEntries = (
       continue;
     }
     const wallet = player.walletAddress.toLowerCase();
-    const existing = merged.get(wallet);
-    const bestScore = Math.max(existing?.bestScore ?? 0, player.weeklyBestScore);
+    if (merged.has(wallet)) {
+      const existing = merged.get(wallet)!;
+      merged.set(wallet, {
+        ...existing,
+        username: player.username ?? existing.username,
+        avatarUrl: player.avatarUrl ?? existing.avatarUrl,
+        totalEarnings: player.totalEarnings ?? existing.totalEarnings,
+      });
+      continue;
+    }
+
     merged.set(wallet, {
       walletAddress: wallet,
-      username: player.username ?? existing?.username,
-      avatarUrl: player.avatarUrl ?? existing?.avatarUrl,
-      bestScore,
-      totalEarnings: player.totalEarnings ?? existing?.totalEarnings,
+      username: player.username ?? undefined,
+      avatarUrl: player.avatarUrl ?? undefined,
+      bestScore: player.weeklyBestScore,
+      totalEarnings: player.totalEarnings,
       sessionCounter,
     });
   }
@@ -192,6 +206,7 @@ export const enrichWeeklyEntriesWithMetadata = (
   });
 };
 
+/** Rank a wallet using its latest submitted score for the current week. */
 export const computeRankForScore = (
   entries: WeeklyLeaderboardEntry[],
   walletAddress: string,
@@ -205,7 +220,7 @@ export const computeRankForScore = (
   if (existingIdx >= 0) {
     withCurrent[existingIdx] = {
       ...withCurrent[existingIdx],
-      bestScore: Math.max(withCurrent[existingIdx].bestScore, score),
+      bestScore: score,
     };
   } else if (score > 0) {
     withCurrent.push({
@@ -219,4 +234,22 @@ export const computeRankForScore = (
     (e) => e.walletAddress.toLowerCase() === normalized,
   );
   return rankIdx >= 0 ? rankIdx + 1 : withCurrent.length + 1;
+};
+
+/** True when this run took or holds weekly #1 (not merely re-submitted a lower score). */
+export const isNewWeeklyLeader = (
+  entries: WeeklyLeaderboardEntry[],
+  walletAddress: string,
+  score: number,
+): boolean => {
+  if (score <= 0) return false;
+
+  const normalized = walletAddress.toLowerCase();
+  const previousLeaderScore =
+    entries.find((e) => e.walletAddress.toLowerCase() !== normalized)?.bestScore ??
+    entries[0]?.bestScore ??
+    0;
+  const rank = computeRankForScore(entries, walletAddress, score);
+
+  return rank === 1 && score >= previousLeaderScore;
 };

--- a/lib/game/weeklyLeaderboard.ts
+++ b/lib/game/weeklyLeaderboard.ts
@@ -245,10 +245,7 @@ export const isNewWeeklyLeader = (
   if (score <= 0) return false;
 
   const normalized = walletAddress.toLowerCase();
-  const previousLeaderScore =
-    entries.find((e) => e.walletAddress.toLowerCase() !== normalized)?.bestScore ??
-    entries[0]?.bestScore ??
-    0;
+  const previousLeaderScore = entries[0]?.bestScore ?? 0;
   const rank = computeRankForScore(entries, walletAddress, score);
 
   return rank === 1 && score >= previousLeaderScore;

--- a/spacetime-module/beat-me/src/lib.rs
+++ b/spacetime-module/beat-me/src/lib.rs
@@ -1276,7 +1276,8 @@ fn apply_weekly_score(player: &mut Player, on_chain_session_id: u64, game_score:
         return;
     }
     if player.weekly_session_id == on_chain_session_id {
-        player.weekly_best_score = std::cmp::max(player.weekly_best_score, game_score);
+        // Weekly leaderboard ranks the latest run, not the best-of-week.
+        player.weekly_best_score = game_score;
     } else if on_chain_session_id > player.weekly_session_id {
         player.weekly_session_id = on_chain_session_id;
         player.weekly_best_score = game_score;

--- a/tests/weekly-leaderboard.test.ts
+++ b/tests/weekly-leaderboard.test.ts
@@ -86,4 +86,14 @@ describe('weekly leaderboard latest-score semantics', () => {
     assert.equal(computeRankForScore(entries, walletA, 1200), 1);
     assert.equal(isNewWeeklyLeader(entries, walletA, 1200), true);
   });
+
+  it('does not mark a lower rerun as a new leader when there are other players on the board', () => {
+    const entries: WeeklyLeaderboardEntry[] = [
+      { walletAddress: walletA, bestScore: 2060, sessionCounter: 1 },
+      { walletAddress: walletB, bestScore: 1500, sessionCounter: 1 },
+    ];
+
+    assert.equal(computeRankForScore(entries, walletA, 1800), 1);
+    assert.equal(isNewWeeklyLeader(entries, walletA, 1800), false);
+  });
 });

--- a/tests/weekly-leaderboard.test.ts
+++ b/tests/weekly-leaderboard.test.ts
@@ -1,0 +1,89 @@
+/**
+ * Weekly leaderboard ranking — run with: npx tsx --test tests/weekly-leaderboard.test.ts
+ */
+
+import assert from 'node:assert/strict';
+import { describe, it } from 'node:test';
+import {
+  mergeWeeklyLeaderboardEntries,
+  computeRankForScore,
+  isNewWeeklyLeader,
+  type WeeklyLeaderboardEntry,
+} from '../lib/game/weeklyLeaderboard';
+
+const walletA = '0xaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa';
+const walletB = '0xbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb';
+
+describe('weekly leaderboard latest-score semantics', () => {
+  it('prefers on-chain score over spacetime when both exist', () => {
+    const merged = mergeWeeklyLeaderboardEntries(
+      1,
+      new Map([[walletA, 1160]]),
+      [
+        {
+          walletAddress: walletA,
+          weeklySessionId: BigInt(1),
+          weeklyBestScore: 2060,
+        },
+      ],
+      10,
+    );
+
+    assert.equal(merged.length, 1);
+    assert.equal(merged[0]?.bestScore, 1160);
+  });
+
+  it('uses spacetime score when wallet is not yet on chain', () => {
+    const merged = mergeWeeklyLeaderboardEntries(
+      1,
+      new Map(),
+      [
+        {
+          walletAddress: walletA,
+          weeklySessionId: BigInt(1),
+          weeklyBestScore: 1800,
+        },
+      ],
+      10,
+    );
+
+    assert.equal(merged[0]?.bestScore, 1800);
+  });
+
+  it('ranks using latest score instead of keeping a higher prior score', () => {
+    const entries: WeeklyLeaderboardEntry[] = [
+      { walletAddress: walletA, bestScore: 2060, sessionCounter: 1 },
+    ];
+
+    assert.equal(computeRankForScore(entries, walletA, 1160), 1);
+    assert.equal(isNewWeeklyLeader(entries, walletA, 1160), false);
+  });
+
+  it('detects a genuine new weekly leader', () => {
+    const entries: WeeklyLeaderboardEntry[] = [
+      { walletAddress: walletB, bestScore: 2000, sessionCounter: 1 },
+      { walletAddress: walletA, bestScore: 1500, sessionCounter: 1 },
+    ];
+
+    assert.equal(computeRankForScore(entries, walletA, 2500), 1);
+    assert.equal(isNewWeeklyLeader(entries, walletA, 2500), true);
+  });
+
+  it('does not mark a lower rerun as a new leader when alone on the board', () => {
+    const entries: WeeklyLeaderboardEntry[] = [
+      { walletAddress: walletA, bestScore: 2060, sessionCounter: 1 },
+    ];
+
+    assert.equal(computeRankForScore(entries, walletA, 1160), 1);
+    assert.equal(isNewWeeklyLeader(entries, walletA, 1160), false);
+  });
+
+  it('adds a first-time player to the board', () => {
+    const entries: WeeklyLeaderboardEntry[] = [
+      { walletAddress: walletB, bestScore: 900, sessionCounter: 1 },
+    ];
+
+    assert.equal(computeRankForScore(entries, walletA, 1200), 1);
+    assert.equal(isNewWeeklyLeader(entries, walletA, 1200), true);
+  });
+});


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Fixes three issues reported after completing a paid game:

1. **Confetti flashed and disappeared** — celebration now locks once started and runs for the full duration instead of being cancelled when the leaderboard refreshes.
2. **Incorrect "NEW HIGH SCORE / Rank #1"** — ranking now uses each player's **latest** score (matching on-chain behavior and UI copy), so a lower rerun no longer shows as a new high score.
3. **Leaderboard not updating in real time** — Spacetime player changes trigger a full chain refresh; skeleton loaders show while data is loading/updating.

## Changes

### Ranking logic (`lib/game/weeklyLeaderboard.ts`)
- Weekly leaderboard merge now treats on-chain scores as authoritative (latest run).
- Spacetime only fills gaps while a submission is propagating.
- `computeRankForScore` replaces a player's score with their latest run instead of keeping the max.
- Added `isNewWeeklyLeader()` — true only when this run genuinely takes or holds #1 with a score that beats the previous leader.

### Game complete UI (`components/game/HighScoreDisplay.tsx`)
- Waits for `scoreSaved` before rank lookup to avoid racing `save-paid-score`.
- Confetti only fires when taking weekly #1; animation is locked for ~8s.
- Banner distinguishes "NEW #1 ON THE WEEKLY BOARD" vs "Score submitted! Rank #N".
- Renamed "Current High Score" → "Leading Score" for clarity.
- Added skeleton rows while leaderboard loads.

### Real-time updates (`hooks/useWeeklyLeaderboard.ts`)
- Spacetime insert/update triggers full refresh (not stale partial merge).
- Poll interval reduced to 15s; added `isRefreshing` state.

### Spacetime module
- `apply_weekly_score` now stores latest score instead of max-of-week.

### Tests
- Added `tests/weekly-leaderboard.test.ts` covering merge, rank, and new-leader detection.

## How to verify

1. Play a paid game and finish with a score lower than your previous weekly score.
2. Confirm rank/score on the results screen match the leaderboard list (no false "NEW HIGH SCORE").
3. Play again and take #1 with a higher score — confetti should fall for the full celebration.
4. Home screen Top Scores should update shortly after game complete (with skeleton while loading).
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-299ea252-e26c-4f0a-ac69-e3c9933b01bb"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-299ea252-e26c-4f0a-ac69-e3c9933b01bb"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

