### PR TITLE
fix: address Gemini code review findings across PRs #122, #124, #125

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -30,29 +30,29 @@ jobs:
         uses: actions/cache@v4
         with:
           path: |
-            ~/.foundry/bin
+            ~/.foundry
           key: foundry-v1.7.1-${{ runner.os }}
 
       - name: Install Foundry
-        if: steps.cache-foundry.outputs.cache-hit != 'true'
         uses: foundry-rs/foundry-toolchain@v1
         with:
           version: v1.7.1
+        continue-on-error: true
 
-      - name: Add Foundry to PATH
-        if: steps.cache-foundry.outputs.cache-hit == 'true'
-        run: echo "$HOME/.foundry/bin" >> $GITHUB_PATH
-
-      - name: Retry install Foundry (fallback)
-        if: steps.cache-foundry.outputs.cache-hit != 'true' && failure()
+      - name: Retry Foundry install (fallback)
+        if: steps.cache-foundry.outputs.cache-hit != 'true'
         run: |
-          for i in 1 2 3; do
-            curl -L https://foundry.paradigm.xyz | bash && \
-            foundryup --install v1.7.1 && break || {
-              echo "Attempt $i failed, retrying in 15s..."
-              sleep 15
-            }
-          done
+          if ! command -v forge &>/dev/null; then
+            for i in 1 2 3; do
+              echo "Attempt $i: installing Foundry via foundryup..."
+              curl -L https://foundry.paradigm.xyz | bash
+              export PATH="$HOME/.foundry/bin:$PATH"
+              foundryup --install v1.7.1 && break || {
+                echo "Attempt $i failed, retrying in 15s..."
+                sleep 15
+              }
+            done
+          fi
           echo "$HOME/.foundry/bin" >> $GITHUB_PATH
 
       - name: Show Forge version

