### PR TITLE
fix: address Gemini PR #129 review — HTTP 500 on total failure + import ordering

### DIFF
--- a/app/api/save-paid-score/route.ts
+++ b/app/api/save-paid-score/route.ts
@@ -3,14 +3,14 @@ import { callReducer } from '@/lib/apis/spacetimeHttp';
 import { verifyEntryToken } from '@/lib/utils/jwt';
 import { finalizePaidScoreLedger } from '@/lib/game/paidScoreLedger';
 import { verifyScoreReceipt } from '@/lib/game/scoreReceipt';
+import { submitOnChainScoreWithRetry, readOnChainSessionCounter } from '@/lib/blockchain/submitOnChainScore';
+import { resolveAuthoritativeSessionId } from '@/lib/game/weeklyLeaderboard';
 
 // On-chain score submission involves readContract + writeContract + waitForReceipt
 // which can take 10-20s. Default Vercel timeout (10s on Hobby) kills the function
 // before the transaction completes, causing silent on-chain submission failures.
 export const maxDuration = 60;
 export const runtime = 'nodejs';
-import { submitOnChainScoreWithRetry, readOnChainSessionCounter } from '@/lib/blockchain/submitOnChainScore';
-import { resolveAuthoritativeSessionId } from '@/lib/game/weeklyLeaderboard';
 
 const MAX_GAME_SCORE = 3000;
 
@@ -195,10 +195,10 @@ export async function POST(req: NextRequest) {
         error: onChainError,
       });
 
-      // Surface a warning to the client, but still report success if the score
-      // is visible via SpacetimeDB. If both failed, the warning is more serious.
+      // Surface a warning to the client. If SpacetimeDB also failed, the score
+      // is not visible anywhere — return failure so the client knows.
       return NextResponse.json({
-        success: true,
+        success: spacetimeUpdated,
         authoritativeScore,
         onChainSessionId,
         spacetimeUpdated,
@@ -209,6 +209,8 @@ export async function POST(req: NextRequest) {
         warning: spacetimeUpdated
           ? 'Score saved to the leaderboard. On-chain sync will be retried.'
           : 'Score could not be saved to the leaderboard. Please try again or contact support.',
+      }, {
+        status: spacetimeUpdated ? 200 : 500,
       });
     }
 

--- a/app/api/submit-onchain-scores/route.ts
+++ b/app/api/submit-onchain-scores/route.ts
@@ -1,9 +1,6 @@
 import { NextRequest, NextResponse } from 'next/server';
 import { checkAdminAuth } from '@/lib/utils/adminAuthMiddleware';
 import { submitScoresOnChain } from '@/lib/blockchain/submitScoresOnChain';
-
-export const maxDuration = 60;
-export const runtime = 'nodejs';
 import {
   createBasePublicClient,
   readOnChainPlayerScores,
@@ -17,6 +14,9 @@ import {
 } from '@/lib/game/weeklyScoresForPlayers';
 import { safeErrorMessage } from '@/lib/utils/safeErrorMessage';
 import { type Hash } from 'viem';
+
+export const maxDuration = 60;
+export const runtime = 'nodejs';
 
 /**
  * POST /api/submit-onchain-scores


### PR DESCRIPTION
## Gemini Review Findings on PR #129

Addresses all 3 Gemini Code Assist comments from PR #129 review.

### High: `success: true` when both SpacetimeDB and on-chain fail
When both `spacetimeUpdated` is false AND `onChainResult.ok` is false, the API returned `success: true` with HTTP 200 — misleading the client into thinking the score was saved.

**Fix:** Return `success: spacetimeUpdated` (false when both fail) and set HTTP status to 500.

### Medium: Import ordering in `save-paid-score/route.ts`
`export const maxDuration` and `export const runtime` were placed between import statements, violating ES6 import ordering.

**Fix:** Moved all imports above the export declarations.

### Medium: Import ordering in `submit-onchain-scores/route.ts`
Same issue — exports interleaved with imports.

**Fix:** Grouped all imports first, then exports.

## Verification
- ✅ `tsc --noEmit` — clean
- ✅ `next build` — clean