### PR TITLE
Fix Orb profile linking with clearer errors and auto-link flow

### DIFF
--- a/app/api/auth/orb/link/route.ts
+++ b/app/api/auth/orb/link/route.ts
@@ -2,6 +2,7 @@ import { NextRequest, NextResponse } from 'next/server';
 import { createPublicClient, http } from 'viem';
 import { base } from 'viem/chains';
 import { verifyOrbAccessToken } from '@/lib/orb/lensProfile.server';
+import { classifyOrbLinkError, type OrbLinkStep } from '@/lib/orb/linkErrors';
 import { spacetimeClient } from '@/lib/apis/spacetime';
 
 export const runtime = 'nodejs';
@@ -20,21 +21,30 @@ type LinkBody = {
   signature?: string;
 };
 
+const linkErrorResponse = (
+  error: string,
+  step: OrbLinkStep,
+  status: number,
+  extra?: Record<string, string | undefined>,
+) =>
+  NextResponse.json({ error, step, ...extra }, { status });
+
 export async function POST(request: NextRequest) {
   try {
     const body = (await request.json()) as LinkBody;
     const { accessToken, walletAddress, message, signature } = body;
 
     if (!accessToken || !walletAddress || !message || !signature) {
-      return NextResponse.json(
-        { error: 'Missing accessToken, walletAddress, message, or signature' },
-        { status: 400 },
+      return linkErrorResponse(
+        'Missing accessToken, walletAddress, message, or signature',
+        'signature',
+        400,
       );
     }
 
     const wallet = walletAddress.trim().toLowerCase();
     if (!wallet.startsWith('0x')) {
-      return NextResponse.json({ error: 'Invalid wallet address' }, { status: 400 });
+      return linkErrorResponse('Invalid wallet address', 'signature', 400);
     }
 
     const isValidSig = await baseClient.verifyMessage({
@@ -44,7 +54,10 @@ export async function POST(request: NextRequest) {
     });
 
     if (!isValidSig) {
-      return NextResponse.json({ error: 'Invalid wallet signature' }, { status: 401 });
+      console.error('❌ Orb link failed at signature step: invalid wallet signature', {
+        wallet,
+      });
+      return linkErrorResponse('Invalid wallet signature', 'signature', 401);
     }
 
     const siweAddressMatch = message.match(
@@ -52,29 +65,90 @@ export async function POST(request: NextRequest) {
     );
     const signedAddress = siweAddressMatch?.[1]?.toLowerCase();
     if (signedAddress && signedAddress !== wallet) {
-      return NextResponse.json(
-        { error: 'Signature address does not match walletAddress' },
-        { status: 401 },
+      console.error('❌ Orb link failed at signature step: address mismatch', {
+        wallet,
+        signedAddress,
+      });
+      return linkErrorResponse(
+        'Signature address does not match walletAddress',
+        'signature',
+        401,
       );
     }
 
-    const profile = await verifyOrbAccessToken(accessToken);
+    let profile;
+    try {
+      profile = await verifyOrbAccessToken(accessToken);
+    } catch (lensError) {
+      const messageText =
+        lensError instanceof Error ? lensError.message : 'Invalid or expired Orb/Lens session';
+      console.error('❌ Orb link failed at lens step:', messageText);
+      const { step, status } = classifyOrbLinkError(messageText);
+      return linkErrorResponse(messageText, step, status);
+    }
 
-    await spacetimeClient.initialize();
+    try {
+      await spacetimeClient.initialize();
+    } catch (initError) {
+      const messageText =
+        initError instanceof Error
+          ? initError.message
+          : 'SpacetimeDB connection failed';
+      console.error('❌ Orb link failed at spacetime_config step:', messageText);
+      return linkErrorResponse(messageText, 'spacetime_config', 503);
+    }
+
     if (!spacetimeClient.isConfigured()) {
-      return NextResponse.json(
-        { error: 'SpacetimeDB not configured on server' },
-        { status: 503 },
+      console.error('❌ Orb link failed at spacetime_config step: not configured');
+      return linkErrorResponse(
+        'SpacetimeDB not configured on server',
+        'spacetime_config',
+        503,
       );
     }
 
-    await spacetimeClient.setVerifiedSocialIdentity({
-      walletAddress: wallet,
-      lensAccountId: profile.lensAccountId,
-      handle: profile.handle,
-      displayName: profile.displayName,
-      avatarUrl: profile.avatarUrl,
-    });
+    const identityHex = spacetimeClient.getConnectedIdentityHex();
+    const adminRecord = identityHex
+      ? await spacetimeClient.getAdminByIdentity(identityHex)
+      : null;
+
+    if (!adminRecord) {
+      console.error('❌ Orb link failed at spacetime_admin step', {
+        identity: identityHex ?? 'unknown',
+        module:
+          process.env.SPACETIME_MODULE ||
+          process.env.NEXT_PUBLIC_SPACETIME_MODULE ||
+          'beat-me',
+      });
+      return linkErrorResponse(
+        'Server identity is not an admin on this Spacetime module',
+        'spacetime_admin',
+        403,
+        { identity: identityHex ?? undefined },
+      );
+    }
+
+    try {
+      await spacetimeClient.setVerifiedSocialIdentity({
+        walletAddress: wallet,
+        lensAccountId: profile.lensAccountId,
+        handle: profile.handle,
+        displayName: profile.displayName,
+        avatarUrl: profile.avatarUrl,
+      });
+    } catch (writeError) {
+      const messageText =
+        writeError instanceof Error
+          ? writeError.message
+          : 'Failed to persist verified social identity';
+      console.error('❌ Orb link failed at spacetime_write step:', messageText, {
+        identity: identityHex ?? 'unknown',
+        wallet,
+        handle: profile.handle,
+      });
+      const { step, status } = classifyOrbLinkError(messageText);
+      return linkErrorResponse(messageText, step, status);
+    }
 
     return NextResponse.json({
       success: true,
@@ -87,13 +161,10 @@ export async function POST(request: NextRequest) {
       },
     });
   } catch (error) {
-    console.error('❌ Orb link failed:', error);
-    return NextResponse.json(
-      {
-        error:
-          error instanceof Error ? error.message : 'Failed to link Orb profile',
-      },
-      { status: 401 },
-    );
+    const messageText =
+      error instanceof Error ? error.message : 'Failed to link Orb profile';
+    const { step, status } = classifyOrbLinkError(messageText);
+    console.error('❌ Orb link failed:', messageText, { step });
+    return linkErrorResponse(messageText, step, status);
   }
 }

--- a/components/auth/OrbConnectButton.tsx
+++ b/components/auth/OrbConnectButton.tsx
@@ -1,6 +1,6 @@
 'use client';
 
-import { useState } from 'react';
+import { useEffect, useRef, useState } from 'react';
 import Image from 'next/image';
 import { Button } from '@/components/ui/button';
 import {
@@ -40,6 +40,7 @@ export default function OrbConnectButton({
   const [dialogOpen, setDialogOpen] = useState(false);
   const [qrCode, setQrCode] = useState<string | null>(null);
   const [deepLink, setDeepLink] = useState<string | null>(null);
+  const autoLinkAttemptedRef = useRef<string | null>(null);
 
   const handleOpenDialog = () => {
     clearError();
@@ -50,6 +51,7 @@ export default function OrbConnectButton({
   };
 
   const handleConnect = async () => {
+    autoLinkAttemptedRef.current = null;
     try {
       await connectWithQr(({ qrCode: code, deepLink: link }) => {
         setQrCode(code);
@@ -66,6 +68,27 @@ export default function OrbConnectButton({
       setDialogOpen(false);
     }
   };
+
+  useEffect(() => {
+    if (!dialogOpen || !session?.accessToken || linkedProfile || isLinking || isConnecting) {
+      return;
+    }
+
+    if (autoLinkAttemptedRef.current === session.accessToken) {
+      return;
+    }
+
+    autoLinkAttemptedRef.current = session.accessToken;
+
+    const runAutoLink = async () => {
+      const profile = await linkToWallet();
+      if (profile) {
+        setDialogOpen(false);
+      }
+    };
+
+    void runAutoLink();
+  }, [dialogOpen, session?.accessToken, linkedProfile, isLinking, isConnecting, linkToWallet]);
 
   if (!isConnected) {
     return null;
@@ -96,6 +119,8 @@ export default function OrbConnectButton({
       </div>
     );
   }
+
+  const showManualLink = session && !linkedProfile && !isLinking && error;
 
   return (
     <>
@@ -150,21 +175,21 @@ export default function OrbConnectButton({
               </a>
             )}
 
-            {session && !linkedProfile && (
+            {isLinking && (
+              <p className="text-sm text-purple-200 text-center">
+                Linking your Orb profile to your Base wallet…
+              </p>
+            )}
+
+            {showManualLink && (
               <Button
                 type="button"
                 onClick={handleLink}
                 disabled={isLinking}
                 className="w-full bg-gradient-to-r from-purple-500 to-pink-500"
+                aria-label="Retry linking Orb profile to Base wallet"
               >
-                {isLinking ? (
-                  <>
-                    <Loader2 className="w-4 h-4 animate-spin mr-2" />
-                    Linking to wallet…
-                  </>
-                ) : (
-                  'Link to Base wallet'
-                )}
+                Retry link to Base wallet
               </Button>
             )}
 

--- a/components/providers/OrbAuthProvider.tsx
+++ b/components/providers/OrbAuthProvider.tsx
@@ -15,6 +15,10 @@ import {
   type LensProfile,
   type OrbSession,
 } from '@/lib/orb/types';
+import {
+  toUserFriendlyOrbLinkError,
+  type OrbLinkStep,
+} from '@/lib/orb/linkErrors';
 import { useBaseAccount } from '@/hooks/useBaseAccount';
 import { signInWithBase } from '@/lib/base-account/auth';
 
@@ -59,6 +63,35 @@ const loadStoredProfile = (): LensProfile | null => {
     return JSON.parse(raw) as LensProfile;
   } catch {
     return null;
+  }
+};
+
+const refreshSessionAccessToken = async (
+  session: OrbSession,
+): Promise<OrbSession> => {
+  if (!session.refreshToken) {
+    return session;
+  }
+
+  try {
+    const orb = getOrbLogin();
+    const refreshed = await orb.refresh({ refreshToken: session.refreshToken });
+    if (!refreshed.accessToken) {
+      return session;
+    }
+
+    return enrichSessionWithAccount({
+      ...session,
+      accessToken: refreshed.accessToken,
+      refreshToken: refreshed.refreshToken ?? session.refreshToken,
+      idToken: refreshed.idToken ?? session.idToken,
+      authenticationId:
+        typeof refreshed.authenticationId === 'string'
+          ? refreshed.authenticationId
+          : session.authenticationId,
+    });
+  } catch {
+    return session;
   }
 };
 
@@ -138,12 +171,17 @@ export const OrbAuthProvider = ({ children }: { children: ReactNode }) => {
     setIsLinking(true);
     setError(null);
     try {
+      const refreshedSession = await refreshSessionAccessToken(session);
+      if (refreshedSession.accessToken !== session.accessToken) {
+        persistSession(refreshedSession);
+      }
+
       const { message, signature } = await signInWithBase(address);
       const response = await fetch('/api/auth/orb/link', {
         method: 'POST',
         headers: { 'Content-Type': 'application/json' },
         body: JSON.stringify({
-          accessToken: session.accessToken,
+          accessToken: refreshedSession.accessToken,
           walletAddress: address,
           message,
           signature,
@@ -152,11 +190,16 @@ export const OrbAuthProvider = ({ children }: { children: ReactNode }) => {
 
       const data = (await response.json()) as {
         error?: string;
+        step?: OrbLinkStep;
         profile?: LensProfile & { displayName?: string };
       };
 
       if (!response.ok) {
-        throw new Error(data.error ?? 'Failed to link Orb profile');
+        const friendly = toUserFriendlyOrbLinkError(
+          data.error ?? 'Failed to link Orb profile',
+          data.step,
+        );
+        throw new Error(friendly);
       }
 
       const profile: LensProfile = {
@@ -173,7 +216,7 @@ export const OrbAuthProvider = ({ children }: { children: ReactNode }) => {
     } finally {
       setIsLinking(false);
     }
-  }, [address, isConnected, persistProfile, session?.accessToken]);
+  }, [address, isConnected, persistProfile, persistSession, session]);
 
   const disconnect = useCallback(() => {
     persistSession(null);

--- a/lib/apis/spacetime.ts
+++ b/lib/apis/spacetime.ts
@@ -78,6 +78,7 @@ export interface SpacetimeInitOptions {
 class SpacetimeDBClient {
   private connection: DbConnection | null = null;
   private isConnected = false;
+  private connectedIdentityHex: string | null = null;
   private connectionPromise: Promise<void> | null = null;
   private initOptions: SpacetimeInitOptions = {};
   private playersSubscribed = false;
@@ -241,6 +242,7 @@ class SpacetimeDBClient {
             console.log(`   Identity: ${identity.toHexString()}`);
             console.log(`   Token: ${token ? '***' + token.slice(-8) : 'None'}`);
             this.connection = conn;
+            this.connectedIdentityHex = identity.toHexString();
             this.isConnected = true;
             this.beginSyncWait();
 
@@ -263,6 +265,7 @@ class SpacetimeDBClient {
             console.log('🔌 Disconnected from SpacetimeDB');
             this.isConnected = false;
             this.connection = null;
+            this.connectedIdentityHex = null;
             this.playersSubscribed = false;
             this.resetSyncState();
           })
@@ -307,6 +310,10 @@ class SpacetimeDBClient {
     return this.connection;
   }
 
+  getConnectedIdentityHex(): string | null {
+    return this.connectedIdentityHex;
+  }
+
   /**
    * Disconnect from SpacetimeDB
    */
@@ -315,6 +322,7 @@ class SpacetimeDBClient {
       this.connection.disconnect();
       this.connection = null;
       this.isConnected = false;
+      this.connectedIdentityHex = null;
       console.log('🔌 Disconnected from SpacetimeDB');
     }
   }
@@ -795,13 +803,23 @@ class SpacetimeDBClient {
       throw new Error('Not connected to SpacetimeDB');
     }
 
-    await this.connection.reducers.setVerifiedSocialIdentity({
+    const conn = this.connection;
+    const params = {
       walletAddress: input.walletAddress.trim().toLowerCase(),
       lensAccountId: input.lensAccountId,
       handle: input.handle.trim().replace(/^@/, ''),
       displayName: input.displayName ?? undefined,
       avatarUrl: input.avatarUrl ?? undefined,
-    });
+    };
+
+    try {
+      await conn.reducers.setVerifiedSocialIdentity(params);
+    } catch (error) {
+      console.error('❌ setVerifiedSocialIdentity failed:', error);
+      throw error instanceof Error
+        ? error
+        : new Error('set_verified_social_identity failed');
+    }
   }
 
   getActiveConnections(limit: number = 20): Array<{

--- a/lib/orb/linkErrors.ts
+++ b/lib/orb/linkErrors.ts
@@ -1,0 +1,71 @@
+export type OrbLinkStep =
+  | 'signature'
+  | 'lens'
+  | 'spacetime_config'
+  | 'spacetime_admin'
+  | 'spacetime_write'
+  | 'handle_conflict';
+
+export const classifyOrbLinkError = (
+  message: string,
+): { step: OrbLinkStep; status: number } => {
+  const lower = message.toLowerCase();
+
+  if (lower.includes('already taken') || lower.includes('already linked')) {
+    return { step: 'handle_conflict', status: 409 };
+  }
+
+  if (lower.includes('only admins')) {
+    return { step: 'spacetime_admin', status: 403 };
+  }
+
+  if (
+    lower.includes('not connected to spacetime') ||
+    lower.includes('connection timeout') ||
+    lower.includes('not configured') ||
+    lower.includes('spacetimedb connection')
+  ) {
+    return { step: 'spacetime_config', status: 503 };
+  }
+
+  if (
+    lower.includes('invalid or expired orb') ||
+    lower.includes('lens graphql') ||
+    lower.includes('failed to refresh lens')
+  ) {
+    return { step: 'lens', status: 401 };
+  }
+
+  if (
+    lower.includes('invalid wallet signature') ||
+    lower.includes('signature address does not match') ||
+    lower.includes('invalid wallet address')
+  ) {
+    return { step: 'signature', status: 401 };
+  }
+
+  return { step: 'spacetime_write', status: 500 };
+};
+
+export const toUserFriendlyOrbLinkError = (
+  error: string,
+  step?: OrbLinkStep,
+): string => {
+  const resolvedStep = step ?? classifyOrbLinkError(error).step;
+
+  switch (resolvedStep) {
+    case 'signature':
+      return 'Wallet signature failed. Reconnect your Base Account and try again.';
+    case 'lens':
+      return 'Orb session expired. Scan the QR code again in the Orb app, then retry linking.';
+    case 'spacetime_config':
+      return 'Beat Me could not reach the game database. Try again in a moment.';
+    case 'spacetime_admin':
+      return 'Profile linking is temporarily unavailable. Please try again later.';
+    case 'handle_conflict':
+      return 'This Lens handle is already linked to another wallet.';
+    case 'spacetime_write':
+    default:
+      return error || 'Failed to link Orb profile. Please try again.';
+  }
+};

--- a/lib/spacetime/index.ts
+++ b/lib/spacetime/index.ts
@@ -291,21 +291,6 @@ const tablesSchema = __schema({
       { name: 'pool_players_player_id_key', constraint: 'unique', columns: ['playerId'] },
     ],
   }, PoolPlayersRow),
-  social_identity: __table({
-    name: 'social_identity',
-    indexes: [
-      { accessor: 'handle', name: 'social_identity_handle_idx_btree', algorithm: 'btree', columns: [
-        'handle',
-      ] },
-      { accessor: 'wallet_address', name: 'social_identity_wallet_address_idx_btree', algorithm: 'btree', columns: [
-        'walletAddress',
-      ] },
-    ],
-    constraints: [
-      { name: 'social_identity_handle_key', constraint: 'unique', columns: ['handle'] },
-      { name: 'social_identity_wallet_address_key', constraint: 'unique', columns: ['walletAddress'] },
-    ],
-  }, SocialIdentityRow),
   prize_history: __table({
     name: 'prize_history',
     indexes: [
@@ -339,6 +324,21 @@ const tablesSchema = __schema({
       { name: 'question_attempts_id_key', constraint: 'unique', columns: ['id'] },
     ],
   }, QuestionAttemptsRow),
+  social_identity: __table({
+    name: 'social_identity',
+    indexes: [
+      { accessor: 'handle', name: 'social_identity_handle_idx_btree', algorithm: 'btree', columns: [
+        'handle',
+      ] },
+      { accessor: 'wallet_address', name: 'social_identity_wallet_address_idx_btree', algorithm: 'btree', columns: [
+        'walletAddress',
+      ] },
+    ],
+    constraints: [
+      { name: 'social_identity_handle_key', constraint: 'unique', columns: ['handle'] },
+      { name: 'social_identity_wallet_address_key', constraint: 'unique', columns: ['walletAddress'] },
+    ],
+  }, SocialIdentityRow),
 });
 
 /** The schema information for all reducers in this module. This is defined the same way as the reducers would have been defined in the server, except the body of the reducer is omitted in code generation. */

--- a/lib/spacetime/types.ts
+++ b/lib/spacetime/types.ts
@@ -225,17 +225,6 @@ export const PoolPlayer = __t.object("PoolPlayer", {
 });
 export type PoolPlayer = __Infer<typeof PoolPlayer>;
 
-export const SocialIdentity = __t.object("SocialIdentity", {
-  walletAddress: __t.string(),
-  lensAccountId: __t.string(),
-  handle: __t.string(),
-  displayName: __t.option(__t.string()),
-  avatarUrl: __t.option(__t.string()),
-  linkedAt: __t.timestamp(),
-  verifiedAt: __t.timestamp(),
-});
-export type SocialIdentity = __Infer<typeof SocialIdentity>;
-
 export const PrizeHistory = __t.object("PrizeHistory", {
   id: __t.u64(),
   walletAddress: __t.string(),
@@ -287,4 +276,15 @@ export const SessionStatus = __t.enum("SessionStatus", {
   Completed: __t.unit(),
 });
 export type SessionStatus = __Infer<typeof SessionStatus>;
+
+export const SocialIdentity = __t.object("SocialIdentity", {
+  walletAddress: __t.string(),
+  lensAccountId: __t.string(),
+  handle: __t.string(),
+  displayName: __t.option(__t.string()),
+  avatarUrl: __t.option(__t.string()),
+  linkedAt: __t.timestamp(),
+  verifiedAt: __t.timestamp(),
+});
+export type SocialIdentity = __Infer<typeof SocialIdentity>;
 


### PR DESCRIPTION
## Summary
- Add step-level diagnostics and admin preflight to `/api/auth/orb/link` so production failures surface specific causes instead of a generic link error.
- Refresh Orb access tokens before linking and harden Spacetime writes with clearer reducer failure propagation.
- Improve Orb connect UX by auto-linking after QR approval and offering retry without forcing a new QR scan.

## Test plan
- [ ] Deploy branch to Vercel preview
- [ ] Connect Base Account, open Orb link dialog, approve sign-in in Orb app
- [ ] Confirm profile links automatically after QR approval
- [ ] If link fails, verify error message is specific (admin, lens session, handle conflict, Spacetime config)
- [ ] Use "Retry link to Base wallet" without rescanning QR
- [ ] Check Vercel function logs for `step` field on failures
- [ ] Confirm linked handle appears in lobby/player UI


Made with [Cursor](https://cursor.com)