### PR TITLE
Add Orb/Lens identity layer with subaccount-aware wallet linking

### DIFF
--- a/app/api/active-players-live/route.ts
+++ b/app/api/active-players-live/route.ts
@@ -1,21 +1,96 @@
 import { NextResponse } from 'next/server';
+import { spacetimeClient } from '@/lib/apis/spacetime';
+import { formatWalletAddress } from '@/lib/identity/resolveBaseProfile';
 
-export const runtime = 'edge';
+export const runtime = 'nodejs';
+export const maxDuration = 30;
 
 export async function GET() {
-  // Ultra-minimal static data - no dependencies, no dynamic generation
-  const players = [
-    { address: '0x838aD0EAE54F99F1926dA7C3b6bFbF617389B4D9', username: 'VITALIK.BASE.ETH', totalScore: 1000, gamesPlayed: 5, isWalletUser: true, lastActive: '2024-01-01T00:00:00.000Z' },
-    { address: '0x4bEf0221d6F7Dd0C969fe46a4e9b339a84F52FDF', username: 'PAULCRAMER.BASE.ETH', totalScore: 850, gamesPlayed: 3, isWalletUser: true, lastActive: '2024-01-01T00:00:00.000Z' },
-    { address: '0x1234567890abcdef1234567890abcdef12345678', username: 'ALICE.BASE.ETH', totalScore: 750, gamesPlayed: 7, isWalletUser: true, lastActive: '2024-01-01T00:00:00.000Z' },
-    { address: '0xabcdef1234567890abcdef1234567890abcdef12', username: 'BOB.BASE.ETH', totalScore: 650, gamesPlayed: 4, isWalletUser: true, lastActive: '2024-01-01T00:00:00.000Z' },
-    { address: '0x9876543210fedcba9876543210fedcba98765432', username: 'CHARLIE.BASE.ETH', totalScore: 550, gamesPlayed: 6, isWalletUser: true, lastActive: '2024-01-01T00:00:00.000Z' }
-  ];
+  try {
+    await spacetimeClient.initialize({ syncPlayers: true });
+    await spacetimeClient.waitForSync(12000).catch(() => undefined);
 
-  return NextResponse.json({ 
-    players, 
-    count: players.length, 
-    source: 'static-demo' 
-  });
+    if (!spacetimeClient.isConfigured()) {
+      return NextResponse.json({
+        players: [],
+        count: 0,
+        source: 'spacetime-unconfigured',
+      });
+    }
+
+    const poolRows = spacetimeClient.getPoolPlayersForActiveSessions();
+    const seen = new Set<string>();
+    const players: Array<{
+      address: string;
+      username: string;
+      avatarUrl: string | null;
+      totalScore: number;
+      gamesPlayed: number;
+      isWalletUser: boolean;
+      lastActive: string;
+    }> = [];
+
+    for (const row of poolRows) {
+      const wallet = row.walletAddress?.trim().toLowerCase();
+      if (!wallet || !wallet.startsWith('0x') || seen.has(wallet)) {
+        continue;
+      }
+      seen.add(wallet);
+
+      const player = spacetimeClient.getPlayerByWallet(wallet);
+      const social = spacetimeClient.getSocialIdentityByWallet(wallet);
+
+      const username = social?.handle
+        ? `@${social.handle}`
+        : player?.username ?? formatWalletAddress(wallet);
+
+      players.push({
+        address: wallet,
+        username,
+        avatarUrl: social?.avatarUrl ?? player?.avatarUrl ?? null,
+        totalScore: Math.round(player?.totalEarnings ?? 0),
+        gamesPlayed: player?.gamesPlayed ?? 0,
+        isWalletUser: true,
+        lastActive: new Date().toISOString(),
+      });
+    }
+
+    if (players.length === 0) {
+      const connections = spacetimeClient.getActiveConnections(16);
+      for (const conn of connections) {
+        const wallet = conn.walletAddress?.trim().toLowerCase();
+        if (!wallet || !wallet.startsWith('0x') || seen.has(wallet)) {
+          continue;
+        }
+        seen.add(wallet);
+        const player = spacetimeClient.getPlayerByWallet(wallet);
+        const social = spacetimeClient.getSocialIdentityByWallet(wallet);
+        players.push({
+          address: wallet,
+          username: social?.handle
+            ? `@${social.handle}`
+            : player?.username ?? formatWalletAddress(wallet),
+          avatarUrl: social?.avatarUrl ?? player?.avatarUrl ?? null,
+          totalScore: Math.round(player?.totalEarnings ?? 0),
+          gamesPlayed: player?.gamesPlayed ?? 0,
+          isWalletUser: true,
+          lastActive: conn.lastActivity.toISOString(),
+        });
+      }
+    }
+
+    return NextResponse.json({
+      players,
+      count: players.length,
+      source: players.length > 0 ? 'spacetime-live' : 'spacetime-empty',
+    });
+  } catch (error) {
+    console.error('❌ active-players-live failed:', error);
+    return NextResponse.json({
+      players: [],
+      count: 0,
+      source: 'spacetime-error',
+      error: error instanceof Error ? error.message : 'Failed to load players',
+    });
+  }
 }
-

--- a/app/api/auth/orb/link/route.ts
+++ b/app/api/auth/orb/link/route.ts
@@ -1,9 +1,17 @@
 import { NextRequest, NextResponse } from 'next/server';
-import { verifyMessage } from 'viem';
+import { createPublicClient, http } from 'viem';
+import { base } from 'viem/chains';
 import { verifyOrbAccessToken } from '@/lib/orb/lensProfile.server';
 import { spacetimeClient } from '@/lib/apis/spacetime';
 
 export const runtime = 'nodejs';
