### PR TITLE
fix: correct PlayerJoined/PlayerRejoined event ABI to match v5 contract

### DIFF
--- a/lib/blockchain/contracts.ts
+++ b/lib/blockchain/contracts.ts
@@ -806,7 +806,7 @@ const TRIVIA_ABI_INLINE = [
       {
         "name": "sessionId",
         "type": "uint256",
-        "indexed": false,
+        "indexed": true,
         "internalType": "uint256"
       }
     ],
@@ -825,7 +825,7 @@ const TRIVIA_ABI_INLINE = [
       {
         "name": "sessionId",
         "type": "uint256",
-        "indexed": false,
+        "indexed": true,
         "internalType": "uint256"
       }
     ],
@@ -868,6 +868,12 @@ const TRIVIA_ABI_INLINE = [
       },
       {
         "name": "startTime",
+        "type": "uint256",
+        "indexed": false,
+        "internalType": "uint256"
+      },
+      {
+        "name": "endTime",
         "type": "uint256",
         "indexed": false,
         "internalType": "uint256"


### PR DESCRIPTION
## Summary

The deployed `TriviaBattlev5` contract emits `PlayerJoined` and `PlayerRejoined` with `sessionId` as **`indexed: true`** (in `topics[2]`), but the ABI in `contracts.ts` had `sessionId` as `indexed: false` (expecting it in `log.data`).

This caused **paid game entry verification to fail every time**:
1. User pays 1 USDC + gas → `joinBattle()` succeeds on-chain ✅
2. Server `verifyPaidTxHash()` tries to decode `PlayerJoined` from receipt logs
3. Old ABI expects `sessionId` in `log.data`, but v5 puts it in `topics[2]`
4. `decodeEventLog` throws: `"Data size of 0 bytes is too small for non-indexed event parameters"`
5. Verification returns: `"Transaction did not call joinBattle or emit PlayerJoined for this wallet"`
6. Game never starts → user sees "Payment received — game did not start"
7. Hitting "Retry with same payment" just re-runs the same failing verification → loop

## Root Cause

The v5 contract source declares:
```solidity
event PlayerJoined(address indexed player, uint256 indexed sessionId);
event PlayerRejoined(address indexed player, uint256 indexed sessionId);
```

But the inline ABI (`TRIVIA_ABI_INLINE`) had:
```json
{ "name": "sessionId", "type": "uint256", "indexed": false }
```

Confirmed by decoding a simulated v5 `PlayerJoined` log with both ABIs — old ABI throws, corrected ABI works.

## Changes (`lib/blockchain/contracts.ts`)

| Event | Before | After |
|---|---|---|
| `PlayerJoined` | `sessionId` indexed:false | `sessionId` indexed:**true** |
| `PlayerRejoined` | `sessionId` indexed:false | `sessionId` indexed:**true** |
| `SessionStarted` | 2 params (sessionId, startTime) | 3 params (sessionId, startTime, **endTime**) |

## Verification

- ✅ TypeScript compiles clean
- ✅ Next.js production build passes (exit 0)
- ✅ Simulated v5 `PlayerJoined` log decodes correctly with fixed ABI
- ✅ `PlayerRejoined` also decodes correctly

## Impact

This fixes the critical bug where users pay 1 USDC + gas but the game never starts. After this fix, `verifyPaidTxHash()` will correctly decode the `PlayerJoined` event and the game will proceed to questions.