### PR TITLE
Improve paid game UX, leaderboard reliability, and celebration

### DIFF
--- a/app/api/save-paid-score/route.ts
+++ b/app/api/save-paid-score/route.ts
@@ -3,8 +3,9 @@ import { spacetimeClient } from '@/lib/apis/spacetime';
 import { verifyEntryToken } from '@/lib/utils/jwt';
 import { finalizePaidScoreLedger } from '@/lib/game/paidScoreLedger';
 import { verifyScoreReceipt } from '@/lib/game/scoreReceipt';
-import { submitOnChainScoreWithRetry } from '@/lib/blockchain/submitOnChainScore';
+import { submitOnChainScoreWithRetry, readOnChainSessionCounter } from '@/lib/blockchain/submitOnChainScore';
 import { retryOnChainScoreBeforeResponse } from '@/lib/blockchain/pendingOnChainScoreRetry';
+import { resolveAuthoritativeSessionId } from '@/lib/game/weeklyLeaderboard';
 
 const MAX_GAME_SCORE = 3000;
 
@@ -100,6 +101,13 @@ export async function POST(req: NextRequest) {
       onChainSessionId = finalized.onChainSessionId;
     }
 
+    const liveSessionCounter = Number(await readOnChainSessionCounter());
+    const authoritativeSessionId = resolveAuthoritativeSessionId(
+      onChainSessionId,
+      liveSessionCounter,
+    );
+    onChainSessionId = authoritativeSessionId;
+
     let spacetimeUpdated = false;
 
     await spacetimeClient.ensurePlayerDataReady();
@@ -150,6 +158,7 @@ export async function POST(req: NextRequest) {
           onChainSessionId,
           spacetimeUpdated,
           onChainSubmitted: true,
+          leaderboardReady: true,
           transactionHash: extendedRetry.transactionHash,
           retried: true,
         });
@@ -162,6 +171,7 @@ export async function POST(req: NextRequest) {
           onChainSessionId,
           spacetimeUpdated,
           onChainSubmitted: false,
+          leaderboardReady: false,
           onChainError: onChainResult.error,
           warning:
             'Score saved but the weekly leaderboard update failed. Your score may not appear until retried.',
@@ -176,6 +186,7 @@ export async function POST(req: NextRequest) {
       onChainSessionId,
       spacetimeUpdated,
       onChainSubmitted: true,
+      leaderboardReady: true,
       transactionHash: onChainResult.transactionHash,
       sessionCounter: onChainResult.sessionCounter.toString(),
     });

--- a/app/api/save-paid-score/route.ts
+++ b/app/api/save-paid-score/route.ts
@@ -101,7 +101,15 @@ export async function POST(req: NextRequest) {
       onChainSessionId = finalized.onChainSessionId;
     }
 
