### PR TITLE
fix(leaderboard): align paid score session id with live on-chain counter

### DIFF
--- a/lib/game/weeklyLeaderboard.ts
+++ b/lib/game/weeklyLeaderboard.ts
@@ -317,18 +317,26 @@ export const parseSessionIdNumeric = (id: string | undefined): number => {
 
 /**
  * Resolve the session id to use for weekly score persistence.
- * Trusts the entry token / score receipt unless it is missing; only falls back to
- * the live counter when no token session id is available. This prevents a player's
- * score from being attributed to a later session if the on-chain counter advanced
- * while they were still finishing their paid run.
+ *
+ * The weekly leaderboard is keyed to the **live** on-chain `sessionCounter`, so the
+ * authoritative session id must match that counter. The entry token's
+ * `onChainSessionId` is a snapshot from when the player paid/joined and can become
+ * stale if a new weekly session started while they were finishing their run.
+ *
+ * Prefer the live counter when it is readable (>0). Fall back to the token/receipt
+ * value only when the live read failed, and default to 0 as a last resort (which
+ * prevents the score from appearing on any weekly board until the chain is reachable).
  */
 export const resolveAuthoritativeSessionId = (
   tokenSessionId: string,
   liveSessionCounter: number,
 ): string => {
+  if (liveSessionCounter > 0) {
+    return String(liveSessionCounter);
+  }
   const tokenNumeric = parseSessionIdNumeric(tokenSessionId);
   if (tokenNumeric > 0) {
     return String(tokenNumeric);
   }
-  return String(liveSessionCounter > 0 ? liveSessionCounter : 0);
+  return '0';
 };

--- a/tests/weekly-leaderboard.test.ts
+++ b/tests/weekly-leaderboard.test.ts
@@ -138,14 +138,17 @@ describe('weekly session transitions', () => {
     assert.equal(merged.length, 0);
   });
 
-  it('resolves authoritative session id from the entry token, not the live counter', () => {
-    // A player paid into session 1; we must not attribute their score to session 2
-    // just because the on-chain counter advanced while they were finishing.
-    assert.equal(resolveAuthoritativeSessionId('1', 2), '1');
-    assert.equal(resolveAuthoritativeSessionId('3', 2), '3');
-    // Falls back to live counter only when the token has no session id.
+  it('prefers the live on-chain session counter over a stale token session id', () => {
+    // The weekly leaderboard is keyed to the live sessionCounter. A token issued when
+    // the player joined/paid may reference an older session if the counter advanced
+    // while they were finishing their run; the score must be attributed to the
+    // current live counter to appear on the leaderboard.
+    assert.equal(resolveAuthoritativeSessionId('1', 2), '2');
+    assert.equal(resolveAuthoritativeSessionId('3', 2), '2');
+    // Falls back to the token value only when the live counter cannot be read.
     assert.equal(resolveAuthoritativeSessionId('', 2), '2');
-    assert.equal(resolveAuthoritativeSessionId('0', 5), '5');
+    assert.equal(resolveAuthoritativeSessionId('5', 0), '5');
+    assert.equal(resolveAuthoritativeSessionId('0', 0), '0');
     assert.equal(parseSessionIdNumeric(''), 0);
   });
 


### PR DESCRIPTION
## Problem
Users who completed paid games on https://beatme.creativeplatform.xyz/ were not appearing on the weekly leaderboard.

## Root Cause
`/api/save-paid-score` resolved the authoritative session id from the entry token's stale `onChainSessionId`. The weekly leaderboard API (`/api/weekly-leaderboard`) merges SpacetimeDB rows with on-chain scores keyed to the **live** `sessionCounter`. When a new weekly session started between a player paying/joining and finishing their run, the score was written to the old `weekly_session_id` and filtered out of the current week's board.

## Fix
`resolveAuthoritativeSessionId` in `lib/game/weeklyLeaderboard.ts` now prefers the live on-chain `sessionCounter` when it can be read, falling back to the token/receipt value only when the live read fails. This keeps SpacetimeDB's `weekly_session_id` in sync with the chain and the leaderboard.

## Verification
- `npx tsx --test tests/weekly-leaderboard.test.ts tests/paid-score-save.test.ts tests/paid-score-leaderboard-filter.test.ts` → 15/15 pass
- `npm run build` → succeeds

## Files Changed
- `lib/game/weeklyLeaderboard.ts`
- `tests/weekly-leaderboard.test.ts`