--- a/app/api/cdp-events/route.ts
+++ b/app/api/cdp-events/route.ts
@@ -117,7 +117,7 @@ const getRecentEvents = async () => {
       scoreSubmitted: scoreSubmitted.map((event: any) => ({
         sessionId: event.data.sessionId,
         playerCount: event.data.playerCount,
-        timestamp: event.data.timestamp,
+        timestamp: event.timestamp,
         blockNumber: event.blockNumber,
         transactionHash: event.transactionHash
       })),

--- a/contracts/TriviaBattlev5.sol
+++ b/contracts/TriviaBattlev5.sol
@@ -100,6 +100,7 @@ contract TriviaBattlev5 is ReentrancyGuard, Ownable, IReceiver {
     error TriviaBattle__NoPendingWithdrawal();
     error TriviaBattle__MaxPlayersReached();
     error TriviaBattle__EntryAfterDeadline();
+    error TriviaBattle__NoScoresSubmitted();
 
     // --- Modifier ---
     modifier onlyOwnerOrChainlink() {
@@ -308,6 +309,11 @@ contract TriviaBattlev5 is ReentrancyGuard, Ownable, IReceiver {
 
     /// @notice Owner-only session end (legacy name preserved for ABI compatibility).
     function endSession() external onlyOwner nonReentrant {
+        _endSession();
+    }
+
+    /// @dev Internal helper for ending the current session. Shared by endSession() and onReport().
+    function _endSession() internal {
         Session storage live = sessions[sessionCounter];
         if (!live.isActive) {
             revert TriviaBattle__SessionNotActive();
@@ -351,7 +357,7 @@ contract TriviaBattlev5 is ReentrancyGuard, Ownable, IReceiver {
         // Require at least one player to have a non-zero score — prevents
         // distributing prizes based on join order when scores were never submitted.
         if (!hasAnyScoresForSession(sessionId)) {
-            revert("No scores submitted for this session");
+            revert TriviaBattle__NoScoresSubmitted();
         }
 
         // Prize pool is the full amount collected in this session (entry fee = 1 USDC)
@@ -694,15 +700,9 @@ contract TriviaBattlev5 is ReentrancyGuard, Ownable, IReceiver {
             return;
         }
         if (selector == SEL_END_SESSION) {
-            Session storage live = sessions[sessionCounter];
-            if (!live.isActive) revert TriviaBattle__SessionNotActive();
-            if (block.timestamp < live.endTime) revert TriviaBattle__SessionDeadlineNotElapsed();
-            if (live.players.length < MIN_PLAYERS) revert TriviaBattle__NotEnoughPlayers();
-            live.isActive = false;
+            _endSession();
             return;
         }
-
-        revert TriviaBattle__Unauthorized();
     }
 
     function supportsInterface(bytes4 interfaceId) external pure returns (bool) {

--- a/hooks/useContractUSDCBalance.ts
+++ b/hooks/useContractUSDCBalance.ts
@@ -88,6 +88,9 @@ function decodeSessionInfo(hex: string): {
     return { isActive: false, distributed: false, startTime: 0, endTime: 0, prizePool: BigInt(0), playerCount: 0 };
   }
   const data = hex.slice(2);
+  if (data.length < 384) {
+    return { isActive: false, distributed: false, startTime: 0, endTime: 0, prizePool: BigInt(0), playerCount: 0 };
+  }
   const isActive = BigInt('0x' + data.slice(0, 64)) !== BigInt(0);
   const distributed = BigInt('0x' + data.slice(64, 128)) !== BigInt(0);
   const startTime = Number(BigInt('0x' + data.slice(128, 192)));
@@ -140,7 +143,7 @@ export function useContractUSDCBalance() {
         rpcCallSafe('eth_call', [{ to: TRIVIA_CONTRACT_ADDRESS, data: SELECTORS.sessionCounter }, 'latest']),
       ]);
 
-      const balanceWeiBigInt = BigInt(balanceWei);
+      const balanceWeiBigInt = (balanceWei && balanceWei !== '0x') ? BigInt(balanceWei) : BigInt(0);
       const decimalsNum = parseInt(decimals, 16) || 6; // fallback to 6 (USDC) if parse fails
       const symbolStr = decodeString(symbol);
       const balance = Number(balanceWeiBigInt) / (10 ** decimalsNum);

--- a/hooks/usePlayerWinnings.ts
+++ b/hooks/usePlayerWinnings.ts
@@ -51,11 +51,11 @@ export function usePlayerWinnings() {
           data: counterData,
         }, 'latest'],
       });
-      const [sessionCounter] = decodeFunctionResult({
+      const sessionCounter = decodeFunctionResult({
         abi: TRIVIA_ABI,
         functionName: 'sessionCounter',
         data: counterResult as `0x${string}`,
-      }) as unknown as readonly [bigint];
+      }) as unknown as bigint;
 
       // Then read getSessionInfo(sessionCounter)
       const sessionData = encodeFunctionData({
@@ -102,8 +102,8 @@ export function usePlayerWinnings() {
         abi: TRIVIA_ABI,
         functionName: 'getPlayerScore',
         data: result as `0x${string}`,
-      }) as unknown as readonly [bigint];
-      setPlayerScore(decoded[0] as unknown as bigint);
+      }) as unknown as bigint;
+      setPlayerScore(decoded);
     } catch (error) {
       console.error('Error fetching player score:', error);
     }

--- a/hooks/usePlayerWinnings.ts
+++ b/hooks/usePlayerWinnings.ts
@@ -111,7 +111,7 @@ export function usePlayerWinnings() {
 
   // Calculate winnings based on score and prize pool
   const calculateWinnings = useCallback(async () => {
-    if (!address || !isConnected || !sessionInfo || !playerScore) {
+    if (!address || !isConnected || sessionInfo === null || playerScore === null || playerScore === undefined) {
       return;
     }
 

--- a/lib/apis/cdp.ts
+++ b/lib/apis/cdp.ts
@@ -117,7 +117,7 @@ export const fetchScoreSubmittedEvents = async (fromBlock?: number, toBlock?: nu
   return events.map((event: any) => ({
     sessionId: event.data.sessionId,
     playerCount: event.data.playerCount,
-    timestamp: event.data.timestamp,
+    timestamp: event.timestamp,
     blockNumber: event.blockNumber,
     transactionHash: event.transactionHash
   }));

--- a/lib/game/weeklyPayoutDiagnostics.ts
+++ b/lib/game/weeklyPayoutDiagnostics.ts
@@ -92,11 +92,11 @@ const readDiagnosticsViaBatch = async (rpcUrl: string) => {
   // First fetch sessionCounter (needed for getSessionInfo arg)
   const counterData = encodeFunctionData({ abi: TRIVIA_ABI, functionName: 'sessionCounter' });
   const counterHex = await rpcBatchEthCall([counterData], rpcUrl);
-  const [sessionCounter] = decodeFunctionResult({
+  const sessionCounter = decodeFunctionResult({
     abi: TRIVIA_ABI,
     functionName: 'sessionCounter',
     data: counterHex[0] as `0x${string}`,
-  }) as unknown as readonly [bigint];
+  }) as unknown as bigint;
 
   const callData = [
     encodeFunctionData({ abi: TRIVIA_ABI, functionName: 'isSessionActive' }),


### PR DESCRIPTION
## Summary

Addresses all actionable Gemini Code Assist review comments from PRs #122, #124, and #125.

## Critical fixes

### `decodeFunctionResult` destructuring crash (PR #125)
- **Files:** `hooks/usePlayerWinnings.ts`, `lib/game/weeklyPayoutDiagnostics.ts`
- **Issue:** Viem's `decodeFunctionResult` returns a single `bigint` directly for single-return-value functions (like `sessionCounter` and `getPlayerScore`), NOT an array. Using `const [x] = ... as readonly [bigint]` would crash with `TypeError: [Symbol.iterator] is not a function` at runtime.
- **Fix:** Changed to `const x = ... as unknown as bigint` (no destructuring).

### `event.data.timestamp` returns undefined (PR #125)
- **Files:** `app/api/cdp-events/route.ts`, `lib/apis/cdp.ts`
- **Issue:** The v5 `ScoresSubmitted` event only has `sessionId` and `playerCount` fields — no `timestamp` in event data. `event.data.timestamp` returns `undefined`.
- **Fix:** Use `event.timestamp` (the block timestamp from the outer event object), consistent with how other events are handled.

## Medium fixes (contract)

### String revert → custom error (PR #124)
- **File:** `contracts/TriviaBattlev5.sol`
- **Issue:** `revert("No scores submitted for this session")` uses a string literal — gas-inefficient and inconsistent with the rest of the contract which uses custom errors.
- **Fix:** Added `error TriviaBattle__NoScoresSubmitted()` and use `revert TriviaBattle__NoScoresSubmitted()`.

### Duplicated endSession logic (PR #124)
- **File:** `contracts/TriviaBattlev5.sol`
- **Issue:** Session-ending logic duplicated between `endSession()` and `onReport()` SEL_END_SESSION branch.
- **Fix:** Extracted `_endSession()` internal helper, called by both.

### Unreachable revert (PR #124)
- **File:** `contracts/TriviaBattlev5.sol`
- **Issue:** The `revert TriviaBattle__Unauthorized()` at the end of `onReport()` was unreachable — all 4 selector branches return early, and the `allowed` check catches non-whitelisted selectors.
- **Fix:** Removed dead code.

## Medium fixes (frontend)

### Hex length validation (PR #122)
- **File:** `hooks/useContractUSDCBalance.ts`
- **Issue:** `decodeSessionInfo` didn't validate hex data length before slicing — malformed/incomplete data would crash on `BigInt()`.
- **Fix:** Added `if (data.length < 384)` guard returning default zero values.

### Unguarded `BigInt(balanceWei)` (PR #122)
- **File:** `hooks/useContractUSDCBalance.ts`
- **Issue:** If `balanceOf` RPC returns `0x`, `BigInt(0x)` throws `SyntaxError`. Other reads in the same block already have this guard.
- **Fix:** `(balanceWei && balanceWei !== '0x') ? BigInt(balanceWei) : BigInt(0)`

## Verification
- ✅ `forge build` — compiles clean
- ✅ `forge test` — 16/16 tests pass
- ✅ `forge fmt --check` — formatting clean
- ✅ `npx tsc --noEmit` — zero errors
- ✅ `npx next build` — production build passes