### PR TITLE
Fix Orb QR init on production via same-origin proxy

### DIFF
--- a/app/api/auth/orb/qr/init/route.ts
+++ b/app/api/auth/orb/qr/init/route.ts
@@ -1,0 +1,47 @@
+import { NextResponse } from 'next/server';
+import {
+  ORB_QR_CREDENTIALS,
+  ORB_QR_INIT_URL,
+  getOrbResponseMessage,
+  getOrbResponseStatus,
+  orbQrFetch,
+} from '@/lib/orb/qrProxy.server';
+
+export const runtime = 'nodejs';
+
+export async function GET() {
+  try {
+    const url = new URL(ORB_QR_INIT_URL);
+    url.searchParams.set('credentials', ORB_QR_CREDENTIALS);
+
+    const response = await orbQrFetch(url.toString(), { method: 'GET' });
+
+    if (!response.ok) {
+      return NextResponse.json(
+        { error: `Orb QR init failed (${response.status})` },
+        { status: 502 },
+      );
+    }
+
+    const payload: unknown = await response.json();
+    const status = getOrbResponseStatus(payload);
+
+    if (status === 'FAILED') {
+      return NextResponse.json(
+        {
+          error: getOrbResponseMessage(payload) ?? 'Orb QR init failed',
+          status,
+        },
+        { status: 502 },
+      );
+    }
+
+    return NextResponse.json(payload);
+  } catch (error) {
+    console.error('Orb QR init proxy error:', error);
+    return NextResponse.json(
+      { error: 'Orb QR init proxy failed' },
+      { status: 502 },
+    );
+  }
+}

