### PR TITLE
Fix weekly payout stuck when on-chain scores are missing

### DIFF
--- a/app/api/save-paid-score/route.ts
+++ b/app/api/save-paid-score/route.ts
@@ -4,6 +4,7 @@ import { verifyEntryToken } from '@/lib/utils/jwt';
 import { finalizePaidScoreLedger } from '@/lib/game/paidScoreLedger';
 import { verifyScoreReceipt } from '@/lib/game/scoreReceipt';
 import { submitOnChainScoreWithRetry } from '@/lib/blockchain/submitOnChainScore';
+import { schedulePendingOnChainScoreRetry } from '@/lib/blockchain/pendingOnChainScoreRetry';
 
 const MAX_GAME_SCORE = 3000;
 
@@ -134,6 +135,11 @@ export async function POST(req: NextRequest) {
         score: authoritativeScore,
         sessionId: onChainSessionId,
         error: onChainResult.error,
+      });
+      schedulePendingOnChainScoreRetry({
+        walletAddress: normalizedWallet,
+        score: authoritativeScore,
+        sessionId: onChainSessionId || undefined,
       });
       return NextResponse.json(
         {

--- a/app/api/save-paid-score/route.ts
+++ b/app/api/save-paid-score/route.ts
@@ -4,7 +4,7 @@ import { verifyEntryToken } from '@/lib/utils/jwt';
 import { finalizePaidScoreLedger } from '@/lib/game/paidScoreLedger';
 import { verifyScoreReceipt } from '@/lib/game/scoreReceipt';
 import { submitOnChainScoreWithRetry } from '@/lib/blockchain/submitOnChainScore';
-import { schedulePendingOnChainScoreRetry } from '@/lib/blockchain/pendingOnChainScoreRetry';
+import { retryOnChainScoreBeforeResponse } from '@/lib/blockchain/pendingOnChainScoreRetry';
 
 const MAX_GAME_SCORE = 3000;
 
@@ -136,11 +136,25 @@ export async function POST(req: NextRequest) {
         sessionId: onChainSessionId,
         error: onChainResult.error,
       });
-      schedulePendingOnChainScoreRetry({
+
+      const extendedRetry = await retryOnChainScoreBeforeResponse({
         walletAddress: normalizedWallet,
         score: authoritativeScore,
         sessionId: onChainSessionId || undefined,
       });
+
+      if (extendedRetry.ok) {
+        return NextResponse.json({
+          success: true,
+          authoritativeScore,
+          onChainSessionId,
+          spacetimeUpdated,
+          onChainSubmitted: true,
+          transactionHash: extendedRetry.transactionHash,
+          retried: true,
+        });
+      }
+
       return NextResponse.json(
         {
           success: true,

--- a/app/api/submit-onchain-scores/route.ts
+++ b/app/api/submit-onchain-scores/route.ts
@@ -4,7 +4,13 @@ import { base } from 'viem/chains';
 import { checkAdminAuth } from '@/lib/utils/adminAuthMiddleware';
 import { spacetimeClient } from '@/lib/apis/spacetime';
 import { submitScoresOnChain } from '@/lib/blockchain/submitScoresOnChain';
+import {
+  readOnChainPlayerScores,
+  scoresAlreadySyncedOnChain,
+  waitForNonZeroOnChainScores,
+} from '@/lib/blockchain/onChainScoreSync';
 import { TRIVIA_ABI, TRIVIA_CONTRACT_ADDRESS } from '@/lib/blockchain/contracts';
+import { safeErrorMessage } from '@/lib/utils/safeErrorMessage';
 
 /**
  * POST /api/submit-onchain-scores
@@ -45,6 +51,20 @@ export async function POST(req: NextRequest) {
       return NextResponse.json({ success: true, message: 'No players in current session', submitted: 0 });
     }
 
+    if (await scoresAlreadySyncedOnChain(publicClient, players)) {
+      const onChain = await readOnChainPlayerScores(publicClient, players);
+      return NextResponse.json({
+        success: true,
+        message: 'Scores already on-chain; sync skipped (idempotent)',
+        submitted: 0,
+        skipped: true,
+        scores: onChain.map((entry) => ({
+          address: entry.address,
+          score: Number(entry.score),
+        })),
+      });
+    }
+
     await spacetimeClient.ensurePlayerDataReady();
 
     const addresses: `0x${string}`[] = [];
@@ -73,6 +93,21 @@ export async function POST(req: NextRequest) {
     const txHash = (await submitScoresOnChain(addresses, scores)) as Hash | null;
 
     if (!txHash) {
+      const syncedAfterRace = await waitForNonZeroOnChainScores(publicClient, players);
+      if (syncedAfterRace) {
+        const onChain = await readOnChainPlayerScores(publicClient, players);
+        return NextResponse.json({
+          success: true,
+          message: 'Scores synced by concurrent request; no new tx required',
+          submitted: 0,
+          skipped: true,
+          scores: onChain.map((entry) => ({
+            address: entry.address,
+            score: Number(entry.score),
+          })),
+        });
+      }
+
       return NextResponse.json({
         success: true,
         message: 'No active on-chain session — scores not submitted',
@@ -81,6 +116,7 @@ export async function POST(req: NextRequest) {
     }
 
     const receipt = await publicClient.waitForTransactionReceipt({ hash: txHash, confirmations: 1 });
+    await waitForNonZeroOnChainScores(publicClient, players, { attempts: 4, delayMs: 1000 });
 
     return NextResponse.json({
       success: receipt.status === 'success',
@@ -91,12 +127,7 @@ export async function POST(req: NextRequest) {
       scores: addresses.map((a, i) => ({ address: a, score: Number(scores[i]) })),
     });
   } catch (error) {
-    const details =
-      error instanceof Error
-        ? error.message
-        : typeof error === 'object' && error !== null
-          ? JSON.stringify(error)
-          : String(error);
+    const details = safeErrorMessage(error);
     console.error('Error submitting on-chain scores:', error);
     return NextResponse.json(
       {

--- a/app/api/submit-onchain-scores/route.ts
+++ b/app/api/submit-onchain-scores/route.ts
@@ -56,7 +56,9 @@ export async function POST(req: NextRequest) {
       if (!profile) {
         missingProfiles.push(addr);
       }
-      const score = profile ? BigInt(profile.bestScore) : BigInt(0);
+      const score = profile
+        ? BigInt(profile.weeklyBestScore > 0 ? profile.weeklyBestScore : profile.bestScore)
+        : BigInt(0);
       addresses.push(addr);
       scores.push(score);
     }
@@ -89,11 +91,17 @@ export async function POST(req: NextRequest) {
       scores: addresses.map((a, i) => ({ address: a, score: Number(scores[i]) })),
     });
   } catch (error) {
+    const details =
+      error instanceof Error
+        ? error.message
+        : typeof error === 'object' && error !== null
+          ? JSON.stringify(error)
+          : String(error);
     console.error('Error submitting on-chain scores:', error);
     return NextResponse.json(
       {
         error: 'Failed to submit on-chain scores',
-        details: error instanceof Error ? error.message : String(error),
+        details,
       },
       { status: 500 }
     );

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -20,6 +20,7 @@ import GameTitle from '@/components/ui/GameTitle';
 import HighScoreDisplay from '@/components/game/HighScoreDisplay';
 import TopEarners from '@/components/leaderboard/TopEarners';
 import { useWeeklyLeaderboard } from '@/hooks/useWeeklyLeaderboard';
+import { getWeeklyPayoutStatus } from '@/lib/game/weeklyPayoutStatus';
 // OnchainKit imports removed - using Base Account instead
 import { Card, CardContent } from '@/components/ui/card';
 import { cn } from '@/lib/utils';
@@ -112,7 +113,17 @@ function HomePage() {
     onChainLastSessionTime > 0 ? BigInt(onChainLastSessionTime) : undefined,
     onChainSessionInterval > 0 ? BigInt(onChainSessionInterval) : undefined,
   );
-  const { refresh: refreshWeeklyLeaderboard } = useWeeklyLeaderboard(10);
+  const { refresh: refreshWeeklyLeaderboard, entries: weeklyLeaderboardEntries, sessionCounter: weeklySessionCounter } = useWeeklyLeaderboard(10);
+
+  const hasOnChainScores = weeklyLeaderboardEntries.some((entry) => entry.bestScore > 0);
+  const weeklyPayoutStatus = getWeeklyPayoutStatus({
+    isLoading: contractBalanceLoading,
+    isSessionActive: onChainSessionActive,
+    sessionPrizePool,
+    countdownExpired: settlementCountdown?.isExpired ?? false,
+    hasOnChainScores,
+    sessionCounter: weeklySessionCounter,
+  });
 
   // Automatically switch to paid solo if trial is exhausted
   useEffect(() => {
@@ -592,10 +603,12 @@ function HomePage() {
   // Determine what to display in the timer area (weekly on-chain settlement)
   const getTimerDisplay = () => {
     if (contractBalanceLoading) return 'Loading...';
-    if (onChainSessionActive && settlementCountdown && !settlementCountdown.isExpired) {
+    if (weeklyPayoutStatus.phase === 'counting_down' && settlementCountdown && !settlementCountdown.isExpired) {
       return formatSettlementCountdown();
     }
-    if (onChainSessionActive) return 'WEEKLY PAYOUT PENDING';
+    if (weeklyPayoutStatus.timerLabel) {
+      return weeklyPayoutStatus.timerLabel;
+    }
     return 'NEXT SESSION OPENS SOON';
   };
 

--- a/chainlink-cre-workflows/weekly-prize-distribution/README.md
+++ b/chainlink-cre-workflows/weekly-prize-distribution/README.md
@@ -67,6 +67,8 @@ Adjust the `gasLimit` in your config file based on your contract's gas requireme
 
 Store the app admin secret in CRE as **`ADMIN_API_SECRET`** (same value as the Vercel `ADMIN_API_SECRET` env var). Without it, the workflow logs a skip reason when scores are missing.
 
+The score-sync API is **idempotent**: concurrent DON node calls return HTTP 200 without a second owner transaction when scores are already on-chain.
+
 Workflow results now use `action`: `skipped` | `distributed` | `failed` (in addition to `distributionExecuted`).
 
 ## Manual unblock (stuck payout)

--- a/chainlink-cre-workflows/weekly-prize-distribution/README.md
+++ b/chainlink-cre-workflows/weekly-prize-distribution/README.md
@@ -61,6 +61,30 @@ To change the schedule, update the `schedule` field in your config file. Example
 
 Adjust the `gasLimit` in your config file based on your contract's gas requirements. The default is 500,000.
 
+### Pre-distribution score sync (production)
+
+`config.production.json` includes `scoreSyncApiUrl` pointing at `POST /api/submit-onchain-scores`. Before distributing, the workflow attempts to sync SpacetimeDB weekly scores on-chain when none are present.
+
+Store the app admin secret in CRE as **`ADMIN_API_SECRET`** (same value as the Vercel `ADMIN_API_SECRET` env var). Without it, the workflow logs a skip reason when scores are missing.
+
+Workflow results now use `action`: `skipped` | `distributed` | `failed` (in addition to `distributionExecuted`).
+
+## Manual unblock (stuck payout)
+
+From the repo root, after deploying the API fix:
+
+```bash
+npx tsx --env-file=.env.local scripts/unblock-weekly-payout.ts
+# or local Spacetime + owner key:
+npx tsx --env-file=.env.local scripts/unblock-weekly-payout.ts --local
+```
+
+Diagnostics:
+
+```bash
+npx tsx --env-file=.env.local scripts/debug_contract_state.ts
+```
+
 ## Contract Requirements
 
 The TriviaBattle contract must:

--- a/chainlink-cre-workflows/weekly-prize-distribution/config.production.json
+++ b/chainlink-cre-workflows/weekly-prize-distribution/config.production.json
@@ -1,5 +1,6 @@
 {
   "schedule": "0 0 * * 0",
+  "scoreSyncApiUrl": "https://beatme.creativeplatform.xyz/api/submit-onchain-scores",
   "evms": [
     {
       "chainName": "ethereum-mainnet-base-1",

--- a/chainlink-cre-workflows/weekly-prize-distribution/main.ts
+++ b/chainlink-cre-workflows/weekly-prize-distribution/main.ts
@@ -218,6 +218,8 @@ function syncScoresFromApp(runtime: Runtime<Config>): boolean {
     return false
   }
 
+  // DON nodes each invoke this HTTP call; the API is idempotent and skips owner
+  // writes when scores are already on-chain to avoid nonce collisions.
   const syncScore = (nodeRuntime: NodeRuntime<Config>): number => {
     const httpClient = new cre.capabilities.HTTPClient()
     const resp = httpClient
@@ -241,6 +243,30 @@ function syncScoresFromApp(runtime: Runtime<Config>): boolean {
   return result >= 1
 }
 
+const RECEIPT_POLL_ATTEMPTS = 12
+
+function readFinalizedBlockNumber(
+  runtime: Runtime<Config>,
+  chainSelector: bigint
+): bigint | null {
+  const evmClient = new cre.capabilities.EVMClient(chainSelector)
+  try {
+    const header = evmClient
+      .headerByNumber(runtime, {
+        blockNumber: LAST_FINALIZED_BLOCK_NUMBER,
+      })
+      .result() as { header?: { number?: string | number | bigint }; number?: string | number | bigint }
+
+    const raw = header.header?.number ?? header.number
+    if (raw === undefined || raw === null) {
+      return null
+    }
+    return typeof raw === "bigint" ? raw : BigInt(raw)
+  } catch {
+    return null
+  }
+}
+
 function verifyDistributionReceipt(
   runtime: Runtime<Config>,
   chainSelector: bigint,
@@ -248,9 +274,25 @@ function verifyDistributionReceipt(
   txHash: string
 ): { status: "success" | "reverted" | "pending" | "unknown" } {
   const evmClient = new cre.capabilities.EVMClient(chainSelector)
-  const maxAttempts = 8
+  let lastSeenBlock = BigInt(0)
 
-  for (let attempt = 1; attempt <= maxAttempts; attempt++) {
+  for (let attempt = 1; attempt <= RECEIPT_POLL_ATTEMPTS; attempt++) {
+    const blockNumber = readFinalizedBlockNumber(runtime, chainSelector)
+    if (blockNumber !== null && blockNumber > lastSeenBlock) {
+      lastSeenBlock = blockNumber
+      runtime.log(
+        `Receipt poll ${attempt}/${RECEIPT_POLL_ATTEMPTS} at finalized block ${blockNumber}`
+      )
+    } else {
+      runtime.log(`Receipt poll ${attempt}/${RECEIPT_POLL_ATTEMPTS} (awaiting new block)`)
+    }
+
+    const poolBeforeReceipt = readSessionInfo(runtime, chainSelector, evmConfig).prizePool
+    if (poolBeforeReceipt === BigInt(0)) {
+      runtime.log("Prize pool cleared — distribution confirmed via state")
+      return { status: "success" }
+    }
+
     try {
       const receiptReply = evmClient
         .getTransactionReceipt(runtime, {
@@ -265,7 +307,6 @@ function verifyDistributionReceipt(
 
       const rawStatus = receipt.receipt?.status ?? receipt.status
       if (rawStatus === undefined || rawStatus === null) {
-        runtime.log(`Receipt pending (attempt ${attempt}/${maxAttempts})`)
         continue
       }
 
@@ -273,11 +314,6 @@ function verifyDistributionReceipt(
         typeof rawStatus === "string" ? parseInt(rawStatus, 16) : Number(rawStatus)
 
       if (statusNum === 1) {
-        const after = readSessionInfo(runtime, chainSelector, evmConfig)
-        if (after.prizePool === BigInt(0)) {
-          return { status: "success" }
-        }
-        runtime.log("Tx succeeded but prize pool not yet zero; treating as success")
         return { status: "success" }
       }
 
@@ -291,8 +327,8 @@ function verifyDistributionReceipt(
     }
   }
 
-  const poolAfter = readSessionInfo(runtime, chainSelector, evmConfig)
-  if (poolAfter.prizePool === BigInt(0)) {
+  const poolAfter = readSessionInfo(runtime, chainSelector, evmConfig).prizePool
+  if (poolAfter === BigInt(0)) {
     return { status: "success" }
   }
 

--- a/chainlink-cre-workflows/weekly-prize-distribution/main.ts
+++ b/chainlink-cre-workflows/weekly-prize-distribution/main.ts
@@ -2,12 +2,14 @@ import {
   cre,
   Runner,
   type Runtime,
+  type NodeRuntime,
   type CronPayload,
   getNetwork,
   LAST_FINALIZED_BLOCK_NUMBER,
   encodeCallMsg,
   bytesToHex,
   hexToBase64,
+  consensusMedianAggregation,
 } from "@chainlink/cre-sdk"
 import { encodeFunctionData, decodeFunctionResult, zeroAddress } from "viem"
 
@@ -19,10 +21,11 @@ type EvmConfig = {
 
 type Config = {
   schedule: string
+  /** Optional app URL for pre-distribution score sync (POST /api/submit-onchain-scores). */
+  scoreSyncApiUrl?: string
   evms: EvmConfig[]
 }
 
-// Session info struct matching the contract
 type SessionInfo = {
   startTime: bigint
   endTime: bigint
@@ -31,17 +34,22 @@ type SessionInfo = {
   trialPlayerCount: bigint
   isActive: boolean
   prizesDistributed: boolean
-  sessionCounter: bigint // Added to track if session was actually started
+  sessionCounter: bigint
 }
 
+type DistributionAction = "skipped" | "distributed" | "failed"
+
 type DistributionResult = {
+  action: DistributionAction
   distributionExecuted: boolean
   reason: string
   txHash?: string
+  receiptStatus?: string
+  scoreSyncAttempted?: boolean
+  scoreSyncSucceeded?: boolean
 }
 
 const initWorkflow = (config: Config) => {
-  // Weekly cron: Every Sunday at 00:00 UTC
   const cronTrigger = new cre.capabilities.CronCapability().trigger({
     schedule: config.schedule,
   })
@@ -55,7 +63,6 @@ const onWeeklyDistribution = (
 ): DistributionResult => {
   const evmConfig = runtime.config.evms[0]
 
-  // Convert the human-readable chain name to a chain selector
   const network = getNetwork({
     chainFamily: "evm",
     chainSelectorName: evmConfig.chainName,
@@ -68,70 +75,75 @@ const onWeeklyDistribution = (
 
   runtime.log(`Weekly distribution check triggered for contract: ${evmConfig.contractAddress}`)
 
-  // Step 1: Read current session state
   const sessionInfo = readSessionInfo(runtime, network.chainSelector.selector, evmConfig)
 
   runtime.log(
     `Session state - Active: ${sessionInfo.isActive}, Prize Pool: ${sessionInfo.prizePool}, Distributed: ${sessionInfo.prizesDistributed}, End Time: ${sessionInfo.endTime}, Session Counter: ${sessionInfo.sessionCounter}, Players: ${sessionInfo.paidPlayerCount}`
   )
 
-  // Step 2: Check if distribution is needed
   const currentTime = BigInt(Math.floor(Date.now() / 1000))
   const isSessionEnded = !sessionInfo.isActive || currentTime > sessionInfo.endTime
 
-  // Early check: If no session was ever started, skip distribution
-  if (sessionInfo.sessionCounter === BigInt(0)) {
-    const reason = `No session has been started yet (sessionCounter = 0). This is expected for a new contract. Skipping distribution.`
+  const skip = (reason: string): DistributionResult => {
     runtime.log(reason)
     return {
+      action: "skipped",
       distributionExecuted: false,
       reason,
     }
+  }
+
+  if (sessionInfo.sessionCounter === BigInt(0)) {
+    return skip(
+      `No session has been started yet (sessionCounter = 0). Skipping distribution.`
+    )
   }
 
   if (!isSessionEnded) {
-    const reason = `Session still active. End time: ${sessionInfo.endTime}, Current time: ${currentTime}`
-    runtime.log(reason)
-    return {
-      distributionExecuted: false,
-      reason,
-    }
+    return skip(
+      `Session still active. End time: ${sessionInfo.endTime}, Current time: ${currentTime}`
+    )
   }
 
   if (sessionInfo.prizesDistributed) {
-    const reason = `Prizes already distributed for session ${sessionInfo.sessionCounter}`
-    runtime.log(reason)
-    return {
-      distributionExecuted: false,
-      reason,
-    }
+    return skip(`Prizes already distributed for session ${sessionInfo.sessionCounter}`)
   }
 
   if (sessionInfo.prizePool === BigInt(0)) {
-    const reason = `No prize pool to distribute for session ${sessionInfo.sessionCounter} (prize pool: 0, players: ${sessionInfo.paidPlayerCount}). This may mean prizes were already distributed or no players joined.`
-    runtime.log(reason)
-    return {
-      distributionExecuted: false,
-      reason,
-    }
+    return skip(
+      `No prize pool to distribute for session ${sessionInfo.sessionCounter} (prize pool: 0, players: ${sessionInfo.paidPlayerCount}).`
+    )
   }
 
-  // Step 3: Verify player scores exist before distribution
-  // The contract's _findTopPlayers() sorts by playerScores mapping.
-  // If no scores have been submitted, distribution would give prizes to arbitrary players.
-  const hasScores = verifyScoresExist(runtime, network.chainSelector.selector, evmConfig)
+  let scoreSyncAttempted = false
+  let scoreSyncSucceeded = false
+  let hasScores = verifyScoresExist(runtime, network.chainSelector.selector, evmConfig)
 
   if (!hasScores) {
-    const reason = `No player scores submitted for session ${sessionInfo.sessionCounter}. Scores must be set via submitScores() before distribution. Skipping to prevent incorrect prize allocation.`
-    runtime.log(reason)
-    return {
-      distributionExecuted: false,
-      reason,
+    runtime.log(
+      `No on-chain scores for session ${sessionInfo.sessionCounter}. Attempting pre-distribution score sync...`
+    )
+    scoreSyncAttempted = true
+    scoreSyncSucceeded = syncScoresFromApp(runtime)
+    if (scoreSyncSucceeded) {
+      runtime.log("Pre-distribution score sync succeeded; re-checking on-chain scores")
+      hasScores = verifyScoresExist(runtime, network.chainSelector.selector, evmConfig)
+    } else {
+      runtime.log("Pre-distribution score sync skipped or failed")
     }
   }
 
-  // Step 4: Call distributePrizes()
-  runtime.log("All conditions met including score verification. Executing distributePrizes()...")
+  if (!hasScores) {
+    return {
+      action: "skipped",
+      distributionExecuted: false,
+      scoreSyncAttempted,
+      scoreSyncSucceeded,
+      reason: `No player scores on-chain for session ${sessionInfo.sessionCounter}. Sync scores via /api/submit-onchain-scores before distribution.`,
+    }
+  }
+
+  runtime.log("All conditions met. Executing distributePrizes()...")
 
   try {
     const txHash = callDistributePrizes(
@@ -140,25 +152,153 @@ const onWeeklyDistribution = (
       evmConfig
     )
 
-    runtime.log(`Distribution transaction successful: ${txHash}`)
+    const receipt = verifyDistributionReceipt(
+      runtime,
+      network.chainSelector.selector,
+      evmConfig,
+      txHash
+    )
+
+    if (receipt.status === "success") {
+      runtime.log(`Distribution confirmed on-chain: ${txHash}`)
+      return {
+        action: "distributed",
+        distributionExecuted: true,
+        reason: "Prizes distributed successfully",
+        txHash,
+        receiptStatus: receipt.status,
+        scoreSyncAttempted,
+        scoreSyncSucceeded,
+      }
+    }
 
     return {
-      distributionExecuted: true,
-      reason: "Prizes distributed successfully",
+      action: "failed",
+      distributionExecuted: false,
+      reason: `Distribution tx ${txHash} did not succeed on-chain (${receipt.status})`,
       txHash,
+      receiptStatus: receipt.status,
+      scoreSyncAttempted,
+      scoreSyncSucceeded,
     }
   } catch (error) {
     const errorMessage = error instanceof Error ? error.message : String(error)
     runtime.log(`Distribution failed: ${errorMessage}`)
     return {
+      action: "failed",
       distributionExecuted: false,
       reason: `Distribution failed: ${errorMessage}`,
+      scoreSyncAttempted,
+      scoreSyncSucceeded,
     }
   }
 }
 
-// Read session info from the contract
-// Note: The contract doesn't have getSessionInfo(), so we read individual state variables
+function syncScoresFromApp(runtime: Runtime<Config>): boolean {
+  const apiUrl = runtime.config.scoreSyncApiUrl?.trim()
+  if (!apiUrl) {
+    runtime.log("scoreSyncApiUrl not configured; cannot auto-sync scores")
+    return false
+  }
+
+  let adminSecret = ""
+  try {
+    const secretValue = runtime.getSecret({ key: "ADMIN_API_SECRET" }).result()
+    adminSecret =
+      typeof secretValue === "string"
+        ? secretValue
+        : new TextDecoder().decode(secretValue as Uint8Array)
+  } catch {
+    runtime.log("ADMIN_API_SECRET not available in CRE secrets; cannot auto-sync scores")
+    return false
+  }
+
+  if (!adminSecret) {
+    runtime.log("ADMIN_API_SECRET is empty")
+    return false
+  }
+
+  const syncScore = (nodeRuntime: NodeRuntime<Config>): number => {
+    const httpClient = new cre.capabilities.HTTPClient()
+    const resp = httpClient
+      .sendRequest(nodeRuntime, {
+        url: apiUrl,
+        method: "POST",
+        headers: {
+          Authorization: `Bearer ${adminSecret}`,
+          "Content-Type": "application/json",
+        },
+        body: new TextEncoder().encode("{}"),
+      })
+      .result()
+
+    const status = resp.statusCode ?? 0
+    nodeRuntime.log(`Score sync HTTP status: ${status}`)
+    return status >= 200 && status < 300 ? 1 : 0
+  }
+
+  const result = runtime.runInNodeMode(syncScore, consensusMedianAggregation())().result()
+  return result >= 1
+}
+
+function verifyDistributionReceipt(
+  runtime: Runtime<Config>,
+  chainSelector: bigint,
+  evmConfig: EvmConfig,
+  txHash: string
+): { status: "success" | "reverted" | "pending" | "unknown" } {
+  const evmClient = new cre.capabilities.EVMClient(chainSelector)
+  const maxAttempts = 8
+
+  for (let attempt = 1; attempt <= maxAttempts; attempt++) {
+    try {
+      const receiptReply = evmClient
+        .getTransactionReceipt(runtime, {
+          hash: txHash,
+        })
+        .result()
+
+      const receipt = receiptReply as {
+        receipt?: { status?: number | string }
+        status?: number | string
+      }
+
+      const rawStatus = receipt.receipt?.status ?? receipt.status
+      if (rawStatus === undefined || rawStatus === null) {
+        runtime.log(`Receipt pending (attempt ${attempt}/${maxAttempts})`)
+        continue
+      }
+
+      const statusNum =
+        typeof rawStatus === "string" ? parseInt(rawStatus, 16) : Number(rawStatus)
+
+      if (statusNum === 1) {
+        const after = readSessionInfo(runtime, chainSelector, evmConfig)
+        if (after.prizePool === BigInt(0)) {
+          return { status: "success" }
+        }
+        runtime.log("Tx succeeded but prize pool not yet zero; treating as success")
+        return { status: "success" }
+      }
+
+      if (statusNum === 0) {
+        return { status: "reverted" }
+      }
+    } catch (error) {
+      runtime.log(
+        `Receipt poll attempt ${attempt} failed: ${error instanceof Error ? error.message : String(error)}`
+      )
+    }
+  }
+
+  const poolAfter = readSessionInfo(runtime, chainSelector, evmConfig)
+  if (poolAfter.prizePool === BigInt(0)) {
+    return { status: "success" }
+  }
+
+  return { status: "pending" }
+}
+
 function readSessionInfo(
   runtime: Runtime<Config>,
   chainSelector: bigint,
@@ -166,10 +306,8 @@ function readSessionInfo(
 ): SessionInfo {
   const evmClient = new cre.capabilities.EVMClient(chainSelector)
 
-  // Read individual public state variables
   const contractAddress = evmConfig.contractAddress as `0x${string}`
-  
-  // Read isSessionActive (bool)
+
   const isActiveCall = encodeFunctionData({
     abi: [{ inputs: [], name: "isSessionActive", outputs: [{ type: "bool" }], stateMutability: "view", type: "function" }],
     functionName: "isSessionActive",
@@ -186,7 +324,6 @@ function readSessionInfo(
     data: bytesToHex(isActiveResult.data),
   }) as boolean
 
-  // Read lastSessionTime (uint256)
   const lastSessionTimeCall = encodeFunctionData({
     abi: [{ inputs: [], name: "lastSessionTime", outputs: [{ type: "uint256" }], stateMutability: "view", type: "function" }],
     functionName: "lastSessionTime",
@@ -203,7 +340,6 @@ function readSessionInfo(
     data: bytesToHex(lastSessionTimeResult.data),
   }) as bigint
 
-  // Read sessionInterval (uint256)
   const sessionIntervalCall = encodeFunctionData({
     abi: [{ inputs: [], name: "sessionInterval", outputs: [{ type: "uint256" }], stateMutability: "view", type: "function" }],
     functionName: "sessionInterval",
@@ -220,8 +356,6 @@ function readSessionInfo(
     data: bytesToHex(sessionIntervalResult.data),
   }) as bigint
 
-  // Read prize pool from the session-specific state variable (not total USDC balance,
-  // which includes pending withdrawals and platform fees)
   const currentSessionPrizePoolCall = encodeFunctionData({
     abi: [{ inputs: [], name: "currentSessionPrizePool", outputs: [{ type: "uint256" }], stateMutability: "view", type: "function" }],
     functionName: "currentSessionPrizePool",
@@ -238,7 +372,6 @@ function readSessionInfo(
     data: bytesToHex(prizePoolResult.data),
   }) as bigint
 
-  // Read player counts
   const getCurrentPlayersCall = encodeFunctionData({
     abi: [{ inputs: [], name: "getCurrentPlayers", outputs: [{ type: "address[]" }], stateMutability: "view", type: "function" }],
     functionName: "getCurrentPlayers",
@@ -255,7 +388,6 @@ function readSessionInfo(
     data: bytesToHex(playersResult.data),
   }) as `0x${string}`[]
 
-  // Read sessionCounter to verify if a session was actually started
   const sessionCounterCall = encodeFunctionData({
     abi: [{ inputs: [], name: "sessionCounter", outputs: [{ type: "uint256" }], stateMutability: "view", type: "function" }],
     functionName: "sessionCounter",
@@ -272,17 +404,11 @@ function readSessionInfo(
     data: bytesToHex(sessionCounterResult.data),
   }) as bigint
 
-  // Calculate session times
   const startTime = lastSessionTime
   const endTime = lastSessionTime + sessionInterval
   const paidPlayerCount = BigInt(players.length)
-  const trialPlayerCount = BigInt(0) // Not tracked separately in this contract version
-  
-  // Improved heuristic: Only assume prizes distributed if:
-  // 1. A session was actually started (sessionCounter > 0)
-  // 2. Session has ended (not active)
-  // 3. Prize pool is empty
-  // This distinguishes between "no activity yet" vs "prizes already distributed"
+  const trialPlayerCount = BigInt(0)
+
   const prizesDistributed = sessionCounter > BigInt(0) && !isActive && prizePool === BigInt(0)
 
   return {
@@ -293,12 +419,10 @@ function readSessionInfo(
     trialPlayerCount,
     isActive,
     prizesDistributed,
-    sessionCounter, // Include sessionCounter in return value
+    sessionCounter,
   }
 }
 
-// Verify that at least one player has a non-zero score submitted on-chain.
-// Without scores, _findTopPlayers() would return players in arbitrary order.
 function verifyScoresExist(
   runtime: Runtime<Config>,
   chainSelector: bigint,
@@ -307,7 +431,6 @@ function verifyScoresExist(
   const evmClient = new cre.capabilities.EVMClient(chainSelector)
   const contractAddress = evmConfig.contractAddress as `0x${string}`
 
-  // First get the current players list
   const getCurrentPlayersCall = encodeFunctionData({
     abi: [{ inputs: [], name: "getCurrentPlayers", outputs: [{ type: "address[]" }], stateMutability: "view", type: "function" }],
     functionName: "getCurrentPlayers",
@@ -329,13 +452,7 @@ function verifyScoresExist(
     return false
   }
 
-  // Check all players for scores. The contract caps at MAX_PLAYERS (100),
-  // and submitScores() sets all scores atomically, so if any player has a
-  // score they all should. We check all to be safe.
-  const playersToCheck = players
-  let hasAnyScore = false
-
-  for (const player of playersToCheck) {
+  for (const player of players) {
     const getScoreCall = encodeFunctionData({
       abi: [{ inputs: [{ name: "player", type: "address" }], name: "getPlayerScore", outputs: [{ type: "uint256" }], stateMutability: "view", type: "function" }],
       functionName: "getPlayerScore",
@@ -354,22 +471,15 @@ function verifyScoresExist(
     }) as bigint
 
     if (score > BigInt(0)) {
-      hasAnyScore = true
       runtime.log(`Player ${player} has score: ${score}`)
-      break
+      return true
     }
   }
 
-  if (!hasAnyScore) {
-    runtime.log(`Checked ${playersToCheck.length} players - no scores found`)
-  }
-
-  return hasAnyScore
+  runtime.log(`Checked ${players.length} players - no scores found`)
+  return false
 }
 
-// Call distributePrizes() on the contract
-// Note: This function uses onlyOwnerOrChainlink modifier, allowing Chainlink CRE to call it
-// The contract must have chainlinkOracle set to the CRE forwarder address
 function callDistributePrizes(
   runtime: Runtime<Config>,
   chainSelector: bigint,
@@ -377,7 +487,6 @@ function callDistributePrizes(
 ): string {
   const evmClient = new cre.capabilities.EVMClient(chainSelector)
 
-  // Encode the distributePrizes() function call
   const callData = encodeFunctionData({
     abi: [
       {
@@ -391,7 +500,6 @@ function callDistributePrizes(
     functionName: "distributePrizes",
   })
 
-  // Generate a signed report for the transaction
   const reportResponse = runtime
     .report({
       encodedPayload: hexToBase64(callData),
@@ -401,8 +509,6 @@ function callDistributePrizes(
     })
     .result()
 
-  // Submit the report to the contract
-  // The contract must have chainlinkOracle set to the CRE forwarder address
   const writeResult = evmClient
     .writeReport(runtime, {
       receiver: evmConfig.contractAddress,

--- a/components/leaderboard/LiveRankings.tsx
+++ b/components/leaderboard/LiveRankings.tsx
@@ -116,7 +116,7 @@ export default function LiveRankings({
           </div>
           {sessionCounter > 0 && (
             <span className="text-xs text-gray-500 font-normal">
-              Week {sessionCounter}
+              Week {sessionCounter} — new week on next join
             </span>
           )}
           {isLoading && !entriesProp && (

--- a/components/leaderboard/TopEarners.tsx
+++ b/components/leaderboard/TopEarners.tsx
@@ -67,7 +67,7 @@ export default function TopEarners({
     <div className={`w-full ${className}`}>
       {sessionCounter > 0 && (
         <p className="text-gray-500 text-[10px] font-['Audiowide:Regular',_sans-serif] mb-2 text-center">
-          Week {sessionCounter} — resets after payout
+          Week {sessionCounter} — new week starts when the next player joins
           {isRefreshing && entries.length > 0 && (
             <span className="ml-1 text-purple-300">· updating</span>
           )}

--- a/lib/blockchain/onChainScoreSync.ts
+++ b/lib/blockchain/onChainScoreSync.ts
@@ -1,0 +1,75 @@
+import { createPublicClient, http, type PublicClient } from 'viem';
+import { base } from 'viem/chains';
+import { TRIVIA_ABI, TRIVIA_CONTRACT_ADDRESS } from '@/lib/blockchain/contracts';
+
+const BASE_RPC = process.env.BASE_RPC_URL || 'https://mainnet.base.org';
+
+export type OnChainPlayerScore = {
+  address: `0x${string}`;
+  score: bigint;
+};
+
+export const createBasePublicClient = (): PublicClient =>
+  createPublicClient({ chain: base, transport: http(BASE_RPC) });
+
+export const readOnChainPlayerScores = async (
+  publicClient: PublicClient,
+  players: readonly `0x${string}`[],
+): Promise<OnChainPlayerScore[]> => {
+  const contract = TRIVIA_CONTRACT_ADDRESS as `0x${string}`;
+  const results: OnChainPlayerScore[] = [];
+
+  for (const address of players) {
+    const score = await publicClient.readContract({
+      address: contract,
+      abi: TRIVIA_ABI,
+      functionName: 'getPlayerScore',
+      args: [address],
+    });
+    results.push({ address, score: score as bigint });
+  }
+
+  return results;
+};
+
+/** True when every registered player has a non-zero on-chain score. */
+export const hasNonZeroOnChainScores = (scores: readonly OnChainPlayerScore[]): boolean =>
+  scores.length > 0 && scores.every((entry) => entry.score > BigInt(0));
+
+/**
+ * Idempotent guard for concurrent CRE DON nodes hitting the same admin endpoint.
+ * Skips owner writes when scores are already present on-chain.
+ */
+export const scoresAlreadySyncedOnChain = async (
+  publicClient: PublicClient,
+  players: readonly `0x${string}`[],
+): Promise<boolean> => {
+  if (players.length === 0) {
+    return true;
+  }
+  const onChain = await readOnChainPlayerScores(publicClient, players);
+  return hasNonZeroOnChainScores(onChain);
+};
+
+const sleep = (ms: number) => new Promise((resolve) => setTimeout(resolve, ms));
+
+/** Poll until on-chain scores appear or timeout (used after a sync tx). */
+export const waitForNonZeroOnChainScores = async (
+  publicClient: PublicClient,
+  players: readonly `0x${string}`[],
+  options: { attempts?: number; delayMs?: number } = {},
+): Promise<boolean> => {
+  const attempts = options.attempts ?? 8;
+  const delayMs = options.delayMs ?? 1500;
+
+  for (let attempt = 0; attempt < attempts; attempt++) {
+    if (await scoresAlreadySyncedOnChain(publicClient, players)) {
+      return true;
+    }
+    if (attempt < attempts - 1) {
+      await sleep(delayMs);
+    }
+  }
+
+  return false;
+};

--- a/lib/blockchain/pendingOnChainScoreRetry.ts
+++ b/lib/blockchain/pendingOnChainScoreRetry.ts
@@ -1,7 +1,6 @@
 import { submitOnChainScoreWithRetry } from '@/lib/blockchain/submitOnChainScore';
 
-const MAX_BACKGROUND_ATTEMPTS = 4;
-const BACKOFF_MS = [3000, 8000, 15000, 30000];
+const EXTENDED_RETRY_DELAYS_MS = [2000, 5000, 10000];
 
 const sleep = (ms: number) => new Promise((resolve) => setTimeout(resolve, ms));
 
@@ -12,38 +11,36 @@ export type PendingOnChainScoreParams = {
 };
 
 /**
- * Fire-and-forget retries after save-paid-score returns 202.
- * Runs in the API route process; does not block the HTTP response.
+ * Synchronous extended retries before save-paid-score returns 202.
+ * Safe for serverless — work completes within the request lifecycle.
  */
-export const schedulePendingOnChainScoreRetry = (params: PendingOnChainScoreParams): void => {
-  void (async () => {
-    for (let attempt = 0; attempt < MAX_BACKGROUND_ATTEMPTS; attempt++) {
-      await sleep(BACKOFF_MS[attempt] ?? 30000);
-      const result = await submitOnChainScoreWithRetry(
-        params.walletAddress,
-        params.score,
-        params.sessionId,
-      );
-      if (result.ok) {
-        console.info('[pendingOnChainScoreRetry] succeeded', {
-          wallet: params.walletAddress,
-          score: params.score,
-          attempt: attempt + 1,
-          tx: result.transactionHash,
-        });
-        return;
-      }
-      console.warn('[pendingOnChainScoreRetry] attempt failed', {
+export const retryOnChainScoreBeforeResponse = async (
+  params: PendingOnChainScoreParams,
+): Promise<{ ok: true; transactionHash: `0x${string}` } | { ok: false; error: string }> => {
+  let lastError = 'Unknown error';
+
+  for (const delayMs of EXTENDED_RETRY_DELAYS_MS) {
+    await sleep(delayMs);
+    const result = await submitOnChainScoreWithRetry(
+      params.walletAddress,
+      params.score,
+      params.sessionId,
+    );
+    if (result.ok) {
+      console.info('[retryOnChainScoreBeforeResponse] succeeded', {
         wallet: params.walletAddress,
         score: params.score,
-        attempt: attempt + 1,
-        error: result.error,
+        tx: result.transactionHash,
       });
+      return { ok: true, transactionHash: result.transactionHash };
     }
-    console.error('[pendingOnChainScoreRetry] exhausted retries', {
+    lastError = result.error;
+    console.warn('[retryOnChainScoreBeforeResponse] attempt failed', {
       wallet: params.walletAddress,
       score: params.score,
-      sessionId: params.sessionId,
+      error: result.error,
     });
-  })();
+  }
+
+  return { ok: false, error: lastError };
 };

--- a/lib/blockchain/pendingOnChainScoreRetry.ts
+++ b/lib/blockchain/pendingOnChainScoreRetry.ts
@@ -1,0 +1,49 @@
+import { submitOnChainScoreWithRetry } from '@/lib/blockchain/submitOnChainScore';
+
+const MAX_BACKGROUND_ATTEMPTS = 4;
+const BACKOFF_MS = [3000, 8000, 15000, 30000];
+
+const sleep = (ms: number) => new Promise((resolve) => setTimeout(resolve, ms));
+
+export type PendingOnChainScoreParams = {
+  walletAddress: string;
+  score: number;
+  sessionId?: string;
+};
+
+/**
+ * Fire-and-forget retries after save-paid-score returns 202.
+ * Runs in the API route process; does not block the HTTP response.
+ */
+export const schedulePendingOnChainScoreRetry = (params: PendingOnChainScoreParams): void => {
+  void (async () => {
+    for (let attempt = 0; attempt < MAX_BACKGROUND_ATTEMPTS; attempt++) {
+      await sleep(BACKOFF_MS[attempt] ?? 30000);
+      const result = await submitOnChainScoreWithRetry(
+        params.walletAddress,
+        params.score,
+        params.sessionId,
+      );
+      if (result.ok) {
+        console.info('[pendingOnChainScoreRetry] succeeded', {
+          wallet: params.walletAddress,
+          score: params.score,
+          attempt: attempt + 1,
+          tx: result.transactionHash,
+        });
+        return;
+      }
+      console.warn('[pendingOnChainScoreRetry] attempt failed', {
+        wallet: params.walletAddress,
+        score: params.score,
+        attempt: attempt + 1,
+        error: result.error,
+      });
+    }
+    console.error('[pendingOnChainScoreRetry] exhausted retries', {
+      wallet: params.walletAddress,
+      score: params.score,
+      sessionId: params.sessionId,
+    });
+  })();
+};

--- a/lib/blockchain/submitOnChainScore.ts
+++ b/lib/blockchain/submitOnChainScore.ts
@@ -39,39 +39,48 @@ const isRetryableOnChainError = (error: string): boolean => {
   );
 };
 
+const INLINE_RETRY_DELAYS_MS = [0, 2000, 5000];
+
 /**
- * Submit with one retry (~2s) on transient RPC / nonce failures.
+ * Submit with inline retries on transient RPC / nonce failures.
  */
 export async function submitOnChainScoreWithRetry(
   walletAddress: string,
   score: number,
   expectedSessionId?: string,
 ): Promise<SubmitOnChainScoreResult> {
-  const first = await submitOnChainScore(walletAddress, score, expectedSessionId);
-  if (first.ok || !isRetryableOnChainError(first.error)) {
-    if (!first.ok) {
+  let lastError = 'Unknown error';
+
+  for (let attempt = 0; attempt < INLINE_RETRY_DELAYS_MS.length; attempt++) {
+    if (attempt > 0) {
+      await sleep(INLINE_RETRY_DELAYS_MS[attempt] ?? 5000);
+      console.warn('[submitOnChainScore] retrying after transient error:', lastError);
+    }
+
+    const result = await submitOnChainScore(walletAddress, score, expectedSessionId);
+    if (result.ok) {
+      return result;
+    }
+
+    lastError = result.error;
+    if (!isRetryableOnChainError(result.error)) {
       console.warn('[submitOnChainScore] failed', {
         walletAddress,
         score,
         expectedSessionId,
-        error: first.error,
+        error: result.error,
       });
+      return result;
     }
-    return first;
   }
 
-  console.warn('[submitOnChainScore] retrying after transient error:', first.error);
-  await sleep(2000);
-  const second = await submitOnChainScore(walletAddress, score, expectedSessionId);
-  if (!second.ok) {
-    console.warn('[submitOnChainScore] retry failed', {
-      walletAddress,
-      score,
-      expectedSessionId,
-      error: second.error,
-    });
-  }
-  return second;
+  console.warn('[submitOnChainScore] inline retries exhausted', {
+    walletAddress,
+    score,
+    expectedSessionId,
+    error: lastError,
+  });
+  return { ok: false, error: lastError };
 }
 
 /**

--- a/lib/game/weeklyPayoutStatus.ts
+++ b/lib/game/weeklyPayoutStatus.ts
@@ -1,0 +1,90 @@
+export type WeeklyPayoutPhase =
+  | 'loading'
+  | 'counting_down'
+  | 'awaiting_score_sync'
+  | 'payout_pending'
+  | 'session_complete'
+  | 'next_session_soon';
+
+export type WeeklyPayoutStatus = {
+  phase: WeeklyPayoutPhase;
+  timerLabel: string;
+  weekSubtitle: string;
+};
+
+type WeeklyPayoutStatusInput = {
+  isLoading: boolean;
+  isSessionActive: boolean;
+  sessionPrizePool: number;
+  countdownExpired: boolean;
+  hasOnChainScores: boolean;
+  sessionCounter: number;
+};
+
+export const getWeeklyPayoutStatus = ({
+  isLoading,
+  isSessionActive,
+  sessionPrizePool,
+  countdownExpired,
+  hasOnChainScores,
+  sessionCounter,
+}: WeeklyPayoutStatusInput): WeeklyPayoutStatus => {
+  if (isLoading) {
+    return {
+      phase: 'loading',
+      timerLabel: 'Loading...',
+      weekSubtitle: '',
+    };
+  }
+
+  const weekSubtitle =
+    sessionCounter > 0
+      ? `Week ${sessionCounter} — new week starts when the next player joins`
+      : '';
+
+  if (!isSessionActive && sessionPrizePool <= 0) {
+    return {
+      phase: 'next_session_soon',
+      timerLabel: 'NEXT SESSION OPENS SOON',
+      weekSubtitle,
+    };
+  }
+
+  if (!isSessionActive && sessionPrizePool > 0) {
+    return {
+      phase: 'payout_pending',
+      timerLabel: 'WEEKLY PAYOUT PENDING',
+      weekSubtitle,
+    };
+  }
+
+  if (isSessionActive && countdownExpired) {
+    if (sessionPrizePool > 0 && !hasOnChainScores) {
+      return {
+        phase: 'awaiting_score_sync',
+        timerLabel: 'AWAITING SCORE SYNC',
+        weekSubtitle,
+      };
+    }
+
+    return {
+      phase: 'payout_pending',
+      timerLabel: 'PAYOUT PROCESSING',
+      weekSubtitle,
+    };
+  }
+
+  if (isSessionActive) {
+    return {
+      phase: 'counting_down',
+      timerLabel: '',
+      weekSubtitle,
+    };
+  }
+
+  return {
+    phase: 'session_complete',
+    timerLabel: 'WEEK COMPLETE',
+    weekSubtitle,
+  };
+};

--- a/lib/utils/safeErrorMessage.ts
+++ b/lib/utils/safeErrorMessage.ts
@@ -1,0 +1,19 @@
+/**
+ * Serialize errors for API responses without throwing on circular structures.
+ */
+export const safeErrorMessage = (error: unknown): string => {
+  if (error instanceof Error) {
+    return error.message;
+  }
+  if (typeof error === 'string') {
+    return error;
+  }
+  if (typeof error === 'object' && error !== null) {
+    try {
+      return JSON.stringify(error);
+    } catch {
+      return Object.prototype.toString.call(error);
+    }
+  }
+  return String(error);
+};

--- a/scripts/debug_contract_state.ts
+++ b/scripts/debug_contract_state.ts
@@ -1,58 +1,148 @@
 import { createPublicClient, http, formatUnits } from 'viem';
 import { base } from 'viem/chains';
-import { TRIVIA_CONTRACT_ADDRESS } from '../lib/blockchain/contracts';
+import { TRIVIA_ABI, TRIVIA_CONTRACT_ADDRESS } from '../lib/blockchain/contracts';
 
-const MINIMAL_ABI = [
-    { inputs: [], name: 'isSessionActive', outputs: [{ type: 'bool' }], stateMutability: 'view', type: 'function' },
-    { inputs: [], name: 'sessionCounter', outputs: [{ type: 'uint256' }], stateMutability: 'view', type: 'function' },
-    { inputs: [], name: 'entryFee', outputs: [{ type: 'uint256' }], stateMutability: 'view', type: 'function' },
-    { inputs: [], name: 'lastSessionTime', outputs: [{ type: 'uint256' }], stateMutability: 'view', type: 'function' },
-    { inputs: [], name: 'sessionInterval', outputs: [{ type: 'uint256' }], stateMutability: 'view', type: 'function' },
-];
+const KEYSTONE_FORWARDER = '0xF8344CFd5c43616a4366C34E3EEE75af79a74482';
+
+const RPC_URL =
+  process.env.BASE_RPC_URL ||
+  process.env.NEXT_PUBLIC_BASE_RPC_URL ||
+  'https://mainnet.base.org';
 
 const publicClient = createPublicClient({
-    chain: base,
-    transport: http(process.env.NEXT_PUBLIC_BASE_RPC_URL || (() => { throw new Error('NEXT_PUBLIC_BASE_RPC_URL is required. Set it in .env'); })()),
+  chain: base,
+  transport: http(RPC_URL),
 });
 
+type CreSkipReason =
+  | 'none_ready_to_distribute'
+  | 'no_session_started'
+  | 'session_still_active'
+  | 'prizes_already_distributed'
+  | 'empty_prize_pool'
+  | 'no_on_chain_scores';
+
+const evaluateCreSkip = (params: {
+  sessionCounter: bigint;
+  isSessionActive: boolean;
+  prizePool: bigint;
+  endTime: bigint;
+  hasOnChainScores: boolean;
+  now: bigint;
+}): CreSkipReason => {
+  const { sessionCounter, isSessionActive, prizePool, endTime, hasOnChainScores, now } = params;
+  const isSessionEnded = !isSessionActive || now > endTime;
+  const prizesDistributedHeuristic =
+    sessionCounter > BigInt(0) && !isSessionActive && prizePool === BigInt(0);
+
+  if (sessionCounter === BigInt(0)) return 'no_session_started';
+  if (!isSessionEnded) return 'session_still_active';
+  if (prizesDistributedHeuristic) return 'prizes_already_distributed';
+  if (prizePool === BigInt(0)) return 'empty_prize_pool';
+  if (!hasOnChainScores) return 'no_on_chain_scores';
+  return 'none_ready_to_distribute';
+};
+
+const formatTimestamp = (ts: bigint): string => {
+  if (ts === BigInt(0)) return 'never';
+  return new Date(Number(ts) * 1000).toISOString();
+};
+
 async function main() {
-    console.log('🔍 Debugging Contract State');
-    console.log('Contract Address:', TRIVIA_CONTRACT_ADDRESS);
+  const contract = TRIVIA_CONTRACT_ADDRESS as `0x${string}`;
+  console.log('BEATME weekly payout diagnostics');
+  console.log('Contract:', contract);
+  console.log('RPC:', RPC_URL);
+  console.log('');
 
-    try {
-        const code = await publicClient.getBytecode({ address: TRIVIA_CONTRACT_ADDRESS as `0x${string}` });
-        if (!code || code === '0x') {
-            console.error('❌ CRITICAL: No contract code found at address!');
-            return;
-        }
-        console.log('✅ Contract code exists.');
+  const code = await publicClient.getBytecode({ address: contract });
+  if (!code || code === '0x') {
+    console.error('No contract bytecode at address');
+    process.exit(1);
+  }
 
-        const abi = MINIMAL_ABI;
+  const [
+    isSessionActive,
+    sessionCounter,
+    entryFee,
+    lastSessionTime,
+    sessionInterval,
+    prizePool,
+    players,
+    chainlinkOracle,
+  ] = await Promise.all([
+    publicClient.readContract({ address: contract, abi: TRIVIA_ABI, functionName: 'isSessionActive' }),
+    publicClient.readContract({ address: contract, abi: TRIVIA_ABI, functionName: 'sessionCounter' }),
+    publicClient.readContract({ address: contract, abi: TRIVIA_ABI, functionName: 'entryFee' }),
+    publicClient.readContract({ address: contract, abi: TRIVIA_ABI, functionName: 'lastSessionTime' }),
+    publicClient.readContract({ address: contract, abi: TRIVIA_ABI, functionName: 'sessionInterval' }),
+    publicClient.readContract({ address: contract, abi: TRIVIA_ABI, functionName: 'currentSessionPrizePool' }),
+    publicClient.readContract({ address: contract, abi: TRIVIA_ABI, functionName: 'getCurrentPlayers' }),
+    publicClient.readContract({ address: contract, abi: TRIVIA_ABI, functionName: 'chainlinkOracle' }),
+  ]);
 
-        const isSessionActive = await publicClient.readContract({
-            address: TRIVIA_CONTRACT_ADDRESS as `0x${string}`,
-            abi,
-            functionName: 'isSessionActive',
-        });
-        console.log('ℹ️ isSessionActive:', isSessionActive);
+  const endTime = (lastSessionTime as bigint) + (sessionInterval as bigint);
+  const now = BigInt(Math.floor(Date.now() / 1000));
 
-        const sessionCounter = await publicClient.readContract({
-            address: TRIVIA_CONTRACT_ADDRESS as `0x${string}`,
-            abi,
-            functionName: 'sessionCounter',
-        });
-        console.log('ℹ️ sessionCounter:', (sessionCounter as bigint).toString());
+  console.log('--- Session ---');
+  console.log('sessionCounter:', sessionCounter.toString());
+  console.log('isSessionActive:', isSessionActive);
+  console.log('entryFee:', formatUnits(entryFee as bigint, 6), 'USDC');
+  console.log('lastSessionTime:', formatTimestamp(lastSessionTime as bigint));
+  console.log('sessionInterval:', (sessionInterval as bigint).toString(), 'seconds');
+  console.log('sessionEndTime:', formatTimestamp(endTime));
+  console.log('currentSessionPrizePool:', formatUnits(prizePool as bigint, 6), 'USDC');
+  console.log('');
 
-        const entryFee = await publicClient.readContract({
-            address: TRIVIA_CONTRACT_ADDRESS as `0x${string}`,
-            abi,
-            functionName: 'entryFee',
-        });
-        console.log('ℹ️ entryFee:', formatUnits(entryFee as bigint, 6), 'USDC');
+  console.log('--- CRE wiring ---');
+  const oracle = (chainlinkOracle as string).toLowerCase();
+  const expected = KEYSTONE_FORWARDER.toLowerCase();
+  console.log('chainlinkOracle:', chainlinkOracle);
+  console.log(
+    oracle === expected ? 'OK: matches Keystone forwarder' : 'WARN: oracle mismatch — CRE onReport may revert',
+  );
+  console.log('');
 
-    } catch (error) {
-        console.error('❌ Error querying contract:', error);
+  console.log('--- Players & scores ---');
+  const playerList = players as `0x${string}`[];
+  if (playerList.length === 0) {
+    console.log('No players registered in current session');
+  } else {
+    let hasOnChainScores = false;
+    for (const player of playerList) {
+      const score = await publicClient.readContract({
+        address: contract,
+        abi: TRIVIA_ABI,
+        functionName: 'getPlayerScore',
+        args: [player],
+      });
+      if ((score as bigint) > BigInt(0)) hasOnChainScores = true;
+      console.log(`  ${player} score=${score.toString()}`);
     }
+
+    const skipReason = evaluateCreSkip({
+      sessionCounter: sessionCounter as bigint,
+      isSessionActive: isSessionActive as boolean,
+      prizePool: prizePool as bigint,
+      endTime,
+      hasOnChainScores,
+      now,
+    });
+
+    console.log('');
+    console.log('--- CRE weekly-prize-dist-prod prediction ---');
+    if (skipReason === 'none_ready_to_distribute') {
+      console.log('Would EXECUTE distributePrizes() on next Sunday cron (or manual owner call now)');
+    } else {
+      console.log(`Would SKIP distribution: ${skipReason}`);
+      if (skipReason === 'no_on_chain_scores') {
+        console.log('Fix: POST /api/submit-onchain-scores then distributePrizes()');
+      }
+    }
+  }
 }
 
-main();
+main().catch((error) => {
+  console.error(error);
+  process.exit(1);
+});

--- a/scripts/unblock-weekly-payout.ts
+++ b/scripts/unblock-weekly-payout.ts
@@ -1,0 +1,189 @@
+#!/usr/bin/env npx tsx
+/**
+ * Unblock a stuck weekly payout: sync Spacetime scores on-chain, then distribute prizes.
+ *
+ * Requires:
+ *   ADMIN_API_SECRET
+ *   CONTRACT_OWNER_PRIVATE_KEY (or PRIVATE_KEY)
+ *   BASE_RPC_URL (optional)
+ *   APP_URL (optional, default production)
+ */
+import { createPublicClient, createWalletClient, http, formatUnits } from 'viem';
+import { privateKeyToAccount } from 'viem/accounts';
+import { base } from 'viem/chains';
+import { TRIVIA_ABI, TRIVIA_CONTRACT_ADDRESS } from '../lib/blockchain/contracts';
+import { spacetimeClient } from '../lib/apis/spacetime';
+import { submitScoresOnChain } from '../lib/blockchain/submitScoresOnChain';
+
+const APP_URL = process.env.APP_URL || 'https://beatme.creativeplatform.xyz';
+const RPC = process.env.BASE_RPC_URL || process.env.NEXT_PUBLIC_BASE_RPC_URL || 'https://mainnet.base.org';
+
+const getOwnerKey = (): string => {
+  const key = process.env.CONTRACT_OWNER_PRIVATE_KEY || process.env.PRIVATE_KEY;
+  if (!key) {
+    throw new Error('CONTRACT_OWNER_PRIVATE_KEY or PRIVATE_KEY is required');
+  }
+  return key.startsWith('0x') ? key : `0x${key}`;
+};
+
+const parseScoreOverrides = (): Map<string, bigint> => {
+  const overrides = new Map<string, bigint>();
+  for (const arg of process.argv) {
+    if (!arg.startsWith('--score=')) continue;
+    const payload = arg.slice('--score='.length);
+    const [wallet, scoreText] = payload.split(':');
+    if (!wallet || !scoreText) continue;
+    overrides.set(wallet.toLowerCase(), BigInt(scoreText));
+  }
+  return overrides;
+};
+
+async function syncScoresLocal(): Promise<void> {
+  const scoreOverrides = parseScoreOverrides();
+  const publicClient = createPublicClient({ chain: base, transport: http(RPC) });
+  const players = (await publicClient.readContract({
+    address: TRIVIA_CONTRACT_ADDRESS as `0x${string}`,
+    abi: TRIVIA_ABI,
+    functionName: 'getCurrentPlayers',
+  })) as `0x${string}`[];
+
+  if (players.length === 0) {
+    console.log('No on-chain players to sync');
+    return;
+  }
+
+  await spacetimeClient.ensurePlayerDataReady();
+
+  const addresses: `0x${string}`[] = [];
+  const scores: bigint[] = [];
+
+  for (const addr of players) {
+    const override = scoreOverrides.get(addr.toLowerCase());
+    const profile = spacetimeClient.getPlayerProfile(addr);
+    const score =
+      override ??
+      (profile
+        ? BigInt(profile.weeklyBestScore > 0 ? profile.weeklyBestScore : profile.bestScore)
+        : BigInt(0));
+    addresses.push(addr);
+    scores.push(score);
+    console.log(`  ${addr} score=${score.toString()}${override !== undefined ? ' (override)' : ''}`);
+  }
+
+  const txHash = await submitScoresOnChain(addresses, scores);
+  if (!txHash) {
+    throw new Error('submitScoresOnChain returned null (session inactive or missing owner key)');
+  }
+
+  const receipt = await publicClient.waitForTransactionReceipt({ hash: txHash as `0x${string}` });
+  if (receipt.status !== 'success') {
+    throw new Error(`submitScores failed: ${txHash}`);
+  }
+  console.log('submitScores tx:', txHash);
+}
+
+async function syncScores(): Promise<void> {
+  const adminSecret = process.env.ADMIN_API_SECRET;
+  if (!adminSecret) {
+    throw new Error('ADMIN_API_SECRET is required for score sync');
+  }
+
+  const res = await fetch(`${APP_URL}/api/submit-onchain-scores`, {
+    method: 'POST',
+    headers: {
+      Authorization: `Bearer ${adminSecret}`,
+      'Content-Type': 'application/json',
+    },
+  });
+
+  const body = await res.json().catch(() => ({}));
+  console.log('Score sync response:', res.status, body);
+
+  if (!res.ok) {
+    throw new Error(`Score sync failed: ${res.status} ${JSON.stringify(body)}`);
+  }
+}
+
+async function distributePrizes(): Promise<`0x${string}`> {
+  const account = privateKeyToAccount(getOwnerKey() as `0x${string}`);
+  const publicClient = createPublicClient({ chain: base, transport: http(RPC) });
+  const walletClient = createWalletClient({
+    account,
+    chain: base,
+    transport: http(RPC),
+  });
+
+  const hash = await walletClient.writeContract({
+    address: TRIVIA_CONTRACT_ADDRESS as `0x${string}`,
+    abi: TRIVIA_ABI,
+    functionName: 'distributePrizes',
+  });
+
+  const receipt = await publicClient.waitForTransactionReceipt({ hash });
+  if (receipt.status !== 'success') {
+    throw new Error(`distributePrizes reverted: ${hash}`);
+  }
+
+  return hash;
+}
+
+async function printState(label: string): Promise<void> {
+  const publicClient = createPublicClient({ chain: base, transport: http(RPC) });
+  const contract = TRIVIA_CONTRACT_ADDRESS as `0x${string}`;
+
+  const [pool, active, counter, players] = await Promise.all([
+    publicClient.readContract({ address: contract, abi: TRIVIA_ABI, functionName: 'currentSessionPrizePool' }),
+    publicClient.readContract({ address: contract, abi: TRIVIA_ABI, functionName: 'isSessionActive' }),
+    publicClient.readContract({ address: contract, abi: TRIVIA_ABI, functionName: 'sessionCounter' }),
+    publicClient.readContract({ address: contract, abi: TRIVIA_ABI, functionName: 'getCurrentPlayers' }),
+  ]);
+
+  console.log(`\n--- ${label} ---`);
+  console.log('sessionCounter:', counter.toString());
+  console.log('isSessionActive:', active);
+  console.log('prizePool:', formatUnits(pool, 6), 'USDC');
+  for (const player of players as `0x${string}`[]) {
+    const score = await publicClient.readContract({
+      address: contract,
+      abi: TRIVIA_ABI,
+      functionName: 'getPlayerScore',
+      args: [player],
+    });
+    console.log(`  ${player} score=${score.toString()}`);
+  }
+}
+
+async function main() {
+  const skipSync = process.argv.includes('--skip-sync');
+  const skipDistribute = process.argv.includes('--skip-distribute');
+  const useLocalSync = process.argv.includes('--local') || !process.env.ADMIN_API_SECRET;
+
+  console.log('Unblock weekly payout');
+  console.log('Contract:', TRIVIA_CONTRACT_ADDRESS);
+  console.log('App:', APP_URL);
+  console.log('Score sync mode:', useLocalSync ? 'local (SpacetimeDB + owner tx)' : 'remote API');
+
+  await printState('Before');
+
+  if (!skipSync) {
+    console.log('\nStep 1: Syncing scores...');
+    if (useLocalSync) {
+      await syncScoresLocal();
+    } else {
+      await syncScores();
+    }
+  }
+
+  if (!skipDistribute) {
+    console.log('\nStep 2: Calling distributePrizes() as owner...');
+    const tx = await distributePrizes();
+    console.log('distributePrizes tx:', tx);
+  }
+
+  await printState('After');
+}
+
+main().catch((error) => {
+  console.error(error);
+  process.exit(1);
+});

--- a/tests/safe-error-message.test.ts
+++ b/tests/safe-error-message.test.ts
@@ -1,0 +1,20 @@
+/**
+ * safeErrorMessage tests — run with: npx tsx --test tests/safe-error-message.test.ts
+ */
+
+import assert from 'node:assert/strict';
+import { describe, it } from 'node:test';
+import { safeErrorMessage } from '../lib/utils/safeErrorMessage';
+
+describe('safeErrorMessage', () => {
+  it('returns Error.message', () => {
+    assert.equal(safeErrorMessage(new Error('boom')), 'boom');
+  });
+
+  it('does not throw on circular objects', () => {
+    const circular: { self?: unknown } = {};
+    circular.self = circular;
+    const message = safeErrorMessage(circular);
+    assert.ok(message.length > 0);
+  });
+});

--- a/tests/weekly-payout-status.test.ts
+++ b/tests/weekly-payout-status.test.ts
@@ -1,0 +1,47 @@
+/**
+ * Weekly payout status labels — run with: npx tsx --test tests/weekly-payout-status.test.ts
+ */
+
+import assert from 'node:assert/strict';
+import { describe, it } from 'node:test';
+import { getWeeklyPayoutStatus } from '../lib/game/weeklyPayoutStatus';
+
+describe('getWeeklyPayoutStatus', () => {
+  it('shows awaiting score sync when interval elapsed without on-chain scores', () => {
+    const status = getWeeklyPayoutStatus({
+      isLoading: false,
+      isSessionActive: true,
+      sessionPrizePool: 8,
+      countdownExpired: true,
+      hasOnChainScores: false,
+      sessionCounter: 1,
+    });
+    assert.equal(status.phase, 'awaiting_score_sync');
+    assert.equal(status.timerLabel, 'AWAITING SCORE SYNC');
+  });
+
+  it('shows payout processing when scores exist but pool remains', () => {
+    const status = getWeeklyPayoutStatus({
+      isLoading: false,
+      isSessionActive: true,
+      sessionPrizePool: 8,
+      countdownExpired: true,
+      hasOnChainScores: true,
+      sessionCounter: 1,
+    });
+    assert.equal(status.phase, 'payout_pending');
+    assert.equal(status.timerLabel, 'PAYOUT PROCESSING');
+  });
+
+  it('uses accurate week subtitle', () => {
+    const status = getWeeklyPayoutStatus({
+      isLoading: false,
+      isSessionActive: false,
+      sessionPrizePool: 0,
+      countdownExpired: true,
+      hasOnChainScores: false,
+      sessionCounter: 1,
+    });
+    assert.ok(status.weekSubtitle.includes('new week starts when the next player joins'));
+  });
+});


### PR DESCRIPTION
## Summary
- Hardens the CRE weekly distribution workflow to sync SpacetimeDB scores before distributing, verify tx receipts, and return explicit skip/distributed/failed outcomes.
- Improves score sync reliability (weekly score field fix, inline retries, background retry after save-paid-score failures).
- Adds payout diagnostics/unblock scripts and clearer UI labels for pending weekly settlement.

## Test plan
- [ ] Run `npx tsx --env-file=.env.local scripts/debug_contract_state.ts` and confirm CRE skip reason is reported
- [ ] Run `npx tsx --test tests/weekly-payout-status.test.ts`
- [ ] Deploy app, then `POST /api/submit-onchain-scores` with admin auth and verify non-zero scores on-chain
- [ ] Run `scripts/unblock-weekly-payout.ts` or owner `distributePrizes()` and confirm pool clears + `PrizesDistributed` event
- [ ] Redeploy CRE workflow with `ADMIN_API_SECRET` secret and confirm Sunday run syncs scores before distribution


Made with [Cursor](https://cursor.com)