### PR TITLE
Simplify weekly leaderboard week label

### DIFF
--- a/components/leaderboard/TopEarners.tsx
+++ b/components/leaderboard/TopEarners.tsx
@@ -67,7 +67,7 @@ export default function TopEarners({
     <div className={`w-full ${className}`}>
       {sessionCounter > 0 && (
         <p className="text-gray-500 text-[10px] font-['Audiowide:Regular',_sans-serif] mb-2 text-center">
-          Week {sessionCounter} — resets after payout
+          Week {sessionCounter}
           {isRefreshing && entries.length > 0 && (
             <span className="ml-1 text-purple-300">· updating</span>
           )}


### PR DESCRIPTION
## Summary
- Remove the "— resets after payout" suffix from the weekly leaderboard header in `TopEarners`
- The label now shows only `Week {sessionCounter}` (e.g. "Week 1")

## Test plan
- [ ] Open the home page TOP SCORES section
- [ ] Confirm the header reads "Week 1" (or current session number) without the payout reset suffix
- [ ] Verify leaderboard entries still load and display correctly


Made with [Cursor](https://cursor.com)