### PR TITLE
fix: scores not appearing on leaderboard — on-chain submission timeout + leaderboardReady logic

### DIFF
--- a/app/api/save-paid-score/route.ts
+++ b/app/api/save-paid-score/route.ts
@@ -3,6 +3,12 @@ import { callReducer } from '@/lib/apis/spacetimeHttp';
 import { verifyEntryToken } from '@/lib/utils/jwt';
 import { finalizePaidScoreLedger } from '@/lib/game/paidScoreLedger';
 import { verifyScoreReceipt } from '@/lib/game/scoreReceipt';
+
+// On-chain score submission involves readContract + writeContract + waitForReceipt
+// which can take 10-20s. Default Vercel timeout (10s on Hobby) kills the function
+// before the transaction completes, causing silent on-chain submission failures.
+export const maxDuration = 60;
+export const runtime = 'nodejs';
 import { submitOnChainScoreWithRetry, readOnChainSessionCounter } from '@/lib/blockchain/submitOnChainScore';
 import { resolveAuthoritativeSessionId } from '@/lib/game/weeklyLeaderboard';
 
@@ -158,12 +164,9 @@ export async function POST(req: NextRequest) {
         spacetimeErr instanceof Error ? spacetimeErr.message : 'SpacetimeDB leaderboard update failed';
     }
 
-    // Leaderboard visibility depends on SpacetimeDB. If SpacetimeDB is unavailable,
-    // do not advertise leaderboardReady=true even if on-chain submission succeeds.
-    const leaderboardReady = spacetimeUpdated;
-
-    // Attempt on-chain score submission in the background. A failure here should not
-    // block the player from seeing their score on the SpacetimeDB-backed leaderboard.
+    // Attempt on-chain score submission. A failure here is non-fatal if
+    // SpacetimeDB already has the score, but we want to know the result
+    // before telling the client whether the leaderboard is ready.
     try {
       onChainResult = await submitOnChainScoreWithRetry(
         normalizedWallet,
@@ -178,6 +181,11 @@ export async function POST(req: NextRequest) {
       };
     }
 
+    // Leaderboard is ready if EITHER source has the score:
+    // - SpacetimeDB (real-time cache) OR
+    // - On-chain (authoritative, read by fetchWeeklyScoresFromChain)
+    const leaderboardReady = spacetimeUpdated || Boolean(onChainResult?.ok);
+
     if (!onChainResult || !onChainResult.ok) {
       const onChainError = onChainResult?.error;
       console.warn('On-chain score submission failed (non-fatal):', {
@@ -187,8 +195,8 @@ export async function POST(req: NextRequest) {
         error: onChainError,
       });
 
-      // Surface a warning to the client, but still report success because the score
-      // is already visible on the leaderboard via SpacetimeDB.
+      // Surface a warning to the client, but still report success if the score
+      // is visible via SpacetimeDB. If both failed, the warning is more serious.
       return NextResponse.json({
         success: true,
         authoritativeScore,
@@ -198,8 +206,9 @@ export async function POST(req: NextRequest) {
         leaderboardReady,
         onChainError,
         spacetimeError,
-        warning:
-          'Score saved to the leaderboard. On-chain sync will be retried.',
+        warning: spacetimeUpdated
+          ? 'Score saved to the leaderboard. On-chain sync will be retried.'
+          : 'Score could not be saved to the leaderboard. Please try again or contact support.',
       });
     }
 

--- a/app/api/submit-onchain-scores/route.ts
+++ b/app/api/submit-onchain-scores/route.ts
@@ -1,6 +1,9 @@
 import { NextRequest, NextResponse } from 'next/server';
 import { checkAdminAuth } from '@/lib/utils/adminAuthMiddleware';
 import { submitScoresOnChain } from '@/lib/blockchain/submitScoresOnChain';
+
+export const maxDuration = 60;
+export const runtime = 'nodejs';
 import {
   createBasePublicClient,
   readOnChainPlayerScores,

--- a/app/api/weekly-leaderboard/route.ts
+++ b/app/api/weekly-leaderboard/route.ts
@@ -1,6 +1,9 @@
 import { NextRequest, NextResponse } from 'next/server';
 import { getWeeklyLeaderboardEntries } from '@/lib/game/weeklyLeaderboardServer';
 
+export const maxDuration = 30;
+export const runtime = 'nodejs';
+
 export async function GET(req: NextRequest) {
   try {
     const { searchParams } = new URL(req.url);


### PR DESCRIPTION
## Root Cause

Scores were not appearing on the home screen leaderboard after completing a paid game.

**Why:** The `save-paid-score` API route had no `maxDuration` set. Vercel's default 10s timeout killed the serverless function before the on-chain `submitScores()` transaction (which involves 3 readContract calls + 1 writeContract + waitForTransactionReceipt) could complete. The score was saved to SpacetimeDB but never made it to the smart contract. Since the leaderboard reads on-chain scores via `fetchWeeklyScoresFromChain()`, it showed nothing.

## Fixes

### 1. Add `maxDuration` to API routes that do on-chain transactions
- `save-paid-score/route.ts`: `maxDuration=60` (does readContract + writeContract + waitForReceipt)
- `weekly-leaderboard/route.ts`: `maxDuration=30` (does multiple readContract calls)
- `submit-onchain-scores/route.ts`: `maxDuration=60` (does writeContract + waitForReceipt)

### 2. Fix `leaderboardReady` logic
Previously `leaderboardReady = spacetimeUpdated` — only true if SpacetimeDB succeeded. If SpacetimeDB was down (e.g. invalid auth token), the frontend showed "Score could not be saved" even if on-chain submission succeeded.

Now `leaderboardReady = spacetimeUpdated || Boolean(onChainResult?.ok)` — true if EITHER source has the score. The on-chain score is read by `fetchWeeklyScoresFromChain()` in the leaderboard API, so scores will appear even when SpacetimeDB is unavailable.

### 3. Better warning messages
- If only on-chain fails (SpacetimeDB works): "Score saved to the leaderboard. On-chain sync will be retried."
- If both fail: "Score could not be saved to the leaderboard. Please try again or contact support."

## Verification
- ✅ `tsc --noEmit` — clean
- ✅ `next build` — clean
- Manual verification: submitted score (1700) for player 0xE9eC… directly on-chain, confirmed leaderboard API returns the entry