### PR TITLE
ci: add Foundry caching + retry fallback for foundryup 504 timeouts

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -25,10 +25,35 @@ jobs:
           # Recursive fetch pulls nested submodules from vendored libraries and can fail in CI.
           submodules: true
 
+      - name: Cache Foundry
+        id: cache-foundry
+        uses: actions/cache@v4
+        with:
+          path: |
+            ~/.foundry/bin
+          key: foundry-v1.7.1-${{ runner.os }}
+
       - name: Install Foundry
+        if: steps.cache-foundry.outputs.cache-hit != 'true'
         uses: foundry-rs/foundry-toolchain@v1
         with:
           version: v1.7.1
+
+      - name: Add Foundry to PATH
+        if: steps.cache-foundry.outputs.cache-hit == 'true'
+        run: echo "$HOME/.foundry/bin" >> $GITHUB_PATH
+
+      - name: Retry install Foundry (fallback)
+        if: steps.cache-foundry.outputs.cache-hit != 'true' && failure()
+        run: |
+          for i in 1 2 3; do
+            curl -L https://foundry.paradigm.xyz | bash && \
+            foundryup --install v1.7.1 && break || {
+              echo "Attempt $i failed, retrying in 15s..."
+              sleep 15
+            }
+          done
+          echo "$HOME/.foundry/bin" >> $GITHUB_PATH
 
       - name: Show Forge version
         run: forge --version


### PR DESCRIPTION
## Problem

All Foundry CI checks have been failing at the `foundryup` install step with `HTTP 504 Gateway Timeout` from GitHub's attestation servers. This is a GitHub infrastructure issue, not a code problem — the CI never gets to run `forge build`, `forge fmt`, or `forge test`.

This caused PR #125 to be merged with failing (infrastructure-only) checks.

## Fix

- **Cache Foundry binary** via `actions/cache@v4` (keyed by version + OS) — on cache hit, skip download entirely
- **Retry fallback** — if `foundry-toolchain` fails and cache misses, run `foundryup` manually with 3 retry attempts and 15s backoff
- **Cache hit path** — adds cached binary to `$GITHUB_PATH` directly

## Impact
Once the cache is populated on the first successful run, subsequent CI runs will use the cached Foundry binary and never hit the download step again. The retry fallback covers the cold-start case.