### PR TITLE
Fix Vercel build: add @radix-ui/react-slot

### DIFF
--- a/package.json
+++ b/package.json
@@ -65,6 +65,7 @@
     "@radix-ui/react-select": "^2.2.6",
     "@radix-ui/react-separator": "^1.1.7",
     "@radix-ui/react-slider": "^1.3.6",
+    "@radix-ui/react-slot": "^1.3.0",
     "@radix-ui/react-switch": "^1.2.6",
     "@radix-ui/react-tabs": "^1.1.13",
     "@radix-ui/react-toggle": "^1.1.10",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -89,6 +89,9 @@ importers:
       '@radix-ui/react-slider':
         specifier: ^1.3.6
         version: 1.4.1(@types/react-dom@18.3.7(@types/react@18.3.31))(@types/react@18.3.31)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
+      '@radix-ui/react-slot':
+        specifier: ^1.3.0
+        version: 1.3.0(@types/react@18.3.31)(react@19.2.7)
       '@radix-ui/react-switch':
         specifier: ^1.2.6
         version: 1.3.1(@types/react-dom@18.3.7(@types/react@18.3.31))(@types/react@18.3.31)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)


### PR DESCRIPTION
## Summary
- Adds `@radix-ui/react-slot` as a direct dependency so pnpm can resolve imports from shadcn UI components (`button`, `form`, `breadcrumb`, `sidebar`).
- Fixes the Vercel type-check failure: `Cannot find module '@radix-ui/react-slot'`.

## Test plan
- [x] `pnpm install`
- [x] `pnpm run build` passes locally
- [ ] Vercel preview deployment succeeds


Made with [Cursor](https://cursor.com)