-    const liveSessionCounter = Number(await readOnChainSessionCounter());
+    let liveSessionCounter = 0;
+    try {
+      liveSessionCounter = Number(await readOnChainSessionCounter());
+    } catch (rpcErr) {
+      console.warn(
+        'Could not read live sessionCounter; falling back to entry token session id:',
+        rpcErr,
+      );
+    }
     const authoritativeSessionId = resolveAuthoritativeSessionId(
       onChainSessionId,
       liveSessionCounter,

--- a/app/game/page.tsx
+++ b/app/game/page.tsx
@@ -369,6 +369,7 @@ export default function Game() {
     setPaidScoreSaved(false);
     const wallet = address;
     const finalScore = totalScore;
+    let cancelled = false;
     void (async () => {
       try {
         const res = await fetch('/api/save-paid-score', {
@@ -376,6 +377,7 @@ export default function Game() {
           headers: { 'Content-Type': 'application/json' },
           body: JSON.stringify({ walletAddress: wallet, finalScore, entryToken }),
         });
+        if (cancelled) return;
         if (!res.ok) {
           paidScoreSavedRef.current = false;
           setPaidScoreSaved(false);
@@ -385,6 +387,7 @@ export default function Game() {
           return;
         }
         const data = await res.json();
+        if (cancelled) return;
         const persisted = Boolean(data.spacetimeUpdated || data.onChainSubmitted);
         if (!persisted) {
           paidScoreSavedRef.current = false;
@@ -406,17 +409,22 @@ export default function Game() {
           setPaidScoreWarning(null);
         }
         for (let attempt = 0; attempt < 5; attempt++) {
+          if (cancelled) return;
           refreshWeeklyLeaderboard();
           if (attempt < 4) {
             await new Promise((resolve) => setTimeout(resolve, 2000));
           }
         }
       } catch {
+        if (cancelled) return;
         paidScoreSavedRef.current = false;
         setPaidScoreSaved(false);
         setPaidScoreWarning('Score could not be saved to the leaderboard.');
       }
     })();
+    return () => {
+      cancelled = true;
+    };
   }, [gameCompleted, isGuestMode, sessionIsTrial, address, totalScore, entryToken, refreshWeeklyLeaderboard]);
 
   // Show guest mode entry screen first

--- a/app/game/page.tsx
+++ b/app/game/page.tsx
@@ -50,7 +50,7 @@ export default function Game() {
   const [showGuestMode, setShowGuestMode] = useState(true);
   const [pendingGuestSync, setPendingGuestSync] = useState<{score: number, gameData: any} | null>(null);
   const timerTriggeredRef = useRef(false);
-  const { entries: weeklyLeaderboardEntries } = useWeeklyLeaderboard(10);
+  const { entries: weeklyLeaderboardEntries, refresh: refreshWeeklyLeaderboard } = useWeeklyLeaderboard(10);
   const weeklyHighScore =
     weeklyLeaderboardEntries.length > 0
       ? Math.max(...weeklyLeaderboardEntries.map((e) => e.bestScore))
@@ -61,6 +61,7 @@ export default function Game() {
   const { address } = useBaseAccount();
   const paidScoreSavedRef = useRef(false);
   const [paidScoreSaved, setPaidScoreSaved] = useState(false);
+  const [paidScoreWarning, setPaidScoreWarning] = useState<string | null>(null);
   const [verifiedCorrectAnswer, setVerifiedCorrectAnswer] = useState<number | null>(null);
   const [isVerifying, setIsVerifying] = useState(false);
 
@@ -378,20 +379,50 @@ export default function Game() {
         if (!res.ok) {
           paidScoreSavedRef.current = false;
           setPaidScoreSaved(false);
+          const errText = await res.text();
+          setPaidScoreWarning('Score could not be saved to the leaderboard.');
+          console.error('save-paid-score failed', errText);
+          return;
+        }
+        const data = await res.json();
+        const persisted = Boolean(data.spacetimeUpdated || data.onChainSubmitted);
+        if (!persisted) {
+          paidScoreSavedRef.current = false;
+          setPaidScoreSaved(false);
+          setPaidScoreWarning(
+            data.warning ??
+              data.error ??
+              'Score could not be saved to the leaderboard. Please try again.',
+          );
           return;
         }
         setPaidScoreSaved(true);
+        if (data.onChainSubmitted === false || data.leaderboardReady === false) {
+          setPaidScoreWarning(
+            data.warning ??
+              'Score saved, but the weekly leaderboard update failed. Try playing again or contact support.',
+          );
+        } else {
+          setPaidScoreWarning(null);
+        }
+        for (let attempt = 0; attempt < 5; attempt++) {
+          refreshWeeklyLeaderboard();
+          if (attempt < 4) {
+            await new Promise((resolve) => setTimeout(resolve, 2000));
+          }
+        }
       } catch {
         paidScoreSavedRef.current = false;
         setPaidScoreSaved(false);
+        setPaidScoreWarning('Score could not be saved to the leaderboard.');
       }
     })();
-  }, [gameCompleted, isGuestMode, sessionIsTrial, address, totalScore, entryToken]);
+  }, [gameCompleted, isGuestMode, sessionIsTrial, address, totalScore, entryToken, refreshWeeklyLeaderboard]);
 
   // Show guest mode entry screen first
   if (showGuestMode) {
     return (
-      <div className="bg-[#000000] min-h-screen w-full flex items-center justify-center px-4">
+      <div className="bg-[#000000] min-h-screen w-full flex items-start justify-center px-4 py-6">
         <div className="w-full max-w-[390px] md:max-w-[428px]">
           <GuestModeEntry 
             onGuestStart={handleGuestStart}
@@ -405,7 +436,7 @@ export default function Game() {
   // Show regular game entry screen if wallet connect was chosen
   if (!gameStarted && !showGuestMode) {
     return (
-      <div className="bg-[#000000] min-h-screen w-full flex items-center justify-center px-4">
+      <div className="bg-[#000000] min-h-screen w-full flex items-start justify-center px-4 py-6">
         <div className="w-full max-w-[390px] md:max-w-[428px]">
           <GameEntry
             onGameStart={handleGameStart}
@@ -453,6 +484,12 @@ export default function Game() {
               <p className="text-sm text-green-400 mb-2">Playing as {guestName}</p>
             )}
             <p className="text-lg font-bold text-yellow-400 mb-4">Total Score: {totalScore} USDC</p>
+            {paidScoreWarning && (
+              <div className="bg-amber-500/10 border border-amber-500/20 rounded-lg p-4 mb-4 text-left">
+                <p className="text-amber-300 text-sm font-medium mb-1">Leaderboard update pending</p>
+                <p className="text-amber-200/80 text-sm">{paidScoreWarning}</p>
+              </div>
+            )}
           </div>
           
           {/* High Score Display */}

--- a/app/game/page.tsx
+++ b/app/game/page.tsx
@@ -370,6 +370,7 @@ export default function Game() {
     const wallet = address;
     const finalScore = totalScore;
     let cancelled = false;
+    let completed = false;
     void (async () => {
       try {
         const res = await fetch('/api/save-paid-score', {
@@ -400,6 +401,7 @@ export default function Game() {
           return;
         }
         setPaidScoreSaved(true);
+        completed = true;
         if (data.onChainSubmitted === false || data.leaderboardReady === false) {
           setPaidScoreWarning(
             data.warning ??
@@ -424,6 +426,9 @@ export default function Game() {
     })();
     return () => {
       cancelled = true;
+      if (!completed) {
+        paidScoreSavedRef.current = false;
+      }
     };
   }, [gameCompleted, isGuestMode, sessionIsTrial, address, totalScore, entryToken, refreshWeeklyLeaderboard]);
 

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -160,6 +160,7 @@ function HomePage() {
     const finalScore = totalScore;
     const wallet = address.toLowerCase();
     let cancelled = false;
+    let completed = false;
     void (async () => {
       try {
         const res = await fetch('/api/save-paid-score', {
@@ -195,6 +196,7 @@ function HomePage() {
           return;
         }
         setPaidScoreSaved(true);
+        completed = true;
         if (data.authoritativeScore != null) {
           console.log('Paid score submitted:', data.authoritativeScore, 'tx', data.transactionHash);
         }
@@ -223,6 +225,9 @@ function HomePage() {
     })();
     return () => {
       cancelled = true;
+      if (!completed) {
+        paidScoreSavedRef.current = false;
+      }
     };
   }, [gameCompleted, address, totalScore, entryToken, basename, refreshContractUsdcBalance, refreshWeeklyLeaderboard]);
 

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -180,11 +180,22 @@ function HomePage() {
           return;
         }
         const data = await res.json();
+        const persisted = Boolean(data.spacetimeUpdated || data.onChainSubmitted);
+        if (!persisted) {
+          paidScoreSavedRef.current = false;
+          setPaidScoreSaved(false);
+          setPaidScoreWarning(
+            data.warning ??
+              data.error ??
+              'Score could not be saved to the leaderboard. Please try again.',
+          );
+          return;
+        }
         setPaidScoreSaved(true);
         if (data.authoritativeScore != null) {
           console.log('Paid score submitted:', data.authoritativeScore, 'tx', data.transactionHash);
         }
-        if (data.onChainSubmitted === false) {
+        if (data.onChainSubmitted === false || data.leaderboardReady === false) {
           setPaidScoreWarning(
             data.warning ??
               'Score saved, but the weekly leaderboard update failed. Try playing again or contact support.',
@@ -193,7 +204,12 @@ function HomePage() {
           setPaidScoreWarning(null);
         }
         refreshContractUsdcBalance();
-        refreshWeeklyLeaderboard();
+        for (let attempt = 0; attempt < 5; attempt++) {
+          refreshWeeklyLeaderboard();
+          if (attempt < 4) {
+            await new Promise((resolve) => setTimeout(resolve, 2000));
+          }
+        }
       } catch (e) {
         paidScoreSavedRef.current = false;
         setPaidScoreSaved(false);
@@ -712,7 +728,7 @@ function HomePage() {
   // Show game entry screen with player mode choice
   if (showGameEntry) {
     return (
-      <div className="bg-[#000000] min-h-screen w-full flex items-center justify-center px-4">
+      <div className="bg-[#000000] min-h-screen w-full flex items-start justify-center px-4 py-6">
         <div className="w-full max-w-[390px] md:max-w-[428px] space-y-4">
           <button
             type="button"

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -159,6 +159,7 @@ function HomePage() {
     setPaidScoreSaved(false);
     const finalScore = totalScore;
     const wallet = address.toLowerCase();
+    let cancelled = false;
     void (async () => {
       try {
         const res = await fetch('/api/save-paid-score', {
@@ -172,6 +173,7 @@ function HomePage() {
             username: basename ?? undefined,
           }),
         });
+        if (cancelled) return;
         if (!res.ok) {
           paidScoreSavedRef.current = false;
           setPaidScoreSaved(false);
@@ -180,6 +182,7 @@ function HomePage() {
           return;
         }
         const data = await res.json();
+        if (cancelled) return;
         const persisted = Boolean(data.spacetimeUpdated || data.onChainSubmitted);
         if (!persisted) {
           paidScoreSavedRef.current = false;
@@ -205,17 +208,22 @@ function HomePage() {
         }
         refreshContractUsdcBalance();
         for (let attempt = 0; attempt < 5; attempt++) {
+          if (cancelled) return;
           refreshWeeklyLeaderboard();
           if (attempt < 4) {
             await new Promise((resolve) => setTimeout(resolve, 2000));
           }
         }
       } catch (e) {
+        if (cancelled) return;
         paidScoreSavedRef.current = false;
         setPaidScoreSaved(false);
         console.error('save-paid-score error', e);
       }
     })();
+    return () => {
+      cancelled = true;
+    };
   }, [gameCompleted, address, totalScore, entryToken, basename, refreshContractUsdcBalance, refreshWeeklyLeaderboard]);
 
   const loadRandomQuestion = useCallback(async () => {

--- a/app/rootProvider.tsx
+++ b/app/rootProvider.tsx
@@ -5,6 +5,7 @@ import { WagmiProvider } from "wagmi";
 import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
 import { SpacetimeProvider } from "@/components/providers/SpacetimeProvider";
 import { BaseAccountProvider } from "@/components/providers/BaseAccountProvider";
+import { Toaster } from "@/components/ui/sonner";
 import { wagmiConfig } from "@/lib/wagmi";
 
 const queryClient = new QueryClient();
@@ -26,6 +27,7 @@ export function RootProvider({ children }: { children: ReactNode }) {
         <SpacetimeProvider>
           <BaseAccountProvider>
             <FarcasterReadyEffect />
+            <Toaster position="top-center" richColors closeButton />
             {children}
           </BaseAccountProvider>
         </SpacetimeProvider>

--- a/components/game/GameEntry.tsx
+++ b/components/game/GameEntry.tsx
@@ -99,7 +99,6 @@ export default function GameEntry({
   const [isFundingUrlGenerating, setIsFundingUrlGenerating] = useState(false);
   const paidGameCalls = useMemo(() => createBaseAccountPaidGameCalls(), []);
   const paidTxRef = useRef<BaseAccountTransactionHandle>(null);
-  const walletPanelRef = useRef<HTMLDivElement>(null);
   const generatingAddressRef = useRef<string | null>(null);
   const paymasterConfigured = Boolean(process.env.NEXT_PUBLIC_PAYMASTER_AND_BUNDLER_ENDPOINT);
   const [pendingPaidEntry, setPendingPaidEntry] = useState<PendingPaidEntry | null>(null);
@@ -478,7 +477,6 @@ export default function GameEntry({
   useEffect(() => {
     if (!isProcessingPayment || !awaitingWalletOpen) return;
     toast.info('Tap Open wallet to approve USDC and join');
-    walletPanelRef.current?.scrollIntoView({ behavior: 'smooth', block: 'center' });
   }, [isProcessingPayment, awaitingWalletOpen]);
 
   const handleFundEth = async () => {
@@ -904,7 +902,6 @@ export default function GameEntry({
 
                   {isProcessingPayment ? (
                     <div
-                      ref={walletPanelRef}
                       className="rounded-lg border border-blue-500/30 bg-blue-950/20 px-4 py-3 text-center"
                       role="status"
                       aria-live="polite"

--- a/components/game/GameEntry.tsx
+++ b/components/game/GameEntry.tsx
@@ -1,6 +1,7 @@
 'use client';
 
 import { useState, useCallback, useEffect, useMemo, useRef } from 'react';
+import { toast } from 'sonner';
 import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card';
 import { Button } from '@/components/ui/button';
 import { Badge } from '@/components/ui/badge';
@@ -98,6 +99,7 @@ export default function GameEntry({
   const [isFundingUrlGenerating, setIsFundingUrlGenerating] = useState(false);
   const paidGameCalls = useMemo(() => createBaseAccountPaidGameCalls(), []);
   const paidTxRef = useRef<BaseAccountTransactionHandle>(null);
+  const walletPanelRef = useRef<HTMLDivElement>(null);
   const generatingAddressRef = useRef<string | null>(null);
   const paymasterConfigured = Boolean(process.env.NEXT_PUBLIC_PAYMASTER_AND_BUNDLER_ENDPOINT);
   const [pendingPaidEntry, setPendingPaidEntry] = useState<PendingPaidEntry | null>(null);
@@ -466,6 +468,18 @@ export default function GameEntry({
     setError(null);
     paidTxRef.current?.submit();
   };
+
+  const handleCancelPayment = () => {
+    setIsProcessingPayment(false);
+    setAwaitingWalletOpen(false);
+    setIsStartingGame(false);
+  };
+
+  useEffect(() => {
+    if (!isProcessingPayment || !awaitingWalletOpen) return;
+    toast.info('Tap Open wallet to approve USDC and join');
+    walletPanelRef.current?.scrollIntoView({ behavior: 'smooth', block: 'center' });
+  }, [isProcessingPayment, awaitingWalletOpen]);
 
   const handleFundEth = async () => {
     if (!address || ethFundingLoading) return;
@@ -889,58 +903,15 @@ export default function GameEntry({
                   )}
 
                   {isProcessingPayment ? (
-                    <div className="space-y-4">
-                      <BaseAccountTransaction
-                        ref={paidTxRef}
-                        calls={paidGameCalls}
-                        onStatus={handleTransactionStatus}
-                        className="w-full"
-                        showSubmitButton={false}
-                        connectedAddress={address}
-                      />
-                      {awaitingWalletOpen ? (
-                        <div
-                          className="rounded-lg border border-blue-500/30 bg-blue-950/20 px-4 py-5 text-center space-y-4"
-                          role="status"
-                          aria-live="polite"
-                        >
-                          <p className="text-sm font-medium text-blue-200">Ready to sign</p>
-                          <p className="text-sm text-zinc-200">
-                            Tap below to open your Base wallet and approve USDC, then confirm join.
-                          </p>
-                          <Button
-                            type="button"
-                            onClick={handleOpenWallet}
-                            className="w-full bg-white text-black hover:bg-gray-100 font-semibold"
-                          >
-                            <Wallet className="h-4 w-4 mr-2" />
-                            Open wallet
-                          </Button>
-                        </div>
-                      ) : (
-                        <div
-                          className="rounded-lg border border-amber-500/30 bg-amber-950/20 px-4 py-5 text-center"
-                          role="status"
-                          aria-live="polite"
-                        >
-                          <p className="text-sm font-medium text-amber-200">Processing entry</p>
-                          <p className="mt-2 text-sm text-zinc-200">
-                            Confirm in your wallet, then wait for on-chain confirmation…
-                          </p>
-                        </div>
-                      )}
-                      <Button
-                        type="button"
-                        onClick={() => {
-                          setIsProcessingPayment(false);
-                          setAwaitingWalletOpen(false);
-                          setIsStartingGame(false);
-                        }}
-                        variant="outline"
-                        className="w-full border-white text-red-400 hover:text-red-500 hover:bg-red-500/20 hover:cursor-pointer"
-                      >
-                        Cancel
-                      </Button>
+                    <div
+                      ref={walletPanelRef}
+                      className="rounded-lg border border-blue-500/30 bg-blue-950/20 px-4 py-3 text-center"
+                      role="status"
+                      aria-live="polite"
+                    >
+                      <p className="text-sm text-blue-200">
+                        Confirm in your wallet — see the overlay above.
+                      </p>
                     </div>
                   ) : (
                     <Button
@@ -1002,6 +973,67 @@ export default function GameEntry({
           )}
         </CardContent>
       </Card>
+
+      {isProcessingPayment && !isJoiningAfterPayment ? (
+        <div
+          className="fixed inset-0 z-50 flex items-center justify-center bg-black/80 px-4"
+          role="dialog"
+          aria-modal="true"
+          aria-labelledby="wallet-overlay-title"
+          aria-live="polite"
+        >
+          <div className="max-w-sm w-full rounded-xl border border-blue-500/40 bg-zinc-900 px-6 py-8 text-center shadow-xl space-y-4">
+            <BaseAccountTransaction
+              ref={paidTxRef}
+              key={paymentFlowId}
+              calls={paidGameCalls}
+              onStatus={handleTransactionStatus}
+              className="sr-only"
+              showSubmitButton={false}
+              connectedAddress={address}
+            />
+            {awaitingWalletOpen ? (
+              <>
+                <Wallet className="mx-auto h-10 w-10 text-blue-400" aria-hidden />
+                <p id="wallet-overlay-title" className="text-lg font-semibold text-white">
+                  Confirm in your wallet
+                </p>
+                <p className="text-sm text-zinc-300">
+                  Step 1: Approve USDC spending. Step 2: Confirm join to start your game.
+                </p>
+                <Button
+                  type="button"
+                  onClick={handleOpenWallet}
+                  className="w-full bg-white text-black hover:bg-gray-100 font-semibold"
+                  aria-label="Open wallet to sign transaction"
+                >
+                  <Wallet className="h-4 w-4 mr-2" />
+                  Open wallet
+                </Button>
+              </>
+            ) : (
+              <>
+                <Loader2 className="mx-auto h-10 w-10 animate-spin text-amber-400" aria-hidden />
+                <p id="wallet-overlay-title" className="text-lg font-semibold text-white">
+                  Waiting for wallet confirmation
+                </p>
+                <p className="text-sm text-zinc-300">
+                  Confirm in your wallet, then wait for on-chain confirmation…
+                </p>
+              </>
+            )}
+            <Button
+              type="button"
+              onClick={handleCancelPayment}
+              variant="outline"
+              className="w-full border-white/20 text-red-400 hover:text-red-300 hover:bg-red-500/10"
+              aria-label="Cancel payment"
+            >
+              Cancel
+            </Button>
+          </div>
+        </div>
+      ) : null}
 
       {isJoiningAfterPayment ? (
         <div

--- a/components/game/GameEntry.tsx
+++ b/components/game/GameEntry.tsx
@@ -739,15 +739,15 @@ export default function GameEntry({
                           size="sm"
                           onClick={handleSwitchAccountClick}
                           disabled={switchAccountDisabled}
-                          className="border-white/20 bg-white/5 text-white/80 hover:bg-white/10 hover:text-white disabled:opacity-50"
-                          aria-label="Switch Base Account"
+                          className="border-red-500/30 bg-red-950/20 text-red-400 hover:bg-red-500/10 hover:text-red-300 disabled:opacity-50"
+                          aria-label="Disconnect Base Account"
                         >
                           {isSwitchingAccount ? (
                             <Loader2 className="h-4 w-4 mr-2 animate-spin" />
                           ) : (
                             <LogOut className="h-4 w-4 mr-2" />
                           )}
-                          Switch account
+                          {isSwitchingAccount ? 'Disconnecting…' : 'Disconnect'}
                         </Button>
                       </div>
                     )}
@@ -1053,9 +1053,9 @@ export default function GameEntry({
       <AlertDialog open={showSwitchAccountConfirm} onOpenChange={setShowSwitchAccountConfirm}>
         <AlertDialogContent className="bg-zinc-900 border-gray-700 text-white">
           <AlertDialogHeader>
-            <AlertDialogTitle>Switch account?</AlertDialogTitle>
+            <AlertDialogTitle>Disconnect?</AlertDialogTitle>
             <AlertDialogDescription className="text-gray-400">
-              You have a pending paid entry for this wallet. Switching accounts will sign you out
+              You have a pending paid entry for this wallet. Disconnecting will sign you out
               and you may need to recover your entry with the new wallet.
             </AlertDialogDescription>
           </AlertDialogHeader>
@@ -1071,7 +1071,7 @@ export default function GameEntry({
               disabled={isSwitchingAccount}
               className="bg-amber-600 hover:bg-amber-500 text-white"
             >
-              {isSwitchingAccount ? 'Switching…' : 'Switch account'}
+              {isSwitchingAccount ? 'Disconnecting…' : 'Disconnect'}
             </AlertDialogAction>
           </AlertDialogFooter>
         </AlertDialogContent>

--- a/components/game/HighScoreDisplay.tsx
+++ b/components/game/HighScoreDisplay.tsx
@@ -120,8 +120,10 @@ export default function HighScoreDisplay({
     if (!scoreSaved || isTrialGame || !normalizedWallet) return;
     if (walletOnLiveBoard) return;
 
+    let cancelled = false;
     let attempts = 0;
     const interval = setInterval(() => {
+      if (cancelled) return;
       attempts += 1;
       void refresh();
       if (attempts >= LEADERBOARD_POLL_ATTEMPTS) {
@@ -129,7 +131,10 @@ export default function HighScoreDisplay({
       }
     }, LEADERBOARD_POLL_INTERVAL_MS);
 
-    return () => clearInterval(interval);
+    return () => {
+      cancelled = true;
+      clearInterval(interval);
+    };
   }, [scoreSaved, isTrialGame, normalizedWallet, walletOnLiveBoard, refresh]);
 
   useEffect(() => {
@@ -182,7 +187,7 @@ export default function HighScoreDisplay({
     !isTrialGame &&
     currentScore > 0 &&
     normalizedWallet &&
-    isNewWeeklyLeader(leaderboardEntries, normalizedWallet, currentScore);
+    isNewWeeklyLeader(topEarners, normalizedWallet, currentScore);
   const isFirstOnBoard =
     !isTrialGame && !leaderboardLoading && isFirstScoreOnEmptyBoard(topEarners);
   const rankReady = !isTrialGame && (scoreSaved || hasSubmitted) && !leaderboardLoading;

--- a/components/game/HighScoreDisplay.tsx
+++ b/components/game/HighScoreDisplay.tsx
@@ -1,6 +1,7 @@
 'use client';
 
 import { useState, useEffect, useMemo, useRef } from 'react';
+import { createPortal } from 'react-dom';
 import { Trophy, Medal, Award, Crown, Coins, CheckCircle } from 'lucide-react';
 import { useHighScores } from '@/hooks/useHighScores';
 import { useWeeklyLeaderboard } from '@/hooks/useWeeklyLeaderboard';
@@ -16,12 +17,15 @@ import ComposeCastButton from '@/components/social/ComposeCastButton';
 import { Confetti } from '@neoconfetti/react';
 import {
   computeRankForScore,
+  isFirstScoreOnEmptyBoard,
   isNewWeeklyLeader,
   type WeeklyLeaderboardEntry,
 } from '@/lib/game/weeklyLeaderboard';
 
 const LEADERBOARD_LIMIT = 10;
-const CONFETTI_DURATION_MS = 8000;
+const CONFETTI_DURATION_MS = 10000;
+const LEADERBOARD_POLL_ATTEMPTS = 5;
+const LEADERBOARD_POLL_INTERVAL_MS = 2000;
 
 interface HighScoreDisplayProps {
   currentScore: number;
@@ -93,9 +97,52 @@ export default function HighScoreDisplay({
   const [backendRank, setBackendRank] = useState<number | null>(null);
   const [backendIsNewLeader, setBackendIsNewLeader] = useState(false);
   const [showConfetti, setShowConfetti] = useState(false);
+  const [confirmedOnLeaderboard, setConfirmedOnLeaderboard] = useState(false);
+  const [confettiStageSize, setConfettiStageSize] = useState({ width: 1200, height: 900 });
   const confettiLockedRef = useRef(false);
 
   const normalizedWallet = walletAddress?.toLowerCase();
+
+  const walletOnLiveBoard = useMemo(() => {
+    if (!normalizedWallet) return false;
+    return topEarners.some(
+      (entry) => entry.walletAddress.toLowerCase() === normalizedWallet,
+    );
+  }, [topEarners, normalizedWallet]);
+
+  useEffect(() => {
+    if (walletOnLiveBoard) {
+      setConfirmedOnLeaderboard(true);
+    }
+  }, [walletOnLiveBoard]);
+
+  useEffect(() => {
+    if (!scoreSaved || isTrialGame || !normalizedWallet) return;
+    if (walletOnLiveBoard) return;
+
+    let attempts = 0;
+    const interval = setInterval(() => {
+      attempts += 1;
+      void refresh();
+      if (attempts >= LEADERBOARD_POLL_ATTEMPTS) {
+        clearInterval(interval);
+      }
+    }, LEADERBOARD_POLL_INTERVAL_MS);
+
+    return () => clearInterval(interval);
+  }, [scoreSaved, isTrialGame, normalizedWallet, walletOnLiveBoard, refresh]);
+
+  useEffect(() => {
+    const updateStageSize = () => {
+      setConfettiStageSize({
+        width: Math.max(window.innerWidth, 320),
+        height: Math.max(window.innerHeight, 600),
+      });
+    };
+    updateStageSize();
+    window.addEventListener('resize', updateStageSize);
+    return () => window.removeEventListener('resize', updateStageSize);
+  }, []);
 
   const leaderboardEntries = useMemo(() => {
     if (isTrialGame) return [];
@@ -104,8 +151,19 @@ export default function HighScoreDisplay({
       return topEarners.slice(0, LEADERBOARD_LIMIT);
     }
 
+    if (confirmedOnLeaderboard) {
+      return topEarners.slice(0, LEADERBOARD_LIMIT);
+    }
+
     return mergeLatestPlayerScore(topEarners, normalizedWallet, currentScore, playerName);
-  }, [isTrialGame, topEarners, normalizedWallet, currentScore, playerName]);
+  }, [
+    isTrialGame,
+    topEarners,
+    normalizedWallet,
+    currentScore,
+    playerName,
+    confirmedOnLeaderboard,
+  ]);
 
   const playerRank = useMemo(() => {
     if (isTrialGame || currentScore <= 0 || !normalizedWallet) return null;
@@ -124,8 +182,12 @@ export default function HighScoreDisplay({
     !isTrialGame &&
     currentScore > 0 &&
     normalizedWallet &&
-    isNewWeeklyLeader(topEarners, normalizedWallet, currentScore);
+    isNewWeeklyLeader(leaderboardEntries, normalizedWallet, currentScore);
+  const isFirstOnBoard =
+    !isTrialGame && !leaderboardLoading && isFirstScoreOnEmptyBoard(topEarners);
   const rankReady = !isTrialGame && (scoreSaved || hasSubmitted) && !leaderboardLoading;
+  const isPostingToLeaderboard =
+    scoreSaved && !confirmedOnLeaderboard && !isTrialGame && currentScore > 0;
 
   const handleClaimSuccess = () => {
     markAsClaimed();
@@ -175,9 +237,16 @@ export default function HighScoreDisplay({
     refresh,
   ]);
 
+  const displayRank = rankReady ? (playerRank ?? backendRank) : null;
+  const showNewLeaderBanner =
+    rankReady &&
+    displayRank === 1 &&
+    currentScore > 0 &&
+    (isNewLeader || isFirstOnBoard || backendIsNewLeader);
+  const shouldShowConfetti = rankReady && currentScore > 0;
+
   useEffect(() => {
-    if (!rankReady || confettiLockedRef.current) return;
-    if (!isNewLeader && !backendIsNewLeader) return;
+    if (!shouldShowConfetti || confettiLockedRef.current) return;
 
     confettiLockedRef.current = true;
     const startDelay = setTimeout(() => {
@@ -192,7 +261,7 @@ export default function HighScoreDisplay({
       clearTimeout(startDelay);
       clearTimeout(hideTimer);
     };
-  }, [rankReady, isNewLeader, backendIsNewLeader]);
+  }, [shouldShowConfetti]);
 
   const getRankIcon = (rank: number) => {
     switch (rank) {
@@ -232,30 +301,33 @@ export default function HighScoreDisplay({
     return <span>Unknown Player</span>;
   };
 
-  const displayRank = rankReady ? (playerRank ?? backendRank) : null;
-  const showNewLeaderBanner =
-    rankReady && (backendIsNewLeader || isNewLeader) && displayRank === 1;
   const showLeaderboardSkeleton =
     (leaderboardLoading || isRefreshing) && leaderboardEntries.length === 0;
 
+  const confettiPortal =
+    showConfetti && typeof document !== 'undefined'
+      ? createPortal(
+          <div
+            className="fixed inset-0 z-[100] pointer-events-none flex items-start justify-center"
+            aria-hidden="true"
+          >
+            <Confetti
+              particleCount={400}
+              force={0.75}
+              duration={CONFETTI_DURATION_MS - 500}
+              colors={['#FFC700', '#FFD700', '#FF0000', '#A855F7', '#EC4899', '#10B981', '#FFFFFF']}
+              particleShape="mix"
+              stageHeight={confettiStageSize.height}
+              stageWidth={confettiStageSize.width}
+            />
+          </div>,
+          document.body,
+        )
+      : null;
+
   return (
     <div className={`bg-white rounded-lg p-4 shadow-lg border ${className} relative overflow-visible`}>
-      {showConfetti && (
-        <div
-          className="fixed inset-0 z-[100] pointer-events-none flex items-start justify-center"
-          aria-hidden="true"
-        >
-          <Confetti
-            particleCount={400}
-            force={0.75}
-            duration={CONFETTI_DURATION_MS - 500}
-            colors={['#FFC700', '#FFD700', '#FF0000', '#A855F7', '#EC4899', '#10B981', '#FFFFFF']}
-            particleShape="mix"
-            stageHeight={900}
-            stageWidth={1200}
-          />
-        </div>
-      )}
+      {confettiPortal}
 
       <div className="mb-4">
         <h3 className="text-lg font-bold text-gray-800 mb-2">High Scores</h3>
@@ -263,6 +335,12 @@ export default function HighScoreDisplay({
         {isTrialGame && currentScore > 0 && (
           <p className="text-xs text-amber-800 bg-amber-50 border border-amber-200 rounded-md px-2 py-1.5 mb-3">
             Practice run — this score is not added to the paid leaderboard.
+          </p>
+        )}
+
+        {isPostingToLeaderboard && (
+          <p className="text-xs text-blue-800 bg-blue-50 border border-blue-200 rounded-md px-2 py-1.5 mb-3">
+            Posting score to leaderboard…
           </p>
         )}
 

--- a/components/game/HighScoreDisplay.tsx
+++ b/components/game/HighScoreDisplay.tsx
@@ -103,22 +103,27 @@ export default function HighScoreDisplay({
 
   const normalizedWallet = walletAddress?.toLowerCase();
 
-  const walletOnLiveBoard = useMemo(() => {
-    if (!normalizedWallet) return false;
-    return topEarners.some(
+  const liveBoardReflectsCurrentScore = useMemo(() => {
+    if (!normalizedWallet || currentScore <= 0) return false;
+    const liveEntry = topEarners.find(
       (entry) => entry.walletAddress.toLowerCase() === normalizedWallet,
     );
-  }, [topEarners, normalizedWallet]);
+    return liveEntry != null && liveEntry.bestScore === currentScore;
+  }, [topEarners, normalizedWallet, currentScore]);
 
   useEffect(() => {
-    if (walletOnLiveBoard) {
+    setConfirmedOnLeaderboard(false);
+  }, [currentScore, normalizedWallet]);
+
+  useEffect(() => {
+    if (liveBoardReflectsCurrentScore) {
       setConfirmedOnLeaderboard(true);
     }
-  }, [walletOnLiveBoard]);
+  }, [liveBoardReflectsCurrentScore]);
 
   useEffect(() => {
     if (!scoreSaved || isTrialGame || !normalizedWallet) return;
-    if (walletOnLiveBoard) return;
+    if (liveBoardReflectsCurrentScore) return;
 
     let cancelled = false;
     let attempts = 0;
@@ -135,7 +140,7 @@ export default function HighScoreDisplay({
       cancelled = true;
       clearInterval(interval);
     };
-  }, [scoreSaved, isTrialGame, normalizedWallet, walletOnLiveBoard, refresh]);
+  }, [scoreSaved, isTrialGame, normalizedWallet, liveBoardReflectsCurrentScore, refresh]);
 
   useEffect(() => {
     const updateStageSize = () => {

--- a/lib/blockchain/submitOnChainScore.ts
+++ b/lib/blockchain/submitOnChainScore.ts
@@ -124,17 +124,24 @@ export async function submitOnChainScore(
       return { ok: false, error: 'On-chain session is not active' };
     }
 
-    if (expectedSessionId && sessionCounter.toString() !== expectedSessionId) {
-      return {
-        ok: false,
-        error: `Session mismatch: expected ${expectedSessionId}, on-chain ${sessionCounter.toString()}`,
-      };
-    }
-
     const normalized = wallet.toLowerCase();
     const registered = (players as `0x${string}`[]).some(
       (p) => p.toLowerCase() === normalized
     );
+
+    if (expectedSessionId && sessionCounter.toString() !== expectedSessionId) {
+      if (registered) {
+        console.warn(
+          `[submitOnChainScore] session mismatch: expected ${expectedSessionId}, using live ${sessionCounter.toString()}`,
+        );
+      } else {
+        return {
+          ok: false,
+          error: `Session mismatch: expected ${expectedSessionId}, on-chain ${sessionCounter.toString()}`,
+        };
+      }
+    }
+
     if (!registered) {
       return { ok: false, error: 'Wallet is not registered in the current on-chain session' };
     }

--- a/lib/game/weeklyLeaderboard.ts
+++ b/lib/game/weeklyLeaderboard.ts
@@ -250,3 +250,28 @@ export const isNewWeeklyLeader = (
 
   return rank === 1 && score >= previousLeaderScore;
 };
+
+/** True when the weekly board has no entries yet (first score of the week). */
+export const isFirstScoreOnEmptyBoard = (
+  entries: WeeklyLeaderboardEntry[],
+): boolean => entries.length === 0;
+
+/** Parse on-chain session id strings safely. */
+export const parseSessionIdNumeric = (id: string | undefined): number => {
+  if (!id?.trim()) return 0;
+  const parsed = Number(id.trim());
+  if (!Number.isFinite(parsed) || parsed < 0) return 0;
+  return Math.floor(parsed);
+};
+
+/**
+ * Resolve the session id to use for weekly score persistence.
+ * Prefers the live on-chain counter when it exceeds token/receipt values (new-week edge case).
+ */
+export const resolveAuthoritativeSessionId = (
+  tokenSessionId: string,
+  liveSessionCounter: number,
+): string => {
+  const tokenNumeric = parseSessionIdNumeric(tokenSessionId);
+  return String(Math.max(tokenNumeric, liveSessionCounter));
+};

--- a/tests/weekly-leaderboard.test.ts
+++ b/tests/weekly-leaderboard.test.ts
@@ -8,6 +8,9 @@ import {
   mergeWeeklyLeaderboardEntries,
   computeRankForScore,
   isNewWeeklyLeader,
+  isFirstScoreOnEmptyBoard,
+  resolveAuthoritativeSessionId,
+  parseSessionIdNumeric,
   type WeeklyLeaderboardEntry,
 } from '../lib/game/weeklyLeaderboard';
 
@@ -95,5 +98,57 @@ describe('weekly leaderboard latest-score semantics', () => {
 
     assert.equal(computeRankForScore(entries, walletA, 1800), 1);
     assert.equal(isNewWeeklyLeader(entries, walletA, 1800), false);
+  });
+});
+
+describe('weekly session transitions', () => {
+  it('includes spacetime scores for the current week', () => {
+    const merged = mergeWeeklyLeaderboardEntries(
+      2,
+      new Map(),
+      [
+        {
+          walletAddress: walletA,
+          weeklySessionId: BigInt(2),
+          weeklyBestScore: 1500,
+        },
+      ],
+      10,
+    );
+
+    assert.equal(merged.length, 1);
+    assert.equal(merged[0]?.bestScore, 1500);
+    assert.equal(merged[0]?.sessionCounter, 2);
+  });
+
+  it('excludes spacetime scores from a prior week', () => {
+    const merged = mergeWeeklyLeaderboardEntries(
+      2,
+      new Map(),
+      [
+        {
+          walletAddress: walletA,
+          weeklySessionId: BigInt(1),
+          weeklyBestScore: 2500,
+        },
+      ],
+      10,
+    );
+
+    assert.equal(merged.length, 0);
+  });
+
+  it('resolves authoritative session id using live counter', () => {
+    assert.equal(resolveAuthoritativeSessionId('1', 2), '2');
+    assert.equal(resolveAuthoritativeSessionId('3', 2), '3');
+    assert.equal(parseSessionIdNumeric(''), 0);
+  });
+
+  it('detects first score on an empty board', () => {
+    assert.equal(isFirstScoreOnEmptyBoard([]), true);
+    assert.equal(
+      isFirstScoreOnEmptyBoard([{ walletAddress: walletA, bestScore: 100, sessionCounter: 2 }]),
+      false,
+    );
   });
 });


### PR DESCRIPTION
## Summary
- Adds a full-screen mobile wallet overlay after "Start paid game" so users no longer miss the Open wallet step below the fold.
- Fixes weekly leaderboard posting by resolving session IDs from the live on-chain counter and tolerating new-week session mismatches when the wallet is registered.
- Celebrates every paid game completion with score > 0 using 10-second confetti, with honest partial-save warnings and leaderboard polling after score submit.

## Test plan
- [ ] On a 390px viewport, tap Start paid game and confirm the wallet overlay appears without scrolling
- [ ] Complete a paid game and verify confetti plays for any score > 0
- [ ] Confirm score appears on the weekly leaderboard after completion (including first game of a new week)
- [ ] Verify partial on-chain save shows a warning instead of a false success state
- [ ] Run `npx tsx --test tests/weekly-leaderboard.test.ts`


Made with [Cursor](https://cursor.com)