### PR TITLE
Fix viem PublicClient type mismatch in on-chain score sync

### DIFF
--- a/app/api/submit-onchain-scores/route.ts
+++ b/app/api/submit-onchain-scores/route.ts
@@ -1,10 +1,10 @@
 import { NextRequest, NextResponse } from 'next/server';
-import { createPublicClient, http, type Hash } from 'viem';
-import { base } from 'viem/chains';
+import { type Hash } from 'viem';
 import { checkAdminAuth } from '@/lib/utils/adminAuthMiddleware';
 import { spacetimeClient } from '@/lib/apis/spacetime';
 import { submitScoresOnChain } from '@/lib/blockchain/submitScoresOnChain';
 import {
+  createBasePublicClient,
   readOnChainPlayerScores,
   scoresAlreadySyncedOnChain,
   waitForNonZeroOnChainScores,
@@ -24,8 +24,6 @@ import { safeErrorMessage } from '@/lib/utils/safeErrorMessage';
  *   - CONTRACT_OWNER_PRIVATE_KEY env var (or PRIVATE_KEY fallback)
  */
 
-const BASE_RPC = process.env.BASE_RPC_URL || 'https://mainnet.base.org';
-
 export async function POST(req: NextRequest) {
   const authError = checkAdminAuth(req);
   if (authError) return authError;
@@ -39,7 +37,7 @@ export async function POST(req: NextRequest) {
   }
 
   try {
-    const publicClient = createPublicClient({ chain: base, transport: http(BASE_RPC) });
+    const publicClient = createBasePublicClient();
 
     const players = (await publicClient.readContract({
       address: TRIVIA_CONTRACT_ADDRESS as `0x${string}`,

--- a/lib/blockchain/onChainScoreSync.ts
+++ b/lib/blockchain/onChainScoreSync.ts
@@ -4,16 +4,20 @@ import { TRIVIA_ABI, TRIVIA_CONTRACT_ADDRESS } from '@/lib/blockchain/contracts'
 
 const BASE_RPC = process.env.BASE_RPC_URL || 'https://mainnet.base.org';
 
+type ReadContractClient = Pick<PublicClient, 'readContract'>;
+
 export type OnChainPlayerScore = {
   address: `0x${string}`;
   score: bigint;
 };
 
-export const createBasePublicClient = (): PublicClient =>
+export const createBasePublicClient = () =>
   createPublicClient({ chain: base, transport: http(BASE_RPC) });
 
+export type BasePublicClient = ReturnType<typeof createBasePublicClient>;
+
 export const readOnChainPlayerScores = async (
-  publicClient: PublicClient,
+  publicClient: ReadContractClient,
   players: readonly `0x${string}`[],
 ): Promise<OnChainPlayerScore[]> => {
   const contract = TRIVIA_CONTRACT_ADDRESS as `0x${string}`;
@@ -41,7 +45,7 @@ export const hasNonZeroOnChainScores = (scores: readonly OnChainPlayerScore[]): 
  * Skips owner writes when scores are already present on-chain.
  */
 export const scoresAlreadySyncedOnChain = async (
-  publicClient: PublicClient,
+  publicClient: ReadContractClient,
   players: readonly `0x${string}`[],
 ): Promise<boolean> => {
   if (players.length === 0) {
@@ -55,7 +59,7 @@ const sleep = (ms: number) => new Promise((resolve) => setTimeout(resolve, ms));
 
 /** Poll until on-chain scores appear or timeout (used after a sync tx). */
 export const waitForNonZeroOnChainScores = async (
-  publicClient: PublicClient,
+  publicClient: ReadContractClient,
   players: readonly `0x${string}`[],
   options: { attempts?: number; delayMs?: number } = {},
 ): Promise<boolean> => {


### PR DESCRIPTION
## Summary
- Narrow `onChainScoreSync` helpers to `Pick<PublicClient, 'readContract'>` so Base-scoped viem clients compile during Next.js type checking.
- Reuse `createBasePublicClient()` in the submit-onchain-scores admin route instead of duplicating client setup.

## Test plan
- [x] `pnpm exec tsc --noEmit`
- [x] `pnpm run build`
- [ ] Confirm Vercel preview build passes for this branch


Made with [Cursor](https://cursor.com)