### PR TITLE
Fix Main Menu navigation after trial game completion

### DIFF
--- a/app/page.tsx
+++ b/app/page.tsx
@@ -81,6 +81,7 @@ function HomePage() {
   const countdownStartedAtRef = useRef<number | null>(null);
   const [isCountdownActive, setIsCountdownActive] = useState(false);
   const [paidScoreWarning, setPaidScoreWarning] = useState<string | null>(null);
+  const [userRequestedMainMenu, setUserRequestedMainMenu] = useState(false);
   // Add trial status hook
   const { address } = useBaseAccount();
   const { data: basename } = useBasename(address ?? undefined);
@@ -259,6 +260,7 @@ function HomePage() {
 
   const handleJoinGame = async () => {
     setJoinGameStartError(null);
+    setUserRequestedMainMenu(false);
     setShowGameEntry(true);
   };
 
@@ -282,6 +284,7 @@ function HomePage() {
 
   const handleWalletConnect = () => {
     // Payment view removed — go straight to game entry with paid modes
+    setUserRequestedMainMenu(false);
     setShowGameEntry(true);
   };
 
@@ -340,6 +343,7 @@ function HomePage() {
       console.error('Error leaving game session:', error);
     } finally {
       setJoinGameStartError(null);
+      setUserRequestedMainMenu(true);
       setShowGameEntry(false);
       setShowGuestMode(false);
       setGameStarted(false);
@@ -554,6 +558,7 @@ function HomePage() {
 
   const handlePlayAgain = () => {
     paidScoreSavedRef.current = false;
+    setUserRequestedMainMenu(false);
     setGameCompleted(false);
     setGameStarted(false);
     setShowGameEntry(true);
@@ -627,10 +632,26 @@ function HomePage() {
   // When trial is exhausted, automatically show game entry with paid modes
   // (Trial Games Complete screen has been removed — users go straight to game entry)
   useEffect(() => {
-    if (trialStatus.requiresWallet && !gameCompleted && !gameStarted && !showGameEntry && !showGuestMode && !inMultiplayerLobby) {
+    if (
+      trialStatus.requiresWallet &&
+      !gameCompleted &&
+      !gameStarted &&
+      !showGameEntry &&
+      !showGuestMode &&
+      !inMultiplayerLobby &&
+      !userRequestedMainMenu
+    ) {
       setShowGameEntry(true);
     }
-  }, [trialStatus.requiresWallet, gameCompleted, gameStarted, showGameEntry, showGuestMode, inMultiplayerLobby]);
+  }, [
+    trialStatus.requiresWallet,
+    gameCompleted,
+    gameStarted,
+    showGameEntry,
+    showGuestMode,
+    inMultiplayerLobby,
+    userRequestedMainMenu,
+  ]);
 
   // Paid multiplayer lobby (memory session)
   if (inMultiplayerLobby) {
@@ -660,6 +681,7 @@ function HomePage() {
         onLeaveLobby={async () => {
           await leaveGame();
           setInMultiplayerLobby(false);
+          setUserRequestedMainMenu(true);
           setShowGameEntry(false);
         }}
       />
@@ -673,11 +695,14 @@ function HomePage() {
         <div className="w-full max-w-[390px] md:max-w-[428px] space-y-4">
           <button
             type="button"
-            onClick={() => setShowGameEntry(false)}
+            onClick={() => {
+              setUserRequestedMainMenu(true);
+              setShowGameEntry(false);
+            }}
             className="text-sm text-gray-400 hover:text-white transition-colors"
-            aria-label="Back to home"
+            aria-label="Main Menu"
           >
-            ← Back to Home
+            ← Main Menu
           </button>
           {/* Player mode: Trial | Solo (paid) | Multiplayer (paid) */}
           <Card className="bg-gradient-to-br from-purple-900/20 to-blue-900/20 border-purple-500/30">
@@ -796,8 +821,9 @@ function HomePage() {
             <button
               onClick={handleBackToHome}
               className="bg-purple-600 hover:bg-purple-700 text-white px-6 py-2 rounded-lg"
+              aria-label="Main Menu"
             >
-              Back to Home
+              Main Menu
             </button>
           </div>
         </div>
@@ -891,8 +917,9 @@ function HomePage() {
             <button
               onClick={handleBackToHome}
               className="bg-purple-600 hover:bg-purple-700 text-white px-6 py-3 rounded-lg text-lg"
+              aria-label="Main Menu"
             >
-              Back to Home
+              Main Menu
             </button>
           </div>
         </div>


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

After completing a trial game, tapping **Back to Home** appeared to do nothing — users stayed on the Solo/Multiplayer mode selection screen instead of returning to the main landing page.

## Root cause

When a trial is exhausted, a `useEffect` automatically opens the game entry screen (`showGameEntry = true`) whenever the user is not in an active game. Tapping "Back to Home" correctly reset game state, but the effect immediately re-opened mode selection because `trialStatus.requiresWallet` was still true.

## Fix

- Added `userRequestedMainMenu` state to track when the user explicitly navigates home.
- The trial-exhausted auto-redirect now respects this flag and does not override an intentional Main Menu navigation.
- Reset the flag when the user taps **Join Game** or chooses to play again.
- Renamed all **Back to Home** buttons to **Main Menu** for clarity.

## Merge conflict resolution (with main)

Merged latest `main` (includes PR #95 leaderboard fixes). One simple conflict in `handlePlayAgain` — both branches added independent state resets. Resolution keeps **both**:
- `setPaidScoreSaved(false)` (leaderboard score-save flow)
- `setUserRequestedMainMenu(false)` (Main Menu navigation flow)

No conflicting intent — changes are complementary.

## How to verify

1. Complete a trial game and view your practice score.
2. Tap **Main Menu** — you should land on the BEAT ME home screen (Join Game, Top Scores), not mode selection.
3. Tap **Join Game** from home — mode selection should still appear normally for paid play.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-299ea252-e26c-4f0a-ac69-e3c9933b01bb"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-299ea252-e26c-4f0a-ac69-e3c9933b01bb"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