--- a/app/api/auth/orb/qr/poll/route.ts
+++ b/app/api/auth/orb/qr/poll/route.ts
@@ -13,14 +13,20 @@ type PollBody = {
 };
 
 export async function POST(request: NextRequest) {
+  let secret: string | undefined;
+
   try {
     const body = (await request.json()) as PollBody;
-    const secret = body.secret?.trim();
+    secret = body.secret?.trim();
+  } catch {
+    return NextResponse.json({ error: 'Invalid JSON body' }, { status: 400 });
+  }
 
-    if (!secret) {
-      return NextResponse.json({ error: 'Missing secret' }, { status: 400 });
-    }
+  if (!secret) {
+    return NextResponse.json({ error: 'Missing secret' }, { status: 400 });
+  }
 
+  try {
     const response = await orbQrFetch(ORB_QR_POLL_URL, {
       method: 'POST',
       headers: {

--- a/app/api/auth/orb/qr/poll/route.ts
+++ b/app/api/auth/orb/qr/poll/route.ts
@@ -1,0 +1,60 @@
+import { NextRequest, NextResponse } from 'next/server';
+import {
+  ORB_QR_POLL_URL,
+  getOrbResponseMessage,
+  getOrbResponseStatus,
+  orbQrFetch,
+} from '@/lib/orb/qrProxy.server';
+
+export const runtime = 'nodejs';
+
+type PollBody = {
+  secret?: string;
+};
+
+export async function POST(request: NextRequest) {
+  try {
+    const body = (await request.json()) as PollBody;
+    const secret = body.secret?.trim();
+
+    if (!secret) {
+      return NextResponse.json({ error: 'Missing secret' }, { status: 400 });
+    }
+
+    const response = await orbQrFetch(ORB_QR_POLL_URL, {
+      method: 'POST',
+      headers: {
+        'Content-Type': 'application/json',
+      },
+      body: JSON.stringify({ secret }),
+    });
+
+    if (!response.ok) {
+      return NextResponse.json(
+        { error: `Orb QR poll failed (${response.status})` },
+        { status: 502 },
+      );
+    }
+
+    const payload: unknown = await response.json();
+    const status = getOrbResponseStatus(payload);
+
+    if (status === 'FAILED') {
+      return NextResponse.json(
+        {
+          error: getOrbResponseMessage(payload) ?? 'Orb QR poll failed',
+          status,
+        },
+        { status: 502 },
+      );
+    }
+
+    return NextResponse.json(payload);
+  } catch (error) {
+    console.error('Orb QR poll proxy error:', error);
+    return NextResponse.json(
+      { error: 'Orb QR poll proxy failed' },
+      { status: 502 },
+    );
+  }
+}

--- a/components/auth/OrbConnectButton.tsx
+++ b/components/auth/OrbConnectButton.tsx
@@ -50,6 +50,10 @@ export default function OrbConnectButton({
   };
 
   const handleConnect = async () => {
+    clearError();
+    setQrCode(null);
+    setDeepLink(null);
+
     try {
       await connectWithQr(({ qrCode: code, deepLink: link }) => {
         setQrCode(code);
@@ -169,9 +173,28 @@ export default function OrbConnectButton({
             )}
 
             {error && (
-              <p className="text-sm text-red-400 text-center" role="alert">
-                {error}
-              </p>
+              <div className="flex flex-col items-center gap-3 w-full">
+                <p className="text-sm text-red-400 text-center" role="alert">
+                  {error}
+                </p>
+                <Button
+                  type="button"
+                  variant="outline"
+                  onClick={handleConnect}
+                  disabled={isConnecting}
+                  className="w-full border-purple-500/50 text-purple-200 hover:bg-purple-500/10"
+                  aria-label="Retry Orb sign-in"
+                >
+                  {isConnecting ? (
+                    <>
+                      <Loader2 className="w-4 h-4 animate-spin mr-2" />
+                      Retrying…
+                    </>
+                  ) : (
+                    'Retry'
+                  )}
+                </Button>
+              </div>
             )}
           </div>
         </DialogContent>

--- a/components/providers/OrbAuthProvider.tsx
+++ b/components/providers/OrbAuthProvider.tsx
@@ -32,6 +32,31 @@ type OrbAuthContextValue = {
 
 const OrbAuthContext = createContext<OrbAuthContextValue | null>(null);
 
+const formatOrbConnectError = (err: unknown): string => {
+  if (!(err instanceof Error)) {
+    return 'Could not start Orb sign-in. Check your connection and try again.';
+  }
+
+  const message = err.message.toLowerCase();
+
+  if (
+    message.includes('qr init request failed') ||
+    message.includes('qr poll request failed')
+  ) {
+    return 'Could not start Orb sign-in. Check your connection and try again.';
+  }
+
+  if (message.includes('timed out') || message.includes('timeout')) {
+    return 'Orb sign-in timed out. Please try again.';
+  }
+
+  if (message.includes('cancelled')) {
+    return 'Orb sign-in was cancelled.';
+  }
+
+  return err.message;
+};
+
 const loadStoredSession = (): OrbSession | null => {
   if (typeof window === 'undefined') {
     return null;
@@ -116,7 +141,7 @@ export const OrbAuthProvider = ({ children }: { children: ReactNode }) => {
         const nextSession = enrichSessionWithAccount(sessionFromQrResult(result));
         persistSession(nextSession);
       } catch (err) {
-        setError(err instanceof Error ? err.message : 'Orb sign-in failed');
+        setError(formatOrbConnectError(err));
         throw err;
       } finally {
         setIsConnecting(false);

--- a/lib/orb/client.ts
+++ b/lib/orb/client.ts
@@ -6,9 +6,23 @@ import type { OrbSession } from './types';
 
 let orbLoginSingleton: ReturnType<typeof createOrbLogin> | null = null;
 
+const defaultOrbLoginConfig: OrbLoginConfig = {
+  qr: {
+    initUrl: '/api/auth/orb/qr/init',
+    pollUrl: '/api/auth/orb/qr/poll',
+  },
+};
+
 export const getOrbLogin = (config?: OrbLoginConfig) => {
   if (!orbLoginSingleton) {
-    orbLoginSingleton = createOrbLogin(config);
+    orbLoginSingleton = createOrbLogin({
+      ...defaultOrbLoginConfig,
+      ...config,
+      qr: {
+        ...defaultOrbLoginConfig.qr,
+        ...config?.qr,
+      },
+    });
   }
   return orbLoginSingleton;
 };

--- a/lib/orb/client.ts
+++ b/lib/orb/client.ts
@@ -14,16 +14,19 @@ const defaultOrbLoginConfig: OrbLoginConfig = {
 };
 
 export const getOrbLogin = (config?: OrbLoginConfig) => {
-  if (!orbLoginSingleton) {
+  if (config) {
     orbLoginSingleton = createOrbLogin({
       ...defaultOrbLoginConfig,
       ...config,
       qr: {
         ...defaultOrbLoginConfig.qr,
-        ...config?.qr,
+        ...config.qr,
       },
     });
+  } else if (!orbLoginSingleton) {
+    orbLoginSingleton = createOrbLogin(defaultOrbLoginConfig);
   }
+
   return orbLoginSingleton;
 };
 

--- a/lib/orb/qrProxy.server.ts
+++ b/lib/orb/qrProxy.server.ts
@@ -1,0 +1,75 @@
+import { getSiteUrl } from '@/lib/config/site';
+
+export const ORB_QR_INIT_URL = 'https://orbapi.xyz/init-sign-in';
+export const ORB_QR_POLL_URL = 'https://orbapi.xyz/poll-sign-in';
+export const ORB_QR_CREDENTIALS = 'id_access_refresh';
+
+export const getOrbAppOrigin = (): string => getSiteUrl();
+
+const getOrbProxyHeaders = (): Record<string, string> => {
+  const origin = getOrbAppOrigin();
+  return {
+    Origin: origin,
+    Referer: `${origin}/`,
+  };
+};
+
+type OrbQrFetchInit = Omit<RequestInit, 'headers'> & {
+  headers?: Record<string, string>;
+};
+
+export const orbQrFetch = async (
+  url: string,
+  init: OrbQrFetchInit = {},
+): Promise<Response> => {
+  const { headers, ...rest } = init;
+  return fetch(url, {
+    ...rest,
+    headers: {
+      ...getOrbProxyHeaders(),
+      ...headers,
+    },
+  });
+};
+
+const isRecord = (value: unknown): value is Record<string, unknown> =>
+  typeof value === 'object' && value !== null && !Array.isArray(value);
+
+export const getOrbResponseStatus = (payload: unknown): string | undefined => {
+  if (!isRecord(payload)) {
+    return undefined;
+  }
+
+  if (typeof payload.status === 'string') {
+    return payload.status;
+  }
+
+  const data = isRecord(payload.data) ? payload.data : undefined;
+  if (typeof data?.status === 'string') {
+    return data.status;
+  }
+
+  const nested = data && isRecord(data.data) ? data.data : undefined;
+  if (typeof nested?.status === 'string') {
+    return nested.status;
+  }
+
+  return undefined;
+};
+
+export const getOrbResponseMessage = (payload: unknown): string | undefined => {
+  if (!isRecord(payload)) {
+    return undefined;
+  }
+
+  if (typeof payload.msg === 'string' && payload.msg.trim()) {
+    return payload.msg;
+  }
+
+  const data = isRecord(payload.data) ? payload.data : undefined;
+  if (typeof data?.msg === 'string' && data.msg.trim()) {
+    return data.msg;
+  }
+
+  return undefined;
+};


### PR DESCRIPTION
## Summary
- Proxies Orb QR init/poll through `/api/auth/orb/qr/*` so production avoids browser CORS blocks against `orbapi.xyz`.
- Points `@orbclub/modules` client auth at the same-origin routes and adds clearer Orb sign-in errors plus a modal retry action.

## Test plan
- [ ] Deploy preview with `NEXT_PUBLIC_URL` set to the app origin
- [ ] Connect Base Account and open **Link Orb Profile**
- [ ] Confirm QR code renders and network calls hit `/api/auth/orb/qr/init` (not `orbapi.xyz`)
- [ ] Scan with Orb app and complete wallet link flow


Made with [Cursor](https://cursor.com)