+
+const baseClient = createPublicClient({
+  chain: base,
+  transport: http(
+    process.env.NEXT_PUBLIC_BASE_RPC_URL ?? 'https://mainnet.base.org',
+  ),
+});
 
 type LinkBody = {
   accessToken?: string;
@@ -29,7 +37,7 @@ export async function POST(request: NextRequest) {
       return NextResponse.json({ error: 'Invalid wallet address' }, { status: 400 });
     }
 
-    const isValidSig = await verifyMessage({
+    const isValidSig = await baseClient.verifyMessage({
       address: wallet as `0x${string}`,
       message,
       signature: signature as `0x${string}`,
@@ -40,7 +48,7 @@ export async function POST(request: NextRequest) {
     }
 
     const siweAddressMatch = message.match(
-      /wants you to sign in with your Ethereum account:\n(0x[a-fA-F0-9]{40})/,
+      /wants you to sign in with your Ethereum account:\r?\n(0x[a-fA-F0-9]{40})/,
     );
     const signedAddress = siweAddressMatch?.[1]?.toLowerCase();
     if (signedAddress && signedAddress !== wallet) {

--- a/app/api/auth/orb/link/route.ts
+++ b/app/api/auth/orb/link/route.ts
@@ -1,0 +1,91 @@
+import { NextRequest, NextResponse } from 'next/server';
+import { verifyMessage } from 'viem';
+import { verifyOrbAccessToken } from '@/lib/orb/lensProfile.server';
+import { spacetimeClient } from '@/lib/apis/spacetime';
+
+export const runtime = 'nodejs';
+
+type LinkBody = {
+  accessToken?: string;
+  walletAddress?: string;
+  message?: string;
+  signature?: string;
+};
+
+export async function POST(request: NextRequest) {
+  try {
+    const body = (await request.json()) as LinkBody;
+    const { accessToken, walletAddress, message, signature } = body;
+
+    if (!accessToken || !walletAddress || !message || !signature) {
+      return NextResponse.json(
+        { error: 'Missing accessToken, walletAddress, message, or signature' },
+        { status: 400 },
+      );
+    }
+
+    const wallet = walletAddress.trim().toLowerCase();
+    if (!wallet.startsWith('0x')) {
+      return NextResponse.json({ error: 'Invalid wallet address' }, { status: 400 });
+    }
+
+    const isValidSig = await verifyMessage({
+      address: wallet as `0x${string}`,
+      message,
+      signature: signature as `0x${string}`,
+    });
+
+    if (!isValidSig) {
+      return NextResponse.json({ error: 'Invalid wallet signature' }, { status: 401 });
+    }
+
+    const siweAddressMatch = message.match(
+      /wants you to sign in with your Ethereum account:\n(0x[a-fA-F0-9]{40})/,
+    );
+    const signedAddress = siweAddressMatch?.[1]?.toLowerCase();
+    if (signedAddress && signedAddress !== wallet) {
+      return NextResponse.json(
+        { error: 'Signature address does not match walletAddress' },
+        { status: 401 },
+      );
+    }
+
+    const profile = await verifyOrbAccessToken(accessToken);
+
+    await spacetimeClient.initialize();
+    if (!spacetimeClient.isConfigured()) {
+      return NextResponse.json(
+        { error: 'SpacetimeDB not configured on server' },
+        { status: 503 },
+      );
+    }
+
+    await spacetimeClient.setVerifiedSocialIdentity({
+      walletAddress: wallet,
+      lensAccountId: profile.lensAccountId,
+      handle: profile.handle,
+      displayName: profile.displayName,
+      avatarUrl: profile.avatarUrl,
+    });
+
+    return NextResponse.json({
+      success: true,
+      profile: {
+        walletAddress: wallet,
+        lensAccountId: profile.lensAccountId,
+        handle: profile.handle,
+        displayName: profile.displayName ?? `@${profile.handle}`,
+        avatarUrl: profile.avatarUrl ?? null,
+      },
+    });
+  } catch (error) {
+    console.error('❌ Orb link failed:', error);
+    return NextResponse.json(
+      {
+        error:
+          error instanceof Error ? error.message : 'Failed to link Orb profile',
+      },
+      { status: 401 },
+    );
+  }
+}

--- a/app/api/player-identities/route.ts
+++ b/app/api/player-identities/route.ts
@@ -96,24 +96,22 @@ export async function GET(request: NextRequest) {
   const spacetimeCache = await loadSpacetimeCache(wallets);
   const identities: Record<string, ResolvedPlayerIdentity> = {};
 
-  await Promise.all(
-    wallets.map(async (wallet) => {
-      const cached = spacetimeCache.get(wallet);
-      const merged = mergeCachedIdentity(wallet, cached);
-      if (merged.displayName && merged.avatarUrl) {
-        identities[wallet] = {
-          walletAddress: wallet,
-          displayName: merged.displayName,
-          avatarUrl: merged.avatarUrl,
-          handle: merged.handle ?? null,
-          basename: null,
-          source: merged.source ?? 'lens',
-        };
-        return;
-      }
-      identities[wallet] = await resolvePlayerIdentity(wallet, cached);
-    }),
-  );
+  for (const wallet of wallets) {
+    const cached = spacetimeCache.get(wallet);
+    const merged = mergeCachedIdentity(wallet, cached);
+    if (merged.displayName && merged.avatarUrl) {
+      identities[wallet] = {
+        walletAddress: wallet,
+        displayName: merged.displayName,
+        avatarUrl: merged.avatarUrl,
+        handle: merged.handle ?? null,
+        basename: null,
+        source: merged.source ?? 'lens',
+      };
+      continue;
+    }
+    identities[wallet] = await resolvePlayerIdentity(wallet, cached);
+  }
 
   return NextResponse.json({ identities });
 }

--- a/app/api/player-identities/route.ts
+++ b/app/api/player-identities/route.ts
@@ -1,0 +1,119 @@
+import { NextRequest, NextResponse } from 'next/server';
+import {
+  mergeCachedIdentity,
+  normalizeWallet,
+  resolvePlayerIdentity,
+  type PlayerIdentityCache,
+  type ResolvedPlayerIdentity,
+} from '@/lib/identity/playerIdentity';
+import { spacetimeClient } from '@/lib/apis/spacetime';
+
+export const runtime = 'nodejs';
+
+const MAX_WALLETS = 20;
+
+const parseWallets = (raw: string | null): string[] => {
+  if (!raw?.trim()) {
+    return [];
+  }
+  return [
+    ...new Set(
+      raw
+        .split(',')
+        .map((w) => normalizeWallet(w))
+        .filter((w) => w.startsWith('0x')),
+    ),
+  ].slice(0, MAX_WALLETS);
+};
+
+const loadSpacetimeCache = async (
+  wallets: string[],
+): Promise<Map<string, PlayerIdentityCache>> => {
+  const cache = new Map<string, PlayerIdentityCache>();
+  if (wallets.length === 0) {
+    return cache;
+  }
+
+  try {
+    await spacetimeClient.initialize({ syncPlayers: true });
+    if (!spacetimeClient.isConfigured()) {
+      return cache;
+    }
+
+    for (const wallet of wallets) {
+      const player = spacetimeClient.getPlayerByWallet(wallet);
+      const social = spacetimeClient.getSocialIdentityByWallet(wallet);
+      const universalWalletAddress =
+        spacetimeClient.getUniversalWalletForSubAccount(wallet);
+
+      if (social) {
+        cache.set(wallet, {
+          username: `@${social.handle}`,
+          handle: social.handle,
+          displayName: social.displayName ?? `@${social.handle}`,
+          avatarUrl: social.avatarUrl ?? null,
+          source: 'lens',
+          universalWalletAddress,
+        });
+        continue;
+      }
+
+      if (player?.username || player?.avatarUrl) {
+        cache.set(wallet, {
+          username: player.username ?? undefined,
+          avatarUrl: player.avatarUrl ?? null,
+          source: 'spacetime',
+          universalWalletAddress,
+        });
+        continue;
+      }
+
+      if (universalWalletAddress) {
+        cache.set(wallet, {
+          universalWalletAddress,
+        });
+      }
+    }
+  } catch (error) {
+    console.warn('⚠️ Spacetime identity cache unavailable:', error);
+  }
+
+  return cache;
+};
+
+export async function GET(request: NextRequest) {
+  const wallets = parseWallets(
+    request.nextUrl.searchParams.get('wallets'),
+  );
+
+  if (wallets.length === 0) {
+    return NextResponse.json(
+      { error: 'Provide wallets query param (comma-separated, max 20)' },
+      { status: 400 },
+    );
+  }
+
+  const spacetimeCache = await loadSpacetimeCache(wallets);
+  const identities: Record<string, ResolvedPlayerIdentity> = {};
+
+  await Promise.all(
+    wallets.map(async (wallet) => {
+      const cached = spacetimeCache.get(wallet);
+      const merged = mergeCachedIdentity(wallet, cached);
+      if (merged.displayName && merged.avatarUrl) {
+        identities[wallet] = {
+          walletAddress: wallet,
+          displayName: merged.displayName,
+          avatarUrl: merged.avatarUrl,
+          handle: merged.handle ?? null,
+          basename: null,
+          source: merged.source ?? 'lens',
+        };
+        return;
+      }
+      identities[wallet] = await resolvePlayerIdentity(wallet, cached);
+    }),
+  );
+
+  return NextResponse.json({ identities });
+}

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -84,8 +84,8 @@ function HomePage() {
   const [paidScoreWarning, setPaidScoreWarning] = useState<string | null>(null);
   const [userRequestedMainMenu, setUserRequestedMainMenu] = useState(false);
   // Add trial status hook
-  const { address } = useBaseAccount();
-  const { data: basename } = useBasename(address ?? undefined);
+  const { address, universalAddress } = useBaseAccount();
+  const { data: basename } = useBasename(address ?? undefined, universalAddress ?? undefined);
   const playerDisplayName = basename ?? (address ? `${address.slice(0, 6)}...${address.slice(-4)}` : 'Player');
   const [joinGameStartError, setJoinGameStartError] = useState<string | null>(null);
   const [isJoiningAfterPayment, setIsJoiningAfterPayment] = useState(false);

--- a/app/rootProvider.tsx
+++ b/app/rootProvider.tsx
@@ -5,6 +5,7 @@ import { WagmiProvider } from "wagmi";
 import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
 import { SpacetimeProvider } from "@/components/providers/SpacetimeProvider";
 import { BaseAccountProvider } from "@/components/providers/BaseAccountProvider";
+import { OrbAuthProvider } from "@/components/providers/OrbAuthProvider";
 import { wagmiConfig } from "@/lib/wagmi";
 
 const queryClient = new QueryClient();
@@ -25,8 +26,10 @@ export function RootProvider({ children }: { children: ReactNode }) {
       <QueryClientProvider client={queryClient}>
         <SpacetimeProvider>
           <BaseAccountProvider>
-            <FarcasterReadyEffect />
-            {children}
+            <OrbAuthProvider>
+              <FarcasterReadyEffect />
+              {children}
+            </OrbAuthProvider>
           </BaseAccountProvider>
         </SpacetimeProvider>
       </QueryClientProvider>

--- a/components/auth/OrbConnectButton.tsx
+++ b/components/auth/OrbConnectButton.tsx
@@ -44,7 +44,7 @@ export default function OrbConnectButton({
   const handleOpenDialog = () => {
     clearError();
     setDialogOpen(true);
-    if (!session) {
+    if (!session && !isConnecting) {
       handleConnect();
     }
   };

--- a/components/auth/OrbConnectButton.tsx
+++ b/components/auth/OrbConnectButton.tsx
@@ -1,0 +1,181 @@
+'use client';
+
+import { useState } from 'react';
+import Image from 'next/image';
+import { Button } from '@/components/ui/button';
+import {
+  Dialog,
+  DialogContent,
+  DialogDescription,
+  DialogHeader,
+  DialogTitle,
+} from '@/components/ui/dialog';
+import { Loader2, Link2, Unlink } from 'lucide-react';
+import { useOrbAuth } from '@/components/providers/OrbAuthProvider';
+import { useBaseAccount } from '@/hooks/useBaseAccount';
+import { PlayerAvatar } from '@/components/identity/PlayerAvatar';
+
+type OrbConnectButtonProps = {
+  className?: string;
+  compact?: boolean;
+};
+
+export default function OrbConnectButton({
+  className = '',
+  compact = false,
+}: OrbConnectButtonProps) {
+  const { isConnected } = useBaseAccount();
+  const {
+    session,
+    linkedProfile,
+    isConnecting,
+    isLinking,
+    error,
+    connectWithQr,
+    linkToWallet,
+    disconnect,
+    clearError,
+  } = useOrbAuth();
+
+  const [dialogOpen, setDialogOpen] = useState(false);
+  const [qrCode, setQrCode] = useState<string | null>(null);
+  const [deepLink, setDeepLink] = useState<string | null>(null);
+
+  const handleOpenDialog = () => {
+    clearError();
+    setDialogOpen(true);
+    if (!session) {
+      handleConnect();
+    }
+  };
+
+  const handleConnect = async () => {
+    try {
+      await connectWithQr(({ qrCode: code, deepLink: link }) => {
+        setQrCode(code);
+        setDeepLink(link ?? null);
+      });
+    } catch {
+      // error surfaced via context
+    }
+  };
+
+  const handleLink = async () => {
+    const profile = await linkToWallet();
+    if (profile) {
+      setDialogOpen(false);
+    }
+  };
+
+  if (!isConnected) {
+    return null;
+  }
+
+  if (linkedProfile) {
+    return (
+      <div className={`flex items-center gap-2 ${className}`}>
+        <PlayerAvatar
+          walletAddress={undefined}
+          username={`@${linkedProfile.handle}`}
+          avatarUrl={linkedProfile.avatarUrl}
+          className="w-8 h-8"
+        />
+        {!compact && (
+          <span className="text-sm text-white/90">@{linkedProfile.handle}</span>
+        )}
+        <Button
+          type="button"
+          variant="ghost"
+          size="sm"
+          onClick={disconnect}
+          className="text-white/60 hover:text-white"
+          aria-label="Disconnect Orb profile"
+        >
+          <Unlink className="w-4 h-4" />
+        </Button>
+      </div>
+    );
+  }
+
+  return (
+    <>
+      <Button
+        type="button"
+        variant="outline"
+        onClick={handleOpenDialog}
+        className={`border-purple-500/50 text-purple-200 hover:bg-purple-500/10 ${className}`}
+        aria-label="Connect Orb profile"
+      >
+        {isConnecting || isLinking ? (
+          <Loader2 className="w-4 h-4 animate-spin mr-2" />
+        ) : (
+          <Link2 className="w-4 h-4 mr-2" />
+        )}
+        {compact ? 'Orb' : 'Link Orb Profile'}
+      </Button>
+
+      <Dialog open={dialogOpen} onOpenChange={setDialogOpen}>
+        <DialogContent className="bg-black border-gray-800 text-white sm:max-w-md">
+          <DialogHeader>
+            <DialogTitle>Connect Orb / Lens</DialogTitle>
+            <DialogDescription className="text-gray-400">
+              Scan with the Orb app to link your Lens handle and avatar to Beat Me.
+            </DialogDescription>
+          </DialogHeader>
+
+          <div className="flex flex-col items-center gap-4 py-2">
+            {qrCode ? (
+              <Image
+                src={qrCode}
+                alt="Orb sign-in QR code"
+                width={220}
+                height={220}
+                className="rounded-lg border border-gray-700"
+                unoptimized
+              />
+            ) : (
+              <div className="w-[220px] h-[220px] flex items-center justify-center bg-gray-900 rounded-lg">
+                <Loader2 className="w-8 h-8 animate-spin text-purple-400" />
+              </div>
+            )}
+
+            {deepLink && (
+              <a
+                href={deepLink}
+                className="text-sm text-purple-300 hover:text-purple-200 underline"
+                target="_blank"
+                rel="noopener noreferrer"
+              >
+                Open in Orb app
+              </a>
+            )}
+
+            {session && !linkedProfile && (
+              <Button
+                type="button"
+                onClick={handleLink}
+                disabled={isLinking}
+                className="w-full bg-gradient-to-r from-purple-500 to-pink-500"
+              >
+                {isLinking ? (
+                  <>
+                    <Loader2 className="w-4 h-4 animate-spin mr-2" />
+                    Linking to wallet…
+                  </>
+                ) : (
+                  'Link to Base wallet'
+                )}
+              </Button>
+            )}
+
+            {error && (
+              <p className="text-sm text-red-400 text-center" role="alert">
+                {error}
+              </p>
+            )}
+          </div>
+        </DialogContent>
+      </Dialog>
+    </>
+  );
+}

--- a/components/game/ActivePlayers.tsx
+++ b/components/game/ActivePlayers.tsx
@@ -2,6 +2,7 @@
 
 import { useState } from 'react';
 import { PlayerAvatarWithFetch } from '@/components/identity/PlayerAvatar';
+import { AvatarSkeleton } from '@/components/identity/IdentitySkeleton';
 import { useActivePlayers, type ActivePlayer } from '@/hooks/useActivePlayers';
 import { useLobbyPlayers } from '@/hooks/useLobbyPlayers';
 import { useSocialShare } from '@/hooks/useSocialShare';
@@ -81,13 +82,17 @@ export default function ActivePlayers({
 
   if (isLoading) {
     return (
-      <div className={`flex items-center justify-center space-x-1 ${className}`}>
+      <div className={`flex items-center justify-start space-x-1 ${className}`}>
         {Array.from({ length: Math.min(8, maxPlayers) }, (_, i) => (
           <div
             key={i}
-            className="w-5 h-5 bg-gray-600 rounded-full animate-pulse"
-            style={{ animationDelay: `${i * 0.1}s` }}
-          />
+            style={{
+              marginRight: i < Math.min(8, maxPlayers) - 1 ? '-8px' : '0',
+              zIndex: Math.min(8, maxPlayers) - i,
+            }}
+          >
+            <AvatarSkeleton className="w-5 h-5 border-2 border-black" />
+          </div>
         ))}
       </div>
     );

--- a/components/game/ActivePlayers.tsx
+++ b/components/game/ActivePlayers.tsx
@@ -1,8 +1,9 @@
 'use client';
 
 import { useState } from 'react';
-import { BaseAvatar } from '@/components/identity/BaseAvatar';
+import { PlayerAvatarWithFetch } from '@/components/identity/PlayerAvatar';
 import { useActivePlayers, type ActivePlayer } from '@/hooks/useActivePlayers';
+import { useLobbyPlayers } from '@/hooks/useLobbyPlayers';
 import { useSocialShare } from '@/hooks/useSocialShare';
 import { Share2, Users, Trophy } from 'lucide-react';
 
@@ -12,6 +13,9 @@ interface ActivePlayersProps {
   showTooltips?: boolean;
   showSocialFeatures?: boolean;
   onPlayerClick?: (player: ActivePlayer) => void;
+  /** When set, reads live lobby participants from SpacetimeDB instead of the API. */
+  sessionId?: string | null;
+  useLiveLobby?: boolean;
 }
 
 export default function ActivePlayers({ 
@@ -19,9 +23,27 @@ export default function ActivePlayers({
   maxPlayers = 16, 
   showTooltips = true,
   showSocialFeatures = true,
-  onPlayerClick
+  onPlayerClick,
+  sessionId = null,
+  useLiveLobby = false,
 }: ActivePlayersProps) {
-  const { players, isLoading, error } = useActivePlayers({ maxPlayers });
+  const apiPlayers = useActivePlayers({ maxPlayers, autoRefresh: !useLiveLobby });
+  const lobby = useLobbyPlayers({ sessionId: useLiveLobby ? sessionId : null });
+
+  const players: ActivePlayer[] = useLiveLobby
+    ? lobby.players.slice(0, maxPlayers).map((p) => ({
+        address: p.address,
+        username: p.username,
+        avatarUrl: p.avatarUrl,
+        totalScore: 0,
+        gamesPlayed: 0,
+        isWalletUser: p.isWalletUser,
+        lastActive: p.joinedAt,
+      }))
+    : apiPlayers.players;
+
+  const isLoading = useLiveLobby ? lobby.isLoading : apiPlayers.isLoading;
+  const error = useLiveLobby ? null : apiPlayers.error;
   const [hoveredPlayer, setHoveredPlayer] = useState<ActivePlayer | null>(null);
   const { sharePlayerActivity } = useSocialShare();
 
@@ -96,14 +118,11 @@ export default function ActivePlayers({
             className="relative"
             onClick={() => handlePlayerClick(player)}
           >
-            <BaseAvatar
-              address={player.isWalletUser ? (player.address as `0x${string}`) : undefined}
+            <PlayerAvatarWithFetch
+              walletAddress={player.isWalletUser ? player.address : undefined}
+              username={player.username}
+              avatarUrl={player.avatarUrl}
               className="w-5 h-5 border-2 border-black rounded-full shadow-sm hover:scale-110 transition-transform duration-200 cursor-pointer"
-              defaultComponent={
-                <div className="w-5 h-5 bg-gradient-to-br from-purple-400 to-pink-400 rounded-full flex items-center justify-center text-white text-xs font-bold">
-                  {player.username.slice(0, 2).toUpperCase()}
-                </div>
-              }
             />
             
           </div>

--- a/components/game/GameEntry.tsx
+++ b/components/game/GameEntry.tsx
@@ -16,6 +16,7 @@ import TrialStatusDisplay from './TrialStatusDisplay';
 import GamePayment from './GamePayment';
 import WalletWithBalance from '@/components/wallet/WalletWithBalance';
 import SubAccountDisplay from '@/components/base-account/SubAccountDisplay';
+import OrbConnectButton from '@/components/auth/OrbConnectButton';
 import GaslessBadge from '@/components/base-account/GaslessBadge';
 import { Gamepad2, Crown, Coins, Play, DollarSign, AlertCircle, CheckCircle, Loader2, Wallet } from 'lucide-react';
 // Removed OnchainKit transaction imports - using Base Account native methods instead
@@ -666,13 +667,18 @@ export default function GameEntry({
               {/* Base Account Display */}
               <div className="mb-4">
                 {isConnected ? (
-                  <SubAccountDisplay
-                    showActions={true}
-                    onFundEth={handleFundEth}
-                    ethFundingLoading={ethFundingLoading}
-                    ethFundingError={ethFundingError}
-                    paymasterConfigured={paymasterConfigured}
-                  />
+                  <>
+                    <SubAccountDisplay
+                      showActions={true}
+                      onFundEth={handleFundEth}
+                      ethFundingLoading={ethFundingLoading}
+                      ethFundingError={ethFundingError}
+                      paymasterConfigured={paymasterConfigured}
+                    />
+                    <div className="mt-3 flex justify-center">
+                      <OrbConnectButton />
+                    </div>
+                  </>
                 ) : (
                   <div className="text-center">
                     <SignInWithBaseButton

--- a/components/game/HighScoreDisplay.tsx
+++ b/components/game/HighScoreDisplay.tsx
@@ -11,6 +11,7 @@ import { useBaseAccount } from '@/hooks/useBaseAccount';
 import ClaimWinningsButton from '@/components/game/ClaimWinningsButton';
 import { BaseName } from '@/components/identity/BaseName';
 import { PlayerAvatarWithFetch } from '@/components/identity/PlayerAvatar';
+import { AvatarSkeleton } from '@/components/identity/IdentitySkeleton';
 import ComposeCastButton from '@/components/social/ComposeCastButton';
 import { Confetti } from '@neoconfetti/react';
 import {
@@ -421,6 +422,7 @@ export default function HighScoreDisplay({
               <div key={`skeleton-${index}`} className="flex items-center justify-between p-2">
                 <div className="flex items-center gap-2 flex-1">
                   <Skeleton className="h-4 w-4 rounded-full" />
+                  <AvatarSkeleton className="w-6 h-6 ml-1" />
                   <Skeleton className="h-4 w-32" />
                 </div>
                 <Skeleton className="h-4 w-12" />

--- a/components/game/HighScoreDisplay.tsx
+++ b/components/game/HighScoreDisplay.tsx
@@ -10,6 +10,7 @@ import { Skeleton } from '@/components/ui/skeleton';
 import { useBaseAccount } from '@/hooks/useBaseAccount';
 import ClaimWinningsButton from '@/components/game/ClaimWinningsButton';
 import { BaseName } from '@/components/identity/BaseName';
+import { PlayerAvatarWithFetch } from '@/components/identity/PlayerAvatar';
 import ComposeCastButton from '@/components/social/ComposeCastButton';
 import { Confetti } from '@neoconfetti/react';
 import {
@@ -441,6 +442,12 @@ export default function HighScoreDisplay({
                 >
                   <div className="flex items-center">
                     {getRankIcon(index + 1)}
+                    <PlayerAvatarWithFetch
+                      walletAddress={entry.walletAddress}
+                      username={entry.username}
+                      avatarUrl={entry.avatarUrl}
+                      className="w-6 h-6 ml-1"
+                    />
                     <span className="ml-2 text-sm font-medium text-gray-700">
                       <PlayerDisplayName
                         walletAddress={entry.walletAddress}

--- a/components/identity/BaseAvatar.tsx
+++ b/components/identity/BaseAvatar.tsx
@@ -1,34 +1,33 @@
 'use client';
 
-import { useEnsName, useEnsAvatar } from 'wagmi';
-import { normalize } from 'viem/ens';
+import { PlayerAvatarWithFetch } from '@/components/identity/PlayerAvatar';
 
 interface BaseAvatarProps {
   address?: `0x${string}`;
   className?: string;
   defaultComponent?: React.ReactNode;
+  avatarUrl?: string | null;
+  username?: string | null;
 }
 
-export function BaseAvatar({ address, className = '', defaultComponent }: BaseAvatarProps) {
-  const { data: ensName } = useEnsName({
-    address,
-    query: { enabled: !!address },
-  });
-
-  const { data: avatarUrl } = useEnsAvatar({
-    name: ensName ? normalize(ensName) : undefined,
-    query: { enabled: !!ensName },
-  });
-
-  if (avatarUrl) {
-    return (
-      <img
-        src={avatarUrl}
-        alt="avatar"
-        className={`rounded-full object-cover ${className}`}
-      />
-    );
+export function BaseAvatar({
+  address,
+  className = '',
+  defaultComponent,
+  avatarUrl,
+  username,
+}: BaseAvatarProps) {
+  if (!address) {
+    return <>{defaultComponent ?? null}</>;
   }
 
-  return <>{defaultComponent ?? null}</>;
+  return (
+    <PlayerAvatarWithFetch
+      walletAddress={address}
+      username={username}
+      avatarUrl={avatarUrl}
+      className={className}
+      fetchIfMissing={!avatarUrl}
+    />
+  );
 }

--- a/components/identity/BaseName.tsx
+++ b/components/identity/BaseName.tsx
@@ -4,11 +4,16 @@ import { useBasename } from '@/hooks/useBasename';
 
 interface BaseNameProps {
   address: `0x${string}`;
+  universalAddress?: `0x${string}` | string | null;
   className?: string;
 }
 
-export const BaseName = ({ address, className = '' }: BaseNameProps) => {
-  const { data: name, isLoading } = useBasename(address);
+export const BaseName = ({
+  address,
+  universalAddress,
+  className = '',
+}: BaseNameProps) => {
+  const { data: name, isLoading } = useBasename(address, universalAddress);
 
   const displayName =
     name ?? `${address.slice(0, 6)}...${address.slice(-4)}`;

--- a/components/identity/BaseName.tsx
+++ b/components/identity/BaseName.tsx
@@ -1,6 +1,7 @@
 'use client';
 
 import { useBasename } from '@/hooks/useBasename';
+import { DisplayNameSkeleton } from '@/components/identity/IdentitySkeleton';
 
 interface BaseNameProps {
   address: `0x${string}`;
@@ -15,12 +16,16 @@ export const BaseName = ({
 }: BaseNameProps) => {
   const { data: name, isLoading } = useBasename(address, universalAddress);
 
+  if (isLoading && !name) {
+    return <DisplayNameSkeleton className={className} />;
+  }
+
   const displayName =
     name ?? `${address.slice(0, 6)}...${address.slice(-4)}`;
 
   return (
     <span className={className} title={address}>
-      {isLoading && !name ? `${address.slice(0, 6)}...` : displayName}
+      {displayName}
     </span>
   );
 };

--- a/components/identity/IdentitySkeleton.tsx
+++ b/components/identity/IdentitySkeleton.tsx
@@ -1,0 +1,25 @@
+'use client';
+
+import { Skeleton } from '@/components/ui/skeleton';
+import { cn } from '@/lib/utils';
+
+export const AvatarSkeleton = ({ className = '' }: { className?: string }) => (
+  <Skeleton
+    className={cn('rounded-full shrink-0', className)}
+    aria-hidden
+  />
+);
+
+export const DisplayNameSkeleton = ({ className = '' }: { className?: string }) => (
+  <Skeleton
+    className={cn('inline-block h-3.5 w-24 rounded-md', className)}
+    aria-hidden
+  />
+);
+
+export const StatValueSkeleton = ({ className = '' }: { className?: string }) => (
+  <Skeleton
+    className={cn('h-8 w-20 mx-auto rounded-md', className)}
+    aria-hidden
+  />
+);

--- a/components/identity/PlayerAvatar.tsx
+++ b/components/identity/PlayerAvatar.tsx
@@ -1,6 +1,6 @@
 'use client';
 
-import { useMemo } from 'react';
+import { useMemo, useState } from 'react';
 import { useQuery } from '@tanstack/react-query';
 import { useBasename } from '@/hooks/useBasename';
 import { resolveLensMediaUrl } from '@/lib/identity/resolveLensMedia';
@@ -9,6 +9,8 @@ import {
   gradientClassForWallet,
   type PlayerIdentityCache,
 } from '@/lib/identity/playerIdentity';
+import { AvatarSkeleton } from '@/components/identity/IdentitySkeleton';
+import { cn } from '@/lib/utils';
 
 export type PlayerAvatarProps = {
   walletAddress?: string | null;
@@ -30,8 +32,10 @@ export const PlayerAvatar = ({
 }: PlayerAvatarProps) => {
   const normalizedWallet = walletAddress?.trim().toLowerCase();
   const isWallet = !!normalizedWallet?.startsWith('0x');
+  const [imageLoaded, setImageLoaded] = useState(false);
+  const [imageError, setImageError] = useState(false);
 
-  const { data: basename } = useBasename(
+  const { data: basename, isLoading: basenameLoading } = useBasename(
     isWallet ? (normalizedWallet as `0x${string}`) : undefined,
     universalWalletAddress ?? undefined,
   );
@@ -49,13 +53,30 @@ export const PlayerAvatar = ({
     ? gradientClassForWallet(normalizedWallet)
     : 'from-purple-400 to-pink-400';
 
-  if (resolvedAvatar) {
+  const isResolvingIdentity =
+    isWallet && !username && !resolvedAvatar && basenameLoading;
+
+  if (isResolvingIdentity) {
+    return <AvatarSkeleton className={className} />;
+  }
+
+  if (resolvedAvatar && !imageError) {
     return (
-      <img
-        src={resolvedAvatar}
-        alt={alt ?? displayLabel}
-        className={`rounded-full object-cover ${className}`}
-      />
+      <div className={cn('relative shrink-0', className)}>
+        {!imageLoaded && (
+          <AvatarSkeleton className="absolute inset-0 h-full w-full" />
+        )}
+        <img
+          src={resolvedAvatar}
+          alt={alt ?? displayLabel}
+          className={cn(
+            'rounded-full object-cover h-full w-full',
+            !imageLoaded && 'opacity-0',
+          )}
+          onLoad={() => setImageLoaded(true)}
+          onError={() => setImageError(true)}
+        />
+      </div>
     );
   }
 
@@ -79,12 +100,13 @@ export const PlayerAvatarWithFetch = ({
   ...rest
 }: PlayerAvatarWithFetchProps) => {
   const normalizedWallet = walletAddress?.trim().toLowerCase();
+  const hasKnownIdentity = !!(rest.username || rest.avatarUrl);
   const shouldFetch =
     fetchIfMissing &&
     !!normalizedWallet?.startsWith('0x') &&
-    !rest.avatarUrl;
+    !hasKnownIdentity;
 
-  const { data } = useQuery({
+  const { data, isPending, isFetching } = useQuery({
     queryKey: ['player-identity', normalizedWallet],
     queryFn: async () => {
       const response = await fetch(
@@ -102,9 +124,16 @@ export const PlayerAvatarWithFetch = ({
     staleTime: 5 * 60 * 1000,
   });
 
+  const isResolving = shouldFetch && (isPending || isFetching) && !data;
+
+  if (isResolving) {
+    return <AvatarSkeleton className={rest.className} />;
+  }
+
   return (
     <PlayerAvatar
       walletAddress={normalizedWallet}
+      universalWalletAddress={rest.universalWalletAddress}
       username={rest.username ?? data?.username ?? data?.displayName}
       avatarUrl={rest.avatarUrl ?? data?.avatarUrl ?? undefined}
       className={rest.className}

--- a/components/identity/PlayerAvatar.tsx
+++ b/components/identity/PlayerAvatar.tsx
@@ -1,0 +1,114 @@
+'use client';
+
+import { useMemo } from 'react';
+import { useQuery } from '@tanstack/react-query';
+import { useBasename } from '@/hooks/useBasename';
+import { resolveLensMediaUrl } from '@/lib/identity/resolveLensMedia';
+import {
+  getInitials,
+  gradientClassForWallet,
+  type PlayerIdentityCache,
+} from '@/lib/identity/playerIdentity';
+
+export type PlayerAvatarProps = {
+  walletAddress?: string | null;
+  /** Universal Base Account address when `walletAddress` is a sub-account */
+  universalWalletAddress?: string | null;
+  username?: string | null;
+  avatarUrl?: string | null;
+  className?: string;
+  alt?: string;
+};
+
+export const PlayerAvatar = ({
+  walletAddress,
+  universalWalletAddress,
+  username,
+  avatarUrl,
+  className = '',
+  alt,
+}: PlayerAvatarProps) => {
+  const normalizedWallet = walletAddress?.trim().toLowerCase();
+  const isWallet = !!normalizedWallet?.startsWith('0x');
+
+  const { data: basename } = useBasename(
+    isWallet ? (normalizedWallet as `0x${string}`) : undefined,
+    universalWalletAddress ?? undefined,
+  );
+
+  const resolvedAvatar = useMemo(() => {
+    if (avatarUrl) {
+      return resolveLensMediaUrl(avatarUrl) ?? avatarUrl;
+    }
+    return null;
+  }, [avatarUrl]);
+
+  const displayLabel = username ?? basename ?? (normalizedWallet ? normalizedWallet.slice(0, 8) : '?');
+  const initials = getInitials(displayLabel);
+  const gradient = normalizedWallet
+    ? gradientClassForWallet(normalizedWallet)
+    : 'from-purple-400 to-pink-400';
+
+  if (resolvedAvatar) {
+    return (
+      <img
+        src={resolvedAvatar}
+        alt={alt ?? displayLabel}
+        className={`rounded-full object-cover ${className}`}
+      />
+    );
+  }
+
+  return (
+    <div
+      className={`rounded-full flex items-center justify-center text-white font-bold bg-gradient-to-br ${gradient} ${className}`}
+      aria-label={alt ?? displayLabel}
+    >
+      <span className="text-[0.55em] leading-none">{initials}</span>
+    </div>
+  );
+};
+
+export type PlayerAvatarWithFetchProps = PlayerAvatarProps & {
+  fetchIfMissing?: boolean;
+};
+
+export const PlayerAvatarWithFetch = ({
+  walletAddress,
+  fetchIfMissing = true,
+  ...rest
+}: PlayerAvatarWithFetchProps) => {
+  const normalizedWallet = walletAddress?.trim().toLowerCase();
+  const shouldFetch =
+    fetchIfMissing &&
+    !!normalizedWallet?.startsWith('0x') &&
+    !rest.avatarUrl;
+
+  const { data } = useQuery({
+    queryKey: ['player-identity', normalizedWallet],
+    queryFn: async () => {
+      const response = await fetch(
+        `/api/player-identities?wallets=${encodeURIComponent(normalizedWallet!)}`,
+      );
+      if (!response.ok) {
+        return null;
+      }
+      const json = (await response.json()) as {
+        identities?: Record<string, PlayerIdentityCache & { displayName?: string }>;
+      };
+      return json.identities?.[normalizedWallet!] ?? null;
+    },
+    enabled: shouldFetch,
+    staleTime: 5 * 60 * 1000,
+  });
+
+  return (
+    <PlayerAvatar
+      walletAddress={normalizedWallet}
+      username={rest.username ?? data?.username ?? data?.displayName}
+      avatarUrl={rest.avatarUrl ?? data?.avatarUrl ?? undefined}
+      className={rest.className}
+      alt={rest.alt}
+    />
+  );
+};

--- a/components/leaderboard/LiveRankings.tsx
+++ b/components/leaderboard/LiveRankings.tsx
@@ -6,6 +6,8 @@ import { Badge } from '@/components/ui/badge';
 import { Trophy, Medal, Award, TrendingUp, Clock, Target, Loader2 } from 'lucide-react';
 import { BaseAvatar } from '@/components/identity/BaseAvatar';
 import { BaseName } from '@/components/identity/BaseName';
+import { AvatarSkeleton, DisplayNameSkeleton } from '@/components/identity/IdentitySkeleton';
+import { Skeleton } from '@/components/ui/skeleton';
 import type { LeaderboardEntry } from '@/types/game';
 import { useMiniAppProfile } from '@/hooks/useMiniAppProfile';
 import { useLeaderboardLive } from '@/hooks/useLeaderboardLive';
@@ -124,7 +126,24 @@ export default function LiveRankings({
       </CardHeader>
 
       <CardContent className="space-y-3">
-        {displayEntries.length === 0 ? (
+        {isLoading && !entriesProp && displayEntries.length === 0 ? (
+          Array.from({ length: limit }).map((_, index) => (
+            <div
+              key={`live-ranking-skeleton-${index}`}
+              className="p-4 rounded-lg border-2 border-gray-200 bg-white"
+            >
+              <div className="flex items-center space-x-4">
+                <Skeleton className="h-6 w-6 rounded-full" />
+                <AvatarSkeleton className="h-8 w-8" />
+                <div className="space-y-2 flex-1">
+                  <DisplayNameSkeleton className="h-4 w-32" />
+                  <Skeleton className="h-3 w-24" />
+                </div>
+                <Skeleton className="h-4 w-16" />
+              </div>
+            </div>
+          ))
+        ) : displayEntries.length === 0 ? (
           <div className="text-center py-8 text-gray-500">
             <Trophy className="h-12 w-12 mx-auto mb-4 text-gray-300" />
             <p className="text-lg font-medium mb-2">No players yet</p>

--- a/components/leaderboard/TopEarners.tsx
+++ b/components/leaderboard/TopEarners.tsx
@@ -1,10 +1,9 @@
 'use client';
 
 import { useWeeklyLeaderboard } from '@/hooks/useWeeklyLeaderboard';
-import Image from 'next/image';
-import { ASSETS } from '@/lib/config/assets';
 import { Skeleton } from '@/components/ui/skeleton';
 import { BaseName } from '@/components/identity/BaseName';
+import { PlayerAvatarWithFetch } from '@/components/identity/PlayerAvatar';
 
 interface TopEarnersProps {
   limit?: number;
@@ -38,12 +37,6 @@ export default function TopEarners({
     if (rank === 1) return '🏆';
     return `#${rank}`;
   };
-
-  const avatarImages = [
-    ASSETS.ellipse7, ASSETS.ellipse4, ASSETS.ellipse5,
-    ASSETS.ellipse6, ASSETS.ellipse8, ASSETS.ellipse9,
-    ASSETS.ellipse10,
-  ];
 
   if (error) {
     return (
@@ -97,12 +90,11 @@ export default function TopEarners({
               </div>
               <div className="content-stretch flex gap-3 items-center justify-start relative shrink-0">
                 <div className="relative shrink-0 size-9">
-                  <Image
-                    alt="player avatar"
-                    className="block max-w-none size-full"
-                    height="36"
-                    src={earner.avatarUrl || avatarImages[index % avatarImages.length]}
-                    width="36"
+                  <PlayerAvatarWithFetch
+                    walletAddress={earner.walletAddress}
+                    username={earner.username}
+                    avatarUrl={earner.avatarUrl}
+                    className="size-9"
                   />
                 </div>
                 <div className="font-['Audiowide:Regular',_sans-serif] leading-[0] not-italic relative shrink-0 text-[#ffffff] text-[12px] text-nowrap">

--- a/components/providers/OrbAuthProvider.tsx
+++ b/components/providers/OrbAuthProvider.tsx
@@ -1,0 +1,219 @@
+'use client';
+
+import {
+  createContext,
+  useCallback,
+  useContext,
+  useEffect,
+  useMemo,
+  useState,
+  type ReactNode,
+} from 'react';
+import { getOrbLogin, enrichSessionWithAccount, sessionFromQrResult } from '@/lib/orb/client';
+import {
+  ORB_SESSION_STORAGE_KEY,
+  type LensProfile,
+  type OrbSession,
+} from '@/lib/orb/types';
+import { useBaseAccount } from '@/hooks/useBaseAccount';
+import { signInWithBase } from '@/lib/base-account/auth';
+
+type OrbAuthContextValue = {
+  session: OrbSession | null;
+  linkedProfile: LensProfile | null;
+  isConnecting: boolean;
+  isLinking: boolean;
+  error: string | null;
+  connectWithQr: (onInit?: (payload: { qrCode: string; deepLink?: string }) => void) => Promise<void>;
+  linkToWallet: () => Promise<LensProfile | null>;
+  disconnect: () => void;
+  clearError: () => void;
+};
+
+const OrbAuthContext = createContext<OrbAuthContextValue | null>(null);
+
+const loadStoredSession = (): OrbSession | null => {
+  if (typeof window === 'undefined') {
+    return null;
+  }
+  try {
+    const raw = localStorage.getItem(ORB_SESSION_STORAGE_KEY);
+    if (!raw) {
+      return null;
+    }
+    return JSON.parse(raw) as OrbSession;
+  } catch {
+    return null;
+  }
+};
+
+const loadStoredProfile = (): LensProfile | null => {
+  if (typeof window === 'undefined') {
+    return null;
+  }
+  try {
+    const raw = localStorage.getItem(`${ORB_SESSION_STORAGE_KEY}_profile`);
+    if (!raw) {
+      return null;
+    }
+    return JSON.parse(raw) as LensProfile;
+  } catch {
+    return null;
+  }
+};
+
+export const OrbAuthProvider = ({ children }: { children: ReactNode }) => {
+  const { address, isConnected } = useBaseAccount();
+  const [session, setSession] = useState<OrbSession | null>(null);
+  const [linkedProfile, setLinkedProfile] = useState<LensProfile | null>(null);
+  const [isConnecting, setIsConnecting] = useState(false);
+  const [isLinking, setIsLinking] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+
+  useEffect(() => {
+    setSession(loadStoredSession());
+    setLinkedProfile(loadStoredProfile());
+  }, []);
+
+  const persistSession = useCallback((next: OrbSession | null) => {
+    setSession(next);
+    if (typeof window === 'undefined') {
+      return;
+    }
+    if (next) {
+      localStorage.setItem(ORB_SESSION_STORAGE_KEY, JSON.stringify(next));
+    } else {
+      localStorage.removeItem(ORB_SESSION_STORAGE_KEY);
+    }
+  }, []);
+
+  const persistProfile = useCallback((profile: LensProfile | null) => {
+    setLinkedProfile(profile);
+    if (typeof window === 'undefined') {
+      return;
+    }
+    if (profile) {
+      localStorage.setItem(`${ORB_SESSION_STORAGE_KEY}_profile`, JSON.stringify(profile));
+    } else {
+      localStorage.removeItem(`${ORB_SESSION_STORAGE_KEY}_profile`);
+    }
+  }, []);
+
+  const connectWithQr = useCallback(
+    async (onInit?: (payload: { qrCode: string; deepLink?: string }) => void) => {
+      setIsConnecting(true);
+      setError(null);
+      try {
+        const orb = getOrbLogin();
+        const result = await orb.connectWithQr({
+          onInit: (payload) => {
+            onInit?.({
+              qrCode: payload.qrCode,
+              deepLink: payload.deepLink,
+            });
+          },
+        });
+        const nextSession = enrichSessionWithAccount(sessionFromQrResult(result));
+        persistSession(nextSession);
+      } catch (err) {
+        setError(err instanceof Error ? err.message : 'Orb sign-in failed');
+        throw err;
+      } finally {
+        setIsConnecting(false);
+      }
+    },
+    [persistSession],
+  );
+
+  const linkToWallet = useCallback(async (): Promise<LensProfile | null> => {
+    if (!session?.accessToken) {
+      setError('Connect Orb first');
+      return null;
+    }
+    if (!isConnected || !address) {
+      setError('Connect Base Account first');
+      return null;
+    }
+
+    setIsLinking(true);
+    setError(null);
+    try {
+      const { message, signature } = await signInWithBase(address);
+      const response = await fetch('/api/auth/orb/link', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({
+          accessToken: session.accessToken,
+          walletAddress: address,
+          message,
+          signature,
+        }),
+      });
+
+      const data = (await response.json()) as {
+        error?: string;
+        profile?: LensProfile & { displayName?: string };
+      };
+
+      if (!response.ok) {
+        throw new Error(data.error ?? 'Failed to link Orb profile');
+      }
+
+      const profile: LensProfile = {
+        lensAccountId: data.profile!.lensAccountId,
+        handle: data.profile!.handle,
+        displayName: data.profile!.displayName,
+        avatarUrl: data.profile!.avatarUrl,
+      };
+      persistProfile(profile);
+      return profile;
+    } catch (err) {
+      setError(err instanceof Error ? err.message : 'Failed to link Orb profile');
+      return null;
+    } finally {
+      setIsLinking(false);
+    }
+  }, [address, isConnected, persistProfile, session?.accessToken]);
+
+  const disconnect = useCallback(() => {
+    persistSession(null);
+    persistProfile(null);
+    setError(null);
+  }, [persistProfile, persistSession]);
+
+  const value = useMemo<OrbAuthContextValue>(
+    () => ({
+      session,
+      linkedProfile,
+      isConnecting,
+      isLinking,
+      error,
+      connectWithQr,
+      linkToWallet,
+      disconnect,
+      clearError: () => setError(null),
+    }),
+    [
+      session,
+      linkedProfile,
+      isConnecting,
+      isLinking,
+      error,
+      connectWithQr,
+      linkToWallet,
+      disconnect,
+    ],
+  );
+
+  return (
+    <OrbAuthContext.Provider value={value}>{children}</OrbAuthContext.Provider>
+  );
+};
+
+export const useOrbAuth = (): OrbAuthContextValue => {
+  const ctx = useContext(OrbAuthContext);
+  if (!ctx) {
+    throw new Error('useOrbAuth must be used within OrbAuthProvider');
+  }
+  return ctx;
+};

--- a/components/social/SocialProfileViewer.tsx
+++ b/components/social/SocialProfileViewer.tsx
@@ -1,7 +1,7 @@
 'use client';
 
 import { useState, useEffect } from 'react';
-import { BaseAvatar } from '@/components/identity/BaseAvatar';
+import { PlayerAvatarWithFetch } from '@/components/identity/PlayerAvatar';
 import { Button } from '@/components/ui/button';
 import { Dialog, DialogContent, DialogHeader, DialogTitle } from '@/components/ui/dialog';
 import { Badge } from '@/components/ui/badge';
@@ -104,14 +104,11 @@ export default function SocialProfileViewer({
           {/* Player Avatar and Basic Info */}
           <div className="text-center space-y-4">
             <div className="relative inline-block">
-              <BaseAvatar
-                address={player.isWalletUser ? (player.address as `0x${string}`) : undefined}
+              <PlayerAvatarWithFetch
+                walletAddress={player.isWalletUser ? player.address : undefined}
+                username={player.username}
+                avatarUrl={player.avatarUrl}
                 className="w-20 h-20 border-4 border-gray-700 rounded-full"
-                defaultComponent={
-                  <div className="w-20 h-20 bg-gradient-to-br from-purple-400 to-pink-400 rounded-full flex items-center justify-center text-white text-2xl font-bold">
-                    {player.username.slice(0, 2).toUpperCase()}
-                  </div>
-                }
               />
               <div className="absolute -bottom-2 -right-2">
                 <Badge className={`${getRankColor(getPlayerRank())} text-white border-0`}>

--- a/components/social/SocialProfileViewer.tsx
+++ b/components/social/SocialProfileViewer.tsx
@@ -2,6 +2,7 @@
 
 import { useState, useEffect } from 'react';
 import { PlayerAvatarWithFetch } from '@/components/identity/PlayerAvatar';
+import { AvatarSkeleton, StatValueSkeleton } from '@/components/identity/IdentitySkeleton';
 import { Button } from '@/components/ui/button';
 import { Dialog, DialogContent, DialogHeader, DialogTitle } from '@/components/ui/dialog';
 import { Badge } from '@/components/ui/badge';
@@ -104,12 +105,16 @@ export default function SocialProfileViewer({
           {/* Player Avatar and Basic Info */}
           <div className="text-center space-y-4">
             <div className="relative inline-block">
-              <PlayerAvatarWithFetch
-                walletAddress={player.isWalletUser ? player.address : undefined}
-                username={player.username}
-                avatarUrl={player.avatarUrl}
-                className="w-20 h-20 border-4 border-gray-700 rounded-full"
-              />
+              {profileLoading && player.isWalletUser ? (
+                <AvatarSkeleton className="w-20 h-20 border-4 border-gray-700" />
+              ) : (
+                <PlayerAvatarWithFetch
+                  walletAddress={player.isWalletUser ? player.address : undefined}
+                  username={player.username}
+                  avatarUrl={player.avatarUrl}
+                  className="w-20 h-20 border-4 border-gray-700 rounded-full"
+                />
+              )}
               <div className="absolute -bottom-2 -right-2">
                 <Badge className={`${getRankColor(getPlayerRank())} text-white border-0`}>
                   {getPlayerRank()}
@@ -141,7 +146,7 @@ export default function SocialProfileViewer({
               <Trophy className="w-6 h-6 text-yellow-400 mx-auto mb-2" />
               <div className="text-2xl font-bold text-white">
                 {profileLoading ? (
-                  <div className="h-8 w-20 mx-auto bg-gray-700 animate-pulse rounded" />
+                  <StatValueSkeleton />
                 ) : (
                   displayStats.totalScore
                 )}
@@ -153,7 +158,7 @@ export default function SocialProfileViewer({
               <Users className="w-6 h-6 text-blue-400 mx-auto mb-2" />
               <div className="text-2xl font-bold text-white">
                 {profileLoading ? (
-                  <div className="h-8 w-20 mx-auto bg-gray-700 animate-pulse rounded" />
+                  <StatValueSkeleton />
                 ) : (
                   displayStats.gamesPlayed
                 )}

--- a/env.example
+++ b/env.example
@@ -70,6 +70,19 @@ NEXT_PUBLIC_TRIVIA_CONTRACT_ADDRESS=0xfF52Ed1DEb46C197aD7fce9DEC93ff9e987f8dB6
 # Base RPC URL (optional, defaults to mainnet.base.org)
 NEXT_PUBLIC_BASE_RPC_URL=https://mainnet.base.org
 
+# Ethereum mainnet RPC for Basename + ENS avatar resolution (Alchemy recommended)
+NEXT_PUBLIC_ALCHEMY_API_KEY=your_alchemy_api_key_here
+
+# SpacetimeDB (server routes + optional admin identity for Orb link writes)
+NEXT_PUBLIC_SPACETIME_HOST=https://maincloud.spacetimedb.com
+NEXT_PUBLIC_SPACETIME_MODULE=beat-me
+SPACETIME_HOST=https://maincloud.spacetimedb.com
+SPACETIME_MODULE=beat-me
+SPACETIME_TOKEN=your_server_admin_token_here
+
+# Optional Lens GraphQL override for Orb profile verification
+LENS_GRAPHQL_URL=https://api.lens.xyz/graphql
+
 # CDP Configuration (for embedded wallets and paymaster)
 NEXT_PUBLIC_CDP_API_KEY=your_cdp_api_key_here
 NEXT_PUBLIC_CDP_PROJECT_ID=your_cdp_project_id_here

--- a/hooks/useActivePlayers.ts
+++ b/hooks/useActivePlayers.ts
@@ -1,3 +1,5 @@
+'use client';
+
 import { useState, useEffect } from 'react';
 
 export interface ActivePlayer {
@@ -12,14 +14,14 @@ export interface ActivePlayer {
 
 interface UseActivePlayersOptions {
   maxPlayers?: number;
-  refreshInterval?: number; // in milliseconds
+  refreshInterval?: number;
   autoRefresh?: boolean;
 }
 
 export const useActivePlayers = ({
   maxPlayers = 16,
   refreshInterval = 30000,
-  autoRefresh = true
+  autoRefresh = true,
 }: UseActivePlayersOptions = {}) => {
   const [players, setPlayers] = useState<ActivePlayer[]>([]);
   const [isLoading, setIsLoading] = useState(true);
@@ -29,89 +31,31 @@ export const useActivePlayers = ({
     try {
       setIsLoading(true);
       setError(null);
-      
-      // Try live CDP SQL API first
+
       const response = await fetch('/api/active-players-live');
       if (!response.ok) {
         throw new Error('Failed to fetch active players');
       }
-      
+
       const data = await response.json();
-      
-      // Log data source for debugging
-      if (data.source && data.source.startsWith('demo')) {
-        console.log('⚠️ Using demo players data:', data.source);
-      } else if (data.source === 'cdp-sql-api-live') {
-        console.log('✅ Using real live player data from CDP SQL API');
-        console.log(`📊 Found ${data.count} active players from blockchain`);
+
+      if (data.source === 'spacetime-live') {
+        console.log(`✅ Loaded ${data.count} live players from SpacetimeDB`);
       }
-      
-      setPlayers(data.players.slice(0, maxPlayers));
+
+      setPlayers((data.players ?? []).slice(0, maxPlayers));
     } catch (err) {
       console.error('Error fetching active players:', err);
       setError(err instanceof Error ? err.message : 'Failed to load players');
-      
-      // Fallback to demo players if API fails
-      setPlayers(generateDemoPlayers(maxPlayers));
+      setPlayers([]);
     } finally {
       setIsLoading(false);
     }
   };
 
-  // Generate demo players for fallback
-  const generateDemoPlayers = (count: number): ActivePlayer[] => {
-    const demoAddresses = [
-      '0x838aD0EAE54F99F1926dA7C3b6bFbF617389B4D9',
-      '0x4bEf0221d6F7Dd0C969fe46a4e9b339a84F52FDF',
-      '0x1234567890abcdef1234567890abcdef12345678',
-      '0xabcdef1234567890abcdef1234567890abcdef12',
-      '0x9876543210fedcba9876543210fedcba98765432',
-      '0xfedcba0987654321fedcba0987654321fedcba09',
-      '0x1111111111111111111111111111111111111111',
-      '0x2222222222222222222222222222222222222222',
-      '0x3333333333333333333333333333333333333333',
-      '0x4444444444444444444444444444444444444444',
-      '0x5555555555555555555555555555555555555555',
-      '0x6666666666666666666666666666666666666666',
-      '0x7777777777777777777777777777777777777777',
-      '0x8888888888888888888888888888888888888888',
-      '0x9999999999999999999999999999999999999999',
-      '0xaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa'
-    ];
-
-    const demoUsernames = [
-      'VITALIK.BASE.ETH',
-      'PAULCRAMER.BASE.ETH',
-      'ALICE.BASE.ETH',
-      'BOB.BASE.ETH',
-      'CHARLIE.BASE.ETH',
-      'DAVE.BASE.ETH',
-      'EVE.BASE.ETH',
-      'FRANK.BASE.ETH',
-      'GRACE.BASE.ETH',
-      'HENRY.BASE.ETH',
-      'IRIS.BASE.ETH',
-      'JACK.BASE.ETH',
-      'KATE.BASE.ETH',
-      'LUCY.BASE.ETH',
-      'MIKE.BASE.ETH',
-      'NINA.BASE.ETH'
-    ];
-
-    return Array.from({ length: Math.min(count, demoAddresses.length) }, (_, i) => ({
-      address: demoAddresses[i]!,
-      username: demoUsernames[i]!,
-      avatarUrl: null,
-      totalScore: Math.floor(Math.random() * 1000) + 100,
-      gamesPlayed: Math.floor(Math.random() * 50) + 1,
-      isWalletUser: true,
-      lastActive: new Date(Date.now() - Math.random() * 24 * 60 * 60 * 1000).toISOString()
-    }));
-  };
-
   useEffect(() => {
     fetchActivePlayers();
-    
+
     if (autoRefresh) {
       const interval = setInterval(fetchActivePlayers, refreshInterval);
       return () => clearInterval(interval);
@@ -122,6 +66,6 @@ export const useActivePlayers = ({
     players,
     isLoading,
     error,
-    refetch: fetchActivePlayers
+    refetch: fetchActivePlayers,
   };
 };

--- a/hooks/useBasename.ts
+++ b/hooks/useBasename.ts
@@ -1,18 +1,22 @@
 'use client';
 
 import { useQuery } from '@tanstack/react-query';
-import { getBasename } from '@/lib/base-account/basename';
+import { getBasenameWithFallback } from '@/lib/base-account/basename';
 
-export const useBasename = (address?: `0x${string}` | string | null) => {
+export const useBasename = (
+  address?: `0x${string}` | string | null,
+  universalFallback?: `0x${string}` | string | null,
+) => {
   const normalizedAddress = address as `0x${string}` | undefined;
+  const normalizedFallback = universalFallback as `0x${string}` | undefined;
 
   return useQuery({
-    queryKey: ['basename', normalizedAddress],
+    queryKey: ['basename', normalizedAddress, normalizedFallback],
     queryFn: () => {
       if (!normalizedAddress) {
         return null;
       }
-      return getBasename(normalizedAddress);
+      return getBasenameWithFallback(normalizedAddress, normalizedFallback);
     },
     enabled: !!normalizedAddress,
     staleTime: 5 * 60 * 1000,

--- a/hooks/useLobbyPlayers.ts
+++ b/hooks/useLobbyPlayers.ts
@@ -9,12 +9,22 @@ import { formatWalletAddress } from '@/lib/identity/resolveBaseProfile';
 import { Timestamp } from 'spacetimedb';
 
 const timestampToIso = (ts: unknown): string => {
+  if (!ts) {
+    return new Date().toISOString();
+  }
+
+  let micros: bigint | undefined;
   if (ts instanceof Timestamp) {
-    return new Date(Number(ts.microsSinceUnixEpoch / BigInt(1000))).toISOString();
+    micros = ts.microsSinceUnixEpoch;
+  } else if (typeof ts === 'object' && ts !== null && 'microsSinceUnixEpoch' in ts) {
+    const raw = (ts as { microsSinceUnixEpoch: unknown }).microsSinceUnixEpoch;
+    micros = typeof raw === 'bigint' ? raw : BigInt(String(raw));
   }
-  if (typeof ts === 'object' && ts !== null && 'microsSinceUnixEpoch' in ts) {
-    return new Date(Number((ts as Timestamp).microsSinceUnixEpoch / BigInt(1000))).toISOString();
+
+  if (micros !== undefined) {
+    return new Date(Number(micros / BigInt(1000))).toISOString();
   }
+
   return new Date().toISOString();
 };
 

--- a/hooks/useLobbyPlayers.ts
+++ b/hooks/useLobbyPlayers.ts
@@ -1,0 +1,111 @@
+'use client';
+
+import { useMemo } from 'react';
+import { useSpacetime } from '@/components/providers/SpacetimeProvider';
+import type { Player } from '@/lib/spacetime/database';
+import type { PoolPlayer } from '@/lib/spacetime/types';
+import type { SocialIdentity } from '@/lib/spacetime/types';
+import { formatWalletAddress } from '@/lib/identity/resolveBaseProfile';
+import { Timestamp } from 'spacetimedb';
+
+const timestampToIso = (ts: unknown): string => {
+  if (ts instanceof Timestamp) {
+    return new Date(Number(ts.microsSinceUnixEpoch / BigInt(1000))).toISOString();
+  }
+  if (typeof ts === 'object' && ts !== null && 'microsSinceUnixEpoch' in ts) {
+    return new Date(Number((ts as Timestamp).microsSinceUnixEpoch / BigInt(1000))).toISOString();
+  }
+  return new Date().toISOString();
+};
+
+export type LobbyPlayer = {
+  playerId: string;
+  address: string;
+  username: string;
+  avatarUrl: string | null;
+  handle: string | null;
+  isWalletUser: boolean;
+  joinedAt: string;
+};
+
+type UseLobbyPlayersOptions = {
+  sessionId?: string | null;
+};
+
+const resolveDisplayName = (
+  wallet: string,
+  player?: Player,
+  social?: SocialIdentity,
+): { username: string; handle: string | null; avatarUrl: string | null } => {
+  if (social?.handle) {
+    return {
+      username: `@${social.handle}`,
+      handle: social.handle,
+      avatarUrl: social.avatarUrl ?? player?.avatarUrl ?? null,
+    };
+  }
+
+  if (player?.username) {
+    return {
+      username: player.username,
+      handle: player.username.startsWith('@') ? player.username.slice(1) : null,
+      avatarUrl: player.avatarUrl ?? null,
+    };
+  }
+
+  return {
+    username: formatWalletAddress(wallet),
+    handle: null,
+    avatarUrl: player?.avatarUrl ?? null,
+  };
+};
+
+export const useLobbyPlayers = ({ sessionId }: UseLobbyPlayersOptions = {}) => {
+  const { connection, isConnected } = useSpacetime();
+
+  const players = useMemo((): LobbyPlayer[] => {
+    if (!connection || !isConnected) {
+      return [];
+    }
+
+    const poolRows = Array.from(connection.db.pool_players.iter()) as PoolPlayer[];
+    const playerRows = Array.from(connection.db.players.iter()) as Player[];
+    const socialRows = Array.from(connection.db.social_identity.iter()) as SocialIdentity[];
+
+    const playersByWallet = new Map(
+      playerRows.map((p) => [p.walletAddress.toLowerCase(), p]),
+    );
+    const socialByWallet = new Map(
+      socialRows.map((s) => [s.walletAddress.toLowerCase(), s]),
+    );
+
+    const filteredPool = sessionId
+      ? poolRows.filter((row) => row.sessionId === sessionId)
+      : poolRows;
+
+    return filteredPool
+      .filter((row) => row.walletAddress)
+      .map((row) => {
+        const wallet = row.walletAddress!.toLowerCase();
+        const player = playersByWallet.get(wallet);
+        const social = socialByWallet.get(wallet);
+        const display = resolveDisplayName(wallet, player, social);
+
+        return {
+          playerId: row.playerId,
+          address: wallet,
+          username: display.username,
+          avatarUrl: display.avatarUrl,
+          handle: display.handle,
+          isWalletUser: true,
+          joinedAt: timestampToIso(row.joinedAt),
+        };
+      });
+  }, [connection, isConnected, sessionId]);
+
+  return {
+    players,
+    isLoading: !isConnected,
+    isLive: isConnected && players.length > 0,
+  };
+};

--- a/hooks/usePlayerIdentities.ts
+++ b/hooks/usePlayerIdentities.ts
@@ -1,0 +1,36 @@
+'use client';
+
+import { useQuery } from '@tanstack/react-query';
+import type { ResolvedPlayerIdentity } from '@/lib/identity/playerIdentity';
+
+const MAX_BATCH = 20;
+
+export const usePlayerIdentities = (walletAddresses: string[]) => {
+  const normalized = [
+    ...new Set(
+      walletAddresses
+        .map((w) => w.trim().toLowerCase())
+        .filter((w) => w.startsWith('0x')),
+    ),
+  ].slice(0, MAX_BATCH);
+
+  return useQuery<Record<string, ResolvedPlayerIdentity>>({
+    queryKey: ['player-identities-batch', normalized.join(',')],
+    queryFn: async () => {
+      if (normalized.length === 0) {
+        return {};
+      }
+      const params = new URLSearchParams({ wallets: normalized.join(',') });
+      const response = await fetch(`/api/player-identities?${params.toString()}`);
+      if (!response.ok) {
+        return {};
+      }
+      const json = (await response.json()) as {
+        identities?: Record<string, ResolvedPlayerIdentity>;
+      };
+      return json.identities ?? {};
+    },
+    enabled: normalized.length > 0,
+    staleTime: 5 * 60 * 1000,
+  });
+};

--- a/hooks/usePlayerIdentity.ts
+++ b/hooks/usePlayerIdentity.ts
@@ -1,0 +1,41 @@
+'use client';
+
+import { useQuery } from '@tanstack/react-query';
+import type { ResolvedPlayerIdentity } from '@/lib/identity/playerIdentity';
+
+export const usePlayerIdentity = (
+  walletAddress?: string | null,
+  cached?: { username?: string | null; avatarUrl?: string | null },
+) => {
+  const normalized = walletAddress?.trim().toLowerCase() ?? '';
+
+  return useQuery<ResolvedPlayerIdentity | null>({
+    queryKey: ['player-identity-full', normalized, cached?.username, cached?.avatarUrl],
+    queryFn: async () => {
+      if (!normalized.startsWith('0x')) {
+        return null;
+      }
+      const params = new URLSearchParams({ wallets: normalized });
+      const response = await fetch(`/api/player-identities?${params.toString()}`);
+      if (!response.ok) {
+        return null;
+      }
+      const json = (await response.json()) as {
+        identities?: Record<string, ResolvedPlayerIdentity>;
+      };
+      return json.identities?.[normalized] ?? null;
+    },
+    enabled: normalized.startsWith('0x'),
+    staleTime: 5 * 60 * 1000,
+    initialData: cached?.username
+      ? {
+          walletAddress: normalized,
+          displayName: cached.username,
+          avatarUrl: cached.avatarUrl ?? null,
+          handle: cached.username.startsWith('@') ? cached.username.slice(1) : null,
+          basename: null,
+          source: 'lens' as const,
+        }
+      : undefined,
+  });
+};

--- a/hooks/useSocialShare.ts
+++ b/hooks/useSocialShare.ts
@@ -95,7 +95,8 @@ export const useSocialShare = () => {
     }
     
     if (playerName) {
-      shareText = shareText.replace('Just played', `${playerName} just played`);
+      const handlePrefix = playerName.startsWith('@') ? playerName : `@${playerName}`;
+      shareText = shareText.replace('Just played', `${handlePrefix} just played`);
     }
     
     return share({
@@ -123,7 +124,7 @@ export const useSocialShare = () => {
     
     switch (activityType) {
       case 'joined-game':
-        shareText = `🎵 ${playerName} just joined BEAT ME! The music trivia battle is heating up! 🎶`;
+        shareText = `🎵 ${playerName.startsWith('@') ? playerName : `@${playerName}`} just joined BEAT ME! The music trivia battle is heating up! 🎶`;
         title = `${playerName} Joined BEAT ME!`;
         break;
       case 'left-game':

--- a/lib/apis/spacetime.ts
+++ b/lib/apis/spacetime.ts
@@ -27,7 +27,7 @@ import {
   type PrizePool,
   type Admin,
 } from '../spacetime/database';
-import type { PoolPlayer } from '../spacetime/types';
+import type { PoolPlayer, SocialIdentity } from '../spacetime/types';
 import { pickCurrentActiveGameSession } from './mapSpacetimeGameSession';
 
 // Re-export types for convenience
@@ -44,7 +44,7 @@ export type {
   PrizePool,
   Admin,
 };
-export type { PoolPlayer };
+export type { PoolPlayer, SocialIdentity };
 
 export interface TopEarner {
   walletAddress: string;
@@ -57,8 +57,14 @@ export interface TopEarner {
 
 // Configuration
 const SPACETIME_CONFIG = {
-  host: process.env.SPACETIME_HOST || 'https://maincloud.spacetimedb.com',
-  module: process.env.SPACETIME_MODULE || 'beat-me',
+  host:
+    process.env.SPACETIME_HOST ||
+    process.env.NEXT_PUBLIC_SPACETIME_HOST ||
+    'https://maincloud.spacetimedb.com',
+  module:
+    process.env.SPACETIME_MODULE ||
+    process.env.NEXT_PUBLIC_SPACETIME_MODULE ||
+    'beat-me',
 };
 
 export interface SpacetimeInitOptions {
@@ -200,8 +206,10 @@ class SpacetimeDBClient {
   }
 
   private async _doInitialize(): Promise<void> {
-    // Check if SpacetimeDB is configured
-    if (!process.env.SPACETIME_HOST || !process.env.SPACETIME_MODULE) {
+    // Check if SpacetimeDB is configured (server or public env)
+    const host = process.env.SPACETIME_HOST || process.env.NEXT_PUBLIC_SPACETIME_HOST;
+    const moduleName = process.env.SPACETIME_MODULE || process.env.NEXT_PUBLIC_SPACETIME_MODULE;
+    if (!host || !moduleName) {
       console.log('⚠️ SpacetimeDB not configured - using fallback mode');
       this.isConnected = false;
       return;
@@ -267,10 +275,11 @@ class SpacetimeDBClient {
             reject(error);
           });
 
-        // Anonymous connection - no token needed
-        // The SDK will generate and manage identity automatically
-
-        // Build connection (this initiates the WebSocket connection)
+        // Use server token when available (admin writes for Orb link)
+        const serverToken = process.env.SPACETIME_TOKEN;
+        if (serverToken && typeof window === 'undefined') {
+          builder.withToken(serverToken);
+        }
         builder.build();
       });
 
@@ -388,14 +397,22 @@ class SpacetimeDBClient {
   /**
    * Link current SpacetimeDB identity to wallet address for persistent stats
    */
-  async linkWalletToIdentity(walletAddress: string): Promise<void> {
+  async linkWalletToIdentity(
+    walletAddress: string,
+    universalWalletAddress?: string | null,
+  ): Promise<void> {
     if (!this.connection) {
       console.warn('⚠️ Not connected to SpacetimeDB');
       return;
     }
 
     try {
-      this.connection.reducers.linkWalletToIdentity({ walletAddress });
+      const universal = universalWalletAddress?.trim().toLowerCase();
+      this.connection.reducers.linkWalletToIdentity({
+        walletAddress: walletAddress.trim().toLowerCase(),
+        universalWalletAddress:
+          universal && universal.startsWith('0x') ? universal : undefined,
+      });
       console.log(`✅ Linked wallet ${walletAddress} to SpacetimeDB identity`);
     } catch (error) {
       console.error('❌ Failed to link wallet:', error);
@@ -413,8 +430,7 @@ class SpacetimeDBClient {
     }
 
     try {
-      // Link the Sub Account address (primary) to SpacetimeDB identity
-      this.connection.reducers.linkWalletToIdentity({ walletAddress: subAccountAddress });
+      await this.linkWalletToIdentity(subAccountAddress, universalAddress);
       
       // Store both addresses in localStorage for reference
       localStorage.setItem('base_account_addresses', JSON.stringify({
@@ -737,6 +753,81 @@ class SpacetimeDBClient {
       )
       .sort((a, b) => b.weeklyBestScore - a.weeklyBestScore)
       .slice(0, limit);
+  }
+
+  getPlayerByWallet(walletAddress: string): Player | undefined {
+    if (!this.connection) return undefined;
+    const wallet = walletAddress.trim().toLowerCase();
+    return (Array.from(this.connection.db.players.iter()) as Player[]).find(
+      (p) => p.walletAddress.toLowerCase() === wallet,
+    );
+  }
+
+  getSocialIdentityByWallet(walletAddress: string): SocialIdentity | undefined {
+    if (!this.connection) return undefined;
+    const wallet = walletAddress.trim().toLowerCase();
+    return (Array.from(this.connection.db.social_identity.iter()) as SocialIdentity[]).find(
+      (row) => row.walletAddress.toLowerCase() === wallet,
+    );
+  }
+
+  getUniversalWalletForSubAccount(walletAddress: string): string | null {
+    if (!this.connection) return null;
+    const wallet = walletAddress.trim().toLowerCase();
+    const mapping = (
+      Array.from(this.connection.db.identity_wallet_mapping.iter()) as Array<{
+        walletAddress: string;
+        universalWalletAddress?: string | null;
+      }>
+    ).find((row) => row.walletAddress.toLowerCase() === wallet);
+    const universal = mapping?.universalWalletAddress?.trim().toLowerCase();
+    return universal?.startsWith('0x') ? universal : null;
+  }
+
+  async setVerifiedSocialIdentity(input: {
+    walletAddress: string;
+    lensAccountId: string;
+    handle: string;
+    displayName?: string;
+    avatarUrl?: string;
+  }): Promise<void> {
+    if (!this.connection) {
+      throw new Error('Not connected to SpacetimeDB');
+    }
+
+    await this.connection.reducers.setVerifiedSocialIdentity({
+      walletAddress: input.walletAddress.trim().toLowerCase(),
+      lensAccountId: input.lensAccountId,
+      handle: input.handle.trim().replace(/^@/, ''),
+      displayName: input.displayName ?? undefined,
+      avatarUrl: input.avatarUrl ?? undefined,
+    });
+  }
+
+  getActiveConnections(limit: number = 20): Array<{
+    walletAddress: string | null;
+    lastActivity: Date;
+  }> {
+    if (!this.connection) return [];
+
+    return (Array.from(this.connection.db.active_connections.iter()) as Array<{
+      walletAddress?: string | null;
+      lastActivity: { toDate?: () => Date } | Date;
+    }>)
+      .map((row) => ({
+        walletAddress: row.walletAddress ?? null,
+        lastActivity:
+          row.lastActivity instanceof Date
+            ? row.lastActivity
+            : (row.lastActivity?.toDate?.() ?? new Date()),
+      }))
+      .sort((a, b) => b.lastActivity.getTime() - a.lastActivity.getTime())
+      .slice(0, limit);
+  }
+
+  getPoolPlayersForActiveSessions(): PoolPlayer[] {
+    if (!this.connection) return [];
+    return Array.from(this.connection.db.pool_players.iter()) as PoolPlayer[];
   }
 
   // ============================================================================

--- a/lib/base-account/auth.ts
+++ b/lib/base-account/auth.ts
@@ -13,7 +13,9 @@ export const generateNonce = (): string => {
   );
 };
 
-export const signInWithBase = async (): Promise<{
+export const signInWithBase = async (
+  signingAddress?: string,
+): Promise<{
   address: string;
   signature: string;
   message: string;
@@ -24,16 +26,25 @@ export const signInWithBase = async (): Promise<{
   const uri = window.location.origin;
   const chainId = base.id;
 
-  const accounts = (await provider.request({
-    method: 'eth_accounts',
-    params: [],
-  })) as string[];
+  let address = signingAddress?.trim().toLowerCase();
 
-  if (!accounts.length) {
-    throw new Error('No account connected');
+  if (!address) {
+    const accounts = (await provider.request({
+      method: 'eth_accounts',
+      params: [],
+    })) as string[];
+
+    if (!accounts.length) {
+      throw new Error('No account connected');
+    }
+
+    // Prefer sub-account (last account) when Base returns [universal, sub].
+    address =
+      accounts.length > 1
+        ? accounts[accounts.length - 1]!.toLowerCase()
+        : accounts[0]!.toLowerCase();
   }
 
-  const address = accounts[0];
   const message = `${domain} wants you to sign in with your Ethereum account:
 ${address}
 

--- a/lib/base-account/basename.ts
+++ b/lib/base-account/basename.ts
@@ -25,3 +25,21 @@ export const getBasename = async (
     return null;
   }
 };
+
+/** Basenames register on the universal Base Account; try sub-account then universal. */
+export const getBasenameWithFallback = async (
+  primaryAddress: `0x${string}`,
+  universalFallback?: `0x${string}` | string | null,
+): Promise<string | null> => {
+  const primaryName = await getBasename(primaryAddress);
+  if (primaryName) {
+    return primaryName;
+  }
+
+  const fallback = universalFallback?.trim().toLowerCase() as `0x${string}` | undefined;
+  if (!fallback || fallback === primaryAddress.toLowerCase()) {
+    return null;
+  }
+
+  return getBasename(fallback);
+};

--- a/lib/identity/playerIdentity.ts
+++ b/lib/identity/playerIdentity.ts
@@ -1,0 +1,136 @@
+import { resolveLensMediaUrl } from '@/lib/identity/resolveLensMedia';
+import {
+  formatWalletAddress,
+  resolveBaseProfile,
+  type BaseProfile,
+} from '@/lib/identity/resolveBaseProfile';
+
+export type PlayerIdentityCache = {
+  username?: string | null;
+  avatarUrl?: string | null;
+  handle?: string | null;
+  displayName?: string | null;
+  source?: 'spacetime' | 'lens' | 'base';
+  universalWalletAddress?: string | null;
+};
+
+export type ResolvedPlayerIdentity = {
+  walletAddress: string;
+  displayName: string;
+  avatarUrl: string | null;
+  handle: string | null;
+  basename: string | null;
+  source: 'lens' | 'base' | 'wallet';
+};
+
+export const normalizeWallet = (address: string): string =>
+  address.trim().toLowerCase();
+
+export const mergeCachedIdentity = (
+  walletAddress: string,
+  cache?: PlayerIdentityCache | null,
+): Partial<ResolvedPlayerIdentity> => {
+  if (!cache) {
+    return {};
+  }
+
+  const handle =
+    cache.handle ??
+    (cache.username?.startsWith('@') ? cache.username.slice(1) : null);
+
+  return {
+    displayName: cache.displayName ?? cache.username ?? undefined,
+    avatarUrl: cache.avatarUrl ?? null,
+    handle: handle ?? null,
+    source: cache.source === 'lens' ? 'lens' : cache.source === 'base' ? 'base' : undefined,
+  };
+};
+
+export const resolvePlayerIdentity = async (
+  walletAddress: string,
+  cache?: PlayerIdentityCache | null,
+): Promise<ResolvedPlayerIdentity> => {
+  const wallet = normalizeWallet(walletAddress);
+  const cached = mergeCachedIdentity(wallet, cache);
+
+  if (cached.displayName && cached.avatarUrl) {
+    return {
+      walletAddress: wallet,
+      displayName: cached.displayName,
+      avatarUrl: cached.avatarUrl,
+      handle: cached.handle ?? null,
+      basename: null,
+      source: cached.source ?? 'lens',
+    };
+  }
+
+  if (cached.displayName) {
+    return {
+      walletAddress: wallet,
+      displayName: cached.displayName,
+      avatarUrl: cached.avatarUrl ?? null,
+      handle: cached.handle ?? null,
+      basename: null,
+      source: cached.source ?? 'lens',
+    };
+  }
+
+  let baseProfile: BaseProfile = { basename: null, avatarUrl: null };
+  if (wallet.startsWith('0x')) {
+    const universal = cache?.universalWalletAddress ?? null;
+    baseProfile = await resolveBaseProfile(
+      wallet as `0x${string}`,
+      universal as `0x${string}` | null,
+    );
+  }
+
+  const displayName =
+    baseProfile.basename ?? formatWalletAddress(wallet);
+
+  return {
+    walletAddress: wallet,
+    displayName,
+    avatarUrl: cached.avatarUrl ?? baseProfile.avatarUrl,
+    handle: cached.handle ?? null,
+    basename: baseProfile.basename,
+    source: baseProfile.basename ? 'base' : 'wallet',
+  };
+};
+
+export const resolveAvatarFromCacheOrBase = (
+  walletAddress: string,
+  cache?: PlayerIdentityCache | null,
+  baseProfile?: BaseProfile | null,
+): string | null => {
+  const resolvedCache = cache?.avatarUrl;
+  if (resolvedCache) {
+    return resolveLensMediaUrl(resolvedCache) ?? resolvedCache;
+  }
+  return baseProfile?.avatarUrl ?? null;
+};
+
+export const getInitials = (displayName: string): string => {
+  const cleaned = displayName.replace(/^@/, '').trim();
+  if (!cleaned) {
+    return '?';
+  }
+  const parts = cleaned.split(/[.\s_-]+/).filter(Boolean);
+  if (parts.length >= 2) {
+    return `${parts[0]![0] ?? ''}${parts[1]![0] ?? ''}`.toUpperCase();
+  }
+  return cleaned.slice(0, 2).toUpperCase();
+};
+
+export const gradientClassForWallet = (walletAddress: string): string => {
+  const hash = walletAddress
+    .split('')
+    .reduce((acc, char) => acc + char.charCodeAt(0), 0);
+  const gradients = [
+    'from-purple-400 to-pink-400',
+    'from-blue-400 to-cyan-400',
+    'from-green-400 to-emerald-400',
+    'from-orange-400 to-red-400',
+    'from-indigo-400 to-violet-400',
+  ];
+  return gradients[hash % gradients.length]!;
+};

--- a/lib/identity/resolveBaseProfile.ts
+++ b/lib/identity/resolveBaseProfile.ts
@@ -1,0 +1,51 @@
+import { createPublicClient, http } from 'viem';
+import { normalize } from 'viem/ens';
+import { mainnet } from 'viem/chains';
+import { getBasename, getBasenameWithFallback } from '@/lib/base-account/basename';
+
+const getMainnetClient = () => {
+  const apiKey = process.env.NEXT_PUBLIC_ALCHEMY_API_KEY;
+  const rpcUrl = apiKey
+    ? `https://eth-mainnet.g.alchemy.com/v2/${apiKey}`
+    : process.env.MAINNET_RPC_URL ?? 'https://eth.llamarpc.com';
+
+  return createPublicClient({
+    chain: mainnet,
+    transport: http(rpcUrl),
+  });
+};
+
+export type BaseProfile = {
+  basename: string | null;
+  avatarUrl: string | null;
+};
+
+export const resolveBaseProfile = async (
+  address: `0x${string}`,
+  universalFallback?: `0x${string}` | string | null,
+): Promise<BaseProfile> => {
+  const basename = await getBasenameWithFallback(address, universalFallback);
+  if (!basename) {
+    return { basename: null, avatarUrl: null };
+  }
+
+  try {
+    const client = getMainnetClient();
+    const avatarUrl = await client.getEnsAvatar({
+      name: normalize(basename),
+    });
+    return {
+      basename,
+      avatarUrl: avatarUrl ?? null,
+    };
+  } catch {
+    return { basename, avatarUrl: null };
+  }
+};
+
+export const formatWalletAddress = (address: string): string => {
+  if (address.length < 10) {
+    return address;
+  }
+  return `${address.slice(0, 6)}...${address.slice(-4)}`;
+};

--- a/lib/identity/resolveLensMedia.ts
+++ b/lib/identity/resolveLensMedia.ts
@@ -1,0 +1,23 @@
+import { parseUrl } from '@orbclub/modules/media';
+
+const DEFAULT_LENS_GATEWAY = 'https://gw.lens.xyz';
+
+export const resolveLensMediaUrl = (
+  uri: string | null | undefined,
+): string | null => {
+  if (!uri?.trim()) {
+    return null;
+  }
+
+  const trimmed = uri.trim();
+  if (trimmed.startsWith('http://') || trimmed.startsWith('https://')) {
+    return trimmed;
+  }
+
+  return (
+    parseUrl(trimmed, {
+      lensGateway: DEFAULT_LENS_GATEWAY,
+      ipfsGateway: 'https://ipfs.io/ipfs/',
+    }) ?? null
+  );
+};

--- a/lib/orb/client.ts
+++ b/lib/orb/client.ts
@@ -1,0 +1,34 @@
+'use client';
+
+import { createOrbLogin } from '@orbclub/modules/auth';
+import type { OrbLoginConfig } from '@orbclub/modules/auth';
+import type { OrbSession } from './types';
+
+let orbLoginSingleton: ReturnType<typeof createOrbLogin> | null = null;
+
+export const getOrbLogin = (config?: OrbLoginConfig) => {
+  if (!orbLoginSingleton) {
+    orbLoginSingleton = createOrbLogin(config);
+  }
+  return orbLoginSingleton;
+};
+
+export const sessionFromQrResult = (result: {
+  accessToken: string;
+  refreshToken?: string;
+  idToken?: string;
+  authenticationId?: string;
+}): OrbSession => ({
+  accessToken: result.accessToken,
+  refreshToken: result.refreshToken,
+  idToken: result.idToken,
+  authenticationId: result.authenticationId,
+});
+
+export const enrichSessionWithAccount = (
+  session: OrbSession,
+  orb = getOrbLogin(),
+): OrbSession => {
+  const account = orb.getAccountFromAccessToken(session.accessToken) ?? undefined;
+  return { ...session, account };
+};

--- a/lib/orb/index.ts
+++ b/lib/orb/index.ts
@@ -1,0 +1,3 @@
+export * from './types';
+export * from './client';
+export { verifyOrbAccessToken, fetchLensProfileFromAccessToken, refreshOrbAccessToken } from './lensProfile.server';

--- a/lib/orb/lensProfile.server.ts
+++ b/lib/orb/lensProfile.server.ts
@@ -1,0 +1,130 @@
+import { createOrbLogin } from '@orbclub/modules/auth';
+import { getLensAccountFromAccessToken } from '@orbclub/modules/auth/lens';
+import { resolveLensMediaUrl } from '@/lib/identity/resolveLensMedia';
+import type { LensProfile } from '@/lib/orb/types';
+
+const DEFAULT_LENS_GRAPHQL_URL =
+  process.env.LENS_GRAPHQL_URL ?? 'https://api.lens.xyz/graphql';
+
+type LensGraphQlAccount = {
+  address?: string;
+  username?: { localName?: string | null } | null;
+  metadata?: {
+    displayName?: string | null;
+    picture?: string | null;
+  } | null;
+};
+
+type LensMeResponse = {
+  data?: {
+    me?: {
+      loggedInAs?: {
+        __typename?: string;
+        account?: LensGraphQlAccount | null;
+      } | null;
+    } | null;
+  } | null;
+  errors?: Array<{ message?: string }>;
+};
+
+const ME_QUERY = `
+  query Me {
+    me {
+      loggedInAs {
+        ... on AccountManaged {
+          account {
+            address
+            username {
+              localName
+            }
+            metadata {
+              displayName
+              picture
+            }
+          }
+        }
+        ... on AccountOwner {
+          account {
+            address
+            username {
+              localName
+            }
+            metadata {
+              displayName
+              picture
+            }
+          }
+        }
+      }
+    }
+  }
+`;
+
+export const fetchLensProfileFromAccessToken = async (
+  accessToken: string,
+): Promise<LensProfile | null> => {
+  const lensAccountId = getLensAccountFromAccessToken(accessToken);
+  if (!lensAccountId) {
+    return null;
+  }
+
+  const response = await fetch(DEFAULT_LENS_GRAPHQL_URL, {
+    method: 'POST',
+    headers: {
+      'Content-Type': 'application/json',
+      Authorization: `Bearer ${accessToken}`,
+    },
+    body: JSON.stringify({ query: ME_QUERY }),
+  });
+
+  if (!response.ok) {
+    throw new Error(`Lens GraphQL failed (${response.status})`);
+  }
+
+  const payload = (await response.json()) as LensMeResponse;
+  if (payload.errors?.length) {
+    throw new Error(payload.errors[0]?.message ?? 'Lens GraphQL error');
+  }
+
+  const account = payload.data?.me?.loggedInAs?.account;
+  const handle = account?.username?.localName?.trim();
+  if (!handle) {
+    return {
+      lensAccountId,
+      handle: lensAccountId.slice(0, 8),
+      displayName: account?.metadata?.displayName ?? undefined,
+      avatarUri: account?.metadata?.picture ?? undefined,
+      avatarUrl: resolveLensMediaUrl(account?.metadata?.picture) ?? undefined,
+    };
+  }
+
+  const avatarUri = account?.metadata?.picture ?? undefined;
+  return {
+    lensAccountId: account?.address ?? lensAccountId,
+    handle,
+    displayName: account?.metadata?.displayName ?? undefined,
+    avatarUri,
+    avatarUrl: resolveLensMediaUrl(avatarUri) ?? undefined,
+  };
+};
+
+export const verifyOrbAccessToken = async (
+  accessToken: string,
+): Promise<LensProfile> => {
+  const profile = await fetchLensProfileFromAccessToken(accessToken);
+  if (!profile) {
+    throw new Error('Invalid or expired Orb/Lens session');
+  }
+  return profile;
+};
+
+export const refreshOrbAccessToken = async (
+  refreshToken: string,
+): Promise<string> => {
+  const orb = createOrbLogin();
+  const refreshed = await orb.refresh({ refreshToken });
+  if (!refreshed.accessToken) {
+    throw new Error('Failed to refresh Lens session');
+  }
+  return refreshed.accessToken;
+};

--- a/lib/orb/types.ts
+++ b/lib/orb/types.ts
@@ -1,0 +1,17 @@
+export type OrbSession = {
+  accessToken: string;
+  refreshToken?: string;
+  idToken?: string;
+  authenticationId?: string;
+  account?: string;
+};
+
+export type LensProfile = {
+  lensAccountId: string;
+  handle: string;
+  displayName?: string;
+  avatarUri?: string;
+  avatarUrl?: string;
+};
+
+export const ORB_SESSION_STORAGE_KEY = 'beatme_orb_session';

--- a/lib/spacetime/appSubscriptionQueries.ts
+++ b/lib/spacetime/appSubscriptionQueries.ts
@@ -33,6 +33,7 @@ export const buildAppSubscriptionQueries = (t: AppSubscriptionTables) => [
     row.lastActivity.gte(Timestamp.UNIX_EPOCH)
   ),
   t.identity_wallet_mapping,
+  t.social_identity,
 ];
 
 /** Minimal subscriptions for serverless `/api/game-session` — avoids long initial sync (504 on Vercel). */

--- a/lib/spacetime/index.ts
+++ b/lib/spacetime/index.ts
@@ -57,6 +57,7 @@ import RecordPaidGameScoreReducer from "./record_paid_game_score_reducer";
 import RecordPrizeDistributionReducer from "./record_prize_distribution_reducer";
 import RecordQuestionAttemptReducer from "./record_question_attempt_reducer";
 import RevokeAdminPrivilegesReducer from "./revoke_admin_privileges_reducer";
+import SetVerifiedSocialIdentityReducer from "./set_verified_social_identity_reducer";
 import StartGameSessionReducer from "./start_game_session_reducer";
 import SyncMultiplayerLobbyEndsAfterSecsReducer from "./sync_multiplayer_lobby_ends_after_secs_reducer";
 import UpdateAnonymousSessionReducer from "./update_anonymous_session_reducer";
@@ -85,6 +86,7 @@ import PoolPlayersRow from "./pool_players_table";
 import PrizeHistoryRow from "./prize_history_table";
 import PrizePoolsRow from "./prize_pools_table";
 import QuestionAttemptsRow from "./question_attempts_table";
+import SocialIdentityRow from "./social_identity_table";
 
 /** Type-only namespace exports for generated type groups. */
 
@@ -289,6 +291,21 @@ const tablesSchema = __schema({
       { name: 'pool_players_player_id_key', constraint: 'unique', columns: ['playerId'] },
     ],
   }, PoolPlayersRow),
+  social_identity: __table({
+    name: 'social_identity',
+    indexes: [
+      { accessor: 'handle', name: 'social_identity_handle_idx_btree', algorithm: 'btree', columns: [
+        'handle',
+      ] },
+      { accessor: 'wallet_address', name: 'social_identity_wallet_address_idx_btree', algorithm: 'btree', columns: [
+        'walletAddress',
+      ] },
+    ],
+    constraints: [
+      { name: 'social_identity_handle_key', constraint: 'unique', columns: ['handle'] },
+      { name: 'social_identity_wallet_address_key', constraint: 'unique', columns: ['walletAddress'] },
+    ],
+  }, SocialIdentityRow),
   prize_history: __table({
     name: 'prize_history',
     indexes: [
@@ -349,6 +366,7 @@ const reducersSchema = __reducers(
   __reducerSchema("record_prize_distribution", RecordPrizeDistributionReducer),
   __reducerSchema("record_question_attempt", RecordQuestionAttemptReducer),
   __reducerSchema("revoke_admin_privileges", RevokeAdminPrivilegesReducer),
+  __reducerSchema("set_verified_social_identity", SetVerifiedSocialIdentityReducer),
   __reducerSchema("start_game_session", StartGameSessionReducer),
   __reducerSchema("sync_multiplayer_lobby_ends_after_secs", SyncMultiplayerLobbyEndsAfterSecsReducer),
   __reducerSchema("update_anonymous_session", UpdateAnonymousSessionReducer),

--- a/lib/spacetime/set_verified_social_identity_reducer.ts
+++ b/lib/spacetime/set_verified_social_identity_reducer.ts
@@ -12,5 +12,8 @@ import {
 
 export default {
   walletAddress: __t.string(),
-  universalWalletAddress: __t.option(__t.string()),
+  lensAccountId: __t.string(),
+  handle: __t.string(),
+  displayName: __t.option(__t.string()),
+  avatarUrl: __t.option(__t.string()),
 };

--- a/lib/spacetime/social_identity_table.ts
+++ b/lib/spacetime/social_identity_table.ts
@@ -11,9 +11,11 @@ import {
 } from "spacetimedb";
 
 export default __t.row({
-  spacetimeIdentity: __t.identity().primaryKey().name("spacetime_identity"),
-  walletAddress: __t.string().name("wallet_address"),
-  universalWalletAddress: __t.option(__t.string()).name("universal_wallet_address"),
+  walletAddress: __t.string().primaryKey().name("wallet_address"),
+  lensAccountId: __t.string().name("lens_account_id"),
+  handle: __t.string(),
+  displayName: __t.option(__t.string()).name("display_name"),
+  avatarUrl: __t.option(__t.string()).name("avatar_url"),
   linkedAt: __t.timestamp().name("linked_at"),
-  lastSeen: __t.timestamp().name("last_seen"),
+  verifiedAt: __t.timestamp().name("verified_at"),
 });

--- a/lib/spacetime/types.ts
+++ b/lib/spacetime/types.ts
@@ -154,6 +154,7 @@ export type GuestPlayer = __Infer<typeof GuestPlayer>;
 export const IdentityWalletMapping = __t.object("IdentityWalletMapping", {
   spacetimeIdentity: __t.identity(),
   walletAddress: __t.string(),
+  universalWalletAddress: __t.option(__t.string()),
   linkedAt: __t.timestamp(),
   lastSeen: __t.timestamp(),
 });
@@ -223,6 +224,17 @@ export const PoolPlayer = __t.object("PoolPlayer", {
   joinedAt: __t.timestamp(),
 });
 export type PoolPlayer = __Infer<typeof PoolPlayer>;
+
+export const SocialIdentity = __t.object("SocialIdentity", {
+  walletAddress: __t.string(),
+  lensAccountId: __t.string(),
+  handle: __t.string(),
+  displayName: __t.option(__t.string()),
+  avatarUrl: __t.option(__t.string()),
+  linkedAt: __t.timestamp(),
+  verifiedAt: __t.timestamp(),
+});
+export type SocialIdentity = __Infer<typeof SocialIdentity>;
 
 export const PrizeHistory = __t.object("PrizeHistory", {
   id: __t.u64(),

--- a/lib/spacetime/types/reducers.ts
+++ b/lib/spacetime/types/reducers.ts
@@ -31,6 +31,7 @@ import RecordPaidGameScoreReducer from "../record_paid_game_score_reducer";
 import RecordPrizeDistributionReducer from "../record_prize_distribution_reducer";
 import RecordQuestionAttemptReducer from "../record_question_attempt_reducer";
 import RevokeAdminPrivilegesReducer from "../revoke_admin_privileges_reducer";
+import SetVerifiedSocialIdentityReducer from "../set_verified_social_identity_reducer";
 import StartGameSessionReducer from "../start_game_session_reducer";
 import SyncMultiplayerLobbyEndsAfterSecsReducer from "../sync_multiplayer_lobby_ends_after_secs_reducer";
 import UpdateAnonymousSessionReducer from "../update_anonymous_session_reducer";
@@ -64,6 +65,7 @@ export type RecordPaidGameScoreParams = __Infer<typeof RecordPaidGameScoreReduce
 export type RecordPrizeDistributionParams = __Infer<typeof RecordPrizeDistributionReducer>;
 export type RecordQuestionAttemptParams = __Infer<typeof RecordQuestionAttemptReducer>;
 export type RevokeAdminPrivilegesParams = __Infer<typeof RevokeAdminPrivilegesReducer>;
+export type SetVerifiedSocialIdentityParams = __Infer<typeof SetVerifiedSocialIdentityReducer>;
 export type StartGameSessionParams = __Infer<typeof StartGameSessionReducer>;
 export type SyncMultiplayerLobbyEndsAfterSecsParams = __Infer<typeof SyncMultiplayerLobbyEndsAfterSecsReducer>;
 export type UpdateAnonymousSessionParams = __Infer<typeof UpdateAnonymousSessionReducer>;

--- a/package-lock.json
+++ b/package-lock.json
@@ -15,6 +15,7 @@
         "@farcaster/miniapp-sdk": "^0.2.0",
         "@lighthouse-web3/sdk": "^0.4.1",
         "@neoconfetti/react": "^1.0.0",
+        "@orbclub/modules": "^0.1.1",
         "@radix-ui/react-accordion": "^1.2.12",
         "@radix-ui/react-alert-dialog": "^1.1.15",
         "@radix-ui/react-aspect-ratio": "^1.1.7",
@@ -5942,6 +5943,12 @@
       "resolved": "https://registry.npmjs.org/@openzeppelin/contracts-upgradeable/-/contracts-upgradeable-4.9.6.tgz",
       "integrity": "sha512-m4iHazOsOCv1DgM7eD7GupTJ+NFVujRZt1wzddDPSVGpWdKq1SKkla5htKG7+IS4d2XOCtzkUNwRZ7Vq5aEUMA==",
       "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@orbclub/modules": {
+      "version": "0.1.1",
+      "resolved": "https://registry.npmjs.org/@orbclub/modules/-/modules-0.1.1.tgz",
+      "integrity": "sha512-yNIkEHzCtNxoOIY/1WQ+LJxNhcUWexAOOcGJDbujIgIdM/9fukeTg286lb8EPDdD2luiR15+plbxi2lyriXuWA==",
       "license": "MIT"
     },
     "node_modules/@paulmillr/qr": {

--- a/package.json
+++ b/package.json
@@ -45,6 +45,7 @@
     "@farcaster/miniapp-sdk": "^0.2.0",
     "@lighthouse-web3/sdk": "^0.4.1",
     "@neoconfetti/react": "^1.0.0",
+    "@orbclub/modules": "^0.1.1",
     "@radix-ui/react-accordion": "^1.2.12",
     "@radix-ui/react-alert-dialog": "^1.1.15",
     "@radix-ui/react-aspect-ratio": "^1.1.7",

--- a/spacetime-module/beat-me/src/lib.rs
+++ b/spacetime-module/beat-me/src/lib.rs
@@ -236,9 +236,33 @@ pub struct IdentityWalletMapping {
     
     #[unique]
     pub wallet_address: String,
+
+    /// Base Account universal smart wallet (basename owner); sub-account is `wallet_address`.
+    pub universal_wallet_address: Option<String>,
     
     pub linked_at: Timestamp,
     pub last_seen: Timestamp,
+}
+
+/// Server-verified Orb/Lens social profile linked to a Base wallet.
+#[spacetimedb::table(accessor = social_identity, public)]
+#[derive(Clone)]
+pub struct SocialIdentity {
+    #[primary_key]
+    pub wallet_address: String,
+
+    pub lens_account_id: String,
+
+    #[unique]
+    pub handle: String,
+
+    pub display_name: Option<String>,
+
+    pub avatar_url: Option<String>,
+
+    pub linked_at: Timestamp,
+
+    pub verified_at: Timestamp,
 }
 
 // Game entries for tracking paid/trial status
@@ -1168,9 +1192,18 @@ pub fn create_player(ctx: &ReducerContext, wallet_address: String, username: Opt
 pub fn link_wallet_to_identity(
     ctx: &ReducerContext,
     wallet_address: String,
+    universal_wallet_address: Option<String>,
 ) {
     let identity = ctx.sender();
-    log::info!("🔗 Linking wallet {} to identity {:?}", wallet_address, identity);
+    let universal = universal_wallet_address
+        .map(|a| a.trim().to_lowercase())
+        .filter(|a| !a.is_empty() && a.starts_with("0x"));
+    log::info!(
+        "🔗 Linking wallet {} (universal {:?}) to identity {:?}",
+        wallet_address,
+        universal,
+        identity
+    );
     
     // Check if this identity is already linked
     if let Some(existing_mapping) = ctx.db.identity_wallet_mapping().spacetime_identity().find(&identity) {
@@ -1178,9 +1211,12 @@ pub fn link_wallet_to_identity(
             log::warn!("⚠️ Identity {:?} already linked to {}", identity, existing_mapping.wallet_address);
             return;
         }
-        // Same wallet, just update last_seen
+        // Same wallet, update last_seen and universal if provided
         let mut mapping = existing_mapping;
         mapping.last_seen = ctx.timestamp;
+        if universal.is_some() {
+            mapping.universal_wallet_address = universal.clone();
+        }
         ctx.db.identity_wallet_mapping().spacetime_identity().update(mapping);
         log::info!("✅ Updated existing link for {}", wallet_address);
         return;
@@ -1197,6 +1233,7 @@ pub fn link_wallet_to_identity(
     ctx.db.identity_wallet_mapping().insert(IdentityWalletMapping {
         spacetime_identity: identity,
         wallet_address: wallet_address.clone(),
+        universal_wallet_address: universal,
         linked_at: ctx.timestamp,
         last_seen: ctx.timestamp,
     });
@@ -1236,6 +1273,104 @@ pub fn link_wallet_to_identity(
     }
     
     log::info!("✅ Successfully linked wallet {} to identity {:?}", wallet_address, identity);
+}
+
+/// Server-only: persist verified Orb/Lens profile for a wallet (admin reducer).
+#[spacetimedb::reducer]
+pub fn set_verified_social_identity(
+    ctx: &ReducerContext,
+    wallet_address: String,
+    lens_account_id: String,
+    handle: String,
+    display_name: Option<String>,
+    avatar_url: Option<String>,
+) -> Result<(), String> {
+    if !is_admin(ctx, &AdminLevel::Admin) {
+        return Err("Only admins may set verified social identity".into());
+    }
+
+    let wallet = wallet_address.trim().to_lowercase();
+    if wallet.is_empty() || !wallet.starts_with("0x") {
+        return Err("Invalid wallet address".into());
+    }
+
+    let handle_trimmed = handle.trim().trim_start_matches('@');
+    if handle_trimmed.is_empty() {
+        return Err("Handle cannot be empty".into());
+    }
+    let handle_owned = handle_trimmed.to_string();
+
+    let display = display_name
+        .map(|d| d.trim().to_string())
+        .filter(|d| !d.is_empty());
+
+    let avatar = avatar_url
+        .map(|u| u.trim().to_string())
+        .filter(|u| !u.is_empty());
+
+    let now = ctx.timestamp;
+
+    if let Some(existing) = ctx.db.social_identity().wallet_address().find(&wallet) {
+        if existing.handle != handle_owned {
+            if ctx.db.social_identity().handle().find(&handle_owned).is_some() {
+                return Err(format!("Handle '@{}' is already linked to another wallet", handle_owned));
+            }
+            ctx.db.social_identity().handle().delete(&existing.handle);
+        }
+        let updated = SocialIdentity {
+            wallet_address: wallet.clone(),
+            lens_account_id: lens_account_id.clone(),
+            handle: handle_owned.clone(),
+            display_name: display.clone(),
+            avatar_url: avatar.clone(),
+            linked_at: existing.linked_at,
+            verified_at: now,
+        };
+        ctx.db.social_identity().wallet_address().update(updated);
+    } else {
+        if ctx.db.social_identity().handle().find(&handle_owned).is_some() {
+            return Err(format!("Handle '@{}' is already taken", handle_owned));
+        }
+        ctx.db.social_identity().insert(SocialIdentity {
+            wallet_address: wallet.clone(),
+            lens_account_id,
+            handle: handle_owned.clone(),
+            display_name: display.clone(),
+            avatar_url: avatar.clone(),
+            linked_at: now,
+            verified_at: now,
+        });
+    }
+
+    let username_for_player = Some(format!("@{}", handle_owned));
+    if let Some(mut player) = ctx.db.players().wallet_address().find(&wallet) {
+        apply_username_if_available(ctx, &wallet, &mut player, username_for_player.clone());
+        if avatar.is_some() {
+            player.avatar_url = avatar.clone();
+        }
+        player.updated_at = now;
+        ctx.db.players().wallet_address().update(player);
+    } else {
+        ctx.db.players().insert(Player {
+            wallet_address: wallet.clone(),
+            username: username_for_player,
+            avatar_url: avatar.clone(),
+            total_score: 0,
+            games_played: 0,
+            best_score: 0,
+            total_earnings: 0.0,
+            trial_games_remaining: 0,
+            trial_completed: true,
+            wallet_connected: true,
+            weekly_session_id: 0,
+            weekly_best_score: 0,
+            created_at: now,
+            updated_at: now,
+        });
+    }
+
+    log::info!("✅ Verified social identity for {} (@{})", wallet, handle_owned);
+    Ok(())
 }
 
 /// Assign username only when the value is free or already owned by this wallet.

--- a/spacetime-module/beat-me/src/lib.rs
+++ b/spacetime-module/beat-me/src/lib.rs
@@ -1315,7 +1315,6 @@ pub fn set_verified_social_identity(
             if ctx.db.social_identity().handle().find(&handle_owned).is_some() {
                 return Err(format!("Handle '@{}' is already linked to another wallet", handle_owned));
             }
-            ctx.db.social_identity().handle().delete(&existing.handle);
         }
         let updated = SocialIdentity {
             wallet_address: wallet.clone(),


### PR DESCRIPTION
## Summary
- Adds optional Orb/Lens social identity linking (server-verified via wallet signature + Lens token) with SpacetimeDB `social_identity` storage and batch player identity resolution APIs.
- Replaces static demo active-player data with live Spacetime presence and wires `PlayerAvatar` across game, leaderboard, and social surfaces.
- Fixes Base Account subaccount behavior: Orb SIWE signs with the sub-account address, and basename/avatar resolution falls back to the universal wallet via `identity_wallet_mapping.universal_wallet_address`.

## Test plan
- [ ] Publish Spacetime module: `spacetime publish beat-me --module-path spacetime-module/beat-me -s maincloud`
- [ ] Connect Base Account (subaccount), confirm wallet linking stores universal address
- [ ] Link Orb profile and verify `/api/auth/orb/link` succeeds (no signature mismatch)
- [ ] Confirm basename/avatar shows for subaccount users whose basename is on universal address
- [ ] Verify active players, leaderboard, and share surfaces show resolved identities
- [ ] Confirm `npm run build` passes


Made with [Cursor](https://cursor.com)