### PR TITLE
fix: weekly payout status shows distributed sessions correctly and CR…

### DIFF
--- a/app/page.tsx
+++ b/app/page.tsx
@@ -107,6 +107,7 @@ function HomePage() {
     isSessionActive: onChainSessionActive,
     lastSessionTime: onChainLastSessionTime,
     sessionInterval: onChainSessionInterval,
+    distributed: onChainDistributed,
   } = useContractUSDCBalance();
 
   const settlementCountdown = useSessionCountdown(
@@ -141,6 +142,7 @@ function HomePage() {
     isLoading: contractBalanceLoading,
     isSessionActive: onChainSessionActive,
     sessionPrizePool,
+    distributed: onChainDistributed,
     countdownExpired: settlementCountdown?.isExpired ?? false,
     hasOnChainScores,
     sessionCounter: weeklySessionCounter,

--- a/chainlink-cre-workflows/weekly-prize-distribution/main.ts
+++ b/chainlink-cre-workflows/weekly-prize-distribution/main.ts
@@ -10,6 +10,7 @@ import {
   bytesToHex,
   hexToBase64,
   consensusMedianAggregation,
+  consensusIdenticalAggregation,
 } from "@chainlink/cre-sdk"
 import { encodeFunctionData, decodeFunctionResult, zeroAddress } from "viem"
 
@@ -608,7 +609,7 @@ function syncScoresFromRankingsApi(
     return new TextDecoder().decode(resp.body ?? new Uint8Array())
   }
 
-  const body = runtime.runInNodeMode(fetchRankings, consensusMedianAggregation())().result()
+  const body = runtime.runInNodeMode(fetchRankings, consensusIdenticalAggregation<string>())().result()
   if (!body) return { synced: false, addresses: [], scores: [] }
 
   let parsed: { players?: { address: string; score: number }[] }
@@ -765,7 +766,7 @@ function syncScoresFromApp(runtime: Runtime<Config>, sessionId: bigint): boolean
     return status >= 200 && status < 300 ? 1 : 0
   }
 
-  const result = runtime.runInNodeMode(syncScore, consensusMedianAggregation())().result()
+  const result = runtime.runInNodeMode(syncScore, consensusIdenticalAggregation<number>())().result()
   return result >= 1
 }
 

--- a/hooks/useContractUSDCBalance.ts
+++ b/hooks/useContractUSDCBalance.ts
@@ -22,6 +22,7 @@ export interface ContractUSDCBalanceState {
   playerCount: number;
   isSessionActive: boolean;
   sessionCounter: number;
+  distributed: boolean;
 }
 
 // Helper function to decode ABI-encoded string
@@ -116,6 +117,7 @@ export function useContractUSDCBalance() {
     playerCount: 0,
     isSessionActive: false,
     sessionCounter: 0,
+    distributed: false,
   });
 
   const hasFetchedOnce = useRef(false);
@@ -189,6 +191,7 @@ export function useContractUSDCBalance() {
         playerCount,
         isSessionActive,
         sessionCounter,
+        distributed: sessionInfo.distributed,
       });
     } catch (error) {
       console.error('Error fetching contract data:', error);

--- a/lib/game/weeklyPayoutDiagnostics.ts
+++ b/lib/game/weeklyPayoutDiagnostics.ts
@@ -38,22 +38,21 @@ const formatTimestamp = (ts: bigint): string => {
   return new Date(Number(ts) * 1000).toISOString();
 };
 
-const evaluateCreSkip = (params: {
+export const evaluateCreSkip = (params: {
   sessionCounter: bigint;
   isSessionActive: boolean;
+  distributed: boolean;
   prizePool: bigint;
   endTime: bigint;
   hasOnChainScores: boolean;
   now: bigint;
 }): CreSkipReason => {
-  const { sessionCounter, isSessionActive, prizePool, endTime, hasOnChainScores, now } = params;
+  const { sessionCounter, isSessionActive, distributed, prizePool, endTime, hasOnChainScores, now } = params;
   const isSessionEnded = !isSessionActive || now > endTime;
-  const prizesDistributedHeuristic =
-    sessionCounter > BigInt(0) && !isSessionActive && prizePool === BigInt(0);
 
   if (sessionCounter === BigInt(0)) return 'no_session_started';
+  if (distributed) return 'prizes_already_distributed';
   if (!isSessionEnded) return 'session_still_active';
-  if (prizesDistributedHeuristic) return 'prizes_already_distributed';
   if (prizePool === BigInt(0)) return 'empty_prize_pool';
   if (!hasOnChainScores) return 'no_on_chain_scores';
   return 'none_ready_to_distribute';
@@ -119,6 +118,7 @@ const readDiagnosticsViaBatch = async (rpcUrl: string) => {
     lastSessionTime: decodeView<bigint>('lastSessionTime', results[2]),
     sessionInterval: decodeView<bigint>('sessionInterval', results[3]),
     prizePool: sessionInfo[4],
+    distributed: sessionInfo[1],
     playerList: decodeView<`0x${string}`[]>('getCurrentPlayers', results[5]),
     chainlinkOracle: decodeView<string>('chainlinkOracle', results[6]),
   };
@@ -164,6 +164,7 @@ const readDiagnosticsSequential = async (rpcUrl: string) => {
     lastSessionTime,
     sessionInterval,
     prizePool: sessionInfo[4],
+    distributed: sessionInfo[1],
     playerList,
     chainlinkOracle,
   };
@@ -177,6 +178,7 @@ const readOnChainSessionState = async (): Promise<{
   lastSessionTime: bigint;
   sessionInterval: bigint;
   prizePool: bigint;
+  distributed: boolean;
   playerList: `0x${string}`[];
   chainlinkOracle: string;
 }> => {
@@ -214,6 +216,7 @@ export const fetchWeeklyPayoutDiagnostics = async (): Promise<WeeklyPayoutDiagno
     prizePool,
     playerList,
     chainlinkOracle,
+    distributed,
   } = await readOnChainSessionState();
 
   const endTime = lastSessionTime + sessionInterval;
@@ -234,6 +237,7 @@ export const fetchWeeklyPayoutDiagnostics = async (): Promise<WeeklyPayoutDiagno
   const creSkipReason = evaluateCreSkip({
     sessionCounter,
     isSessionActive,
+    distributed,
     prizePool,
     endTime,
     hasOnChainScores,

--- a/lib/game/weeklyPayoutStatus.ts
+++ b/lib/game/weeklyPayoutStatus.ts
@@ -16,6 +16,7 @@ type WeeklyPayoutStatusInput = {
   isLoading: boolean;
   isSessionActive: boolean;
   sessionPrizePool: number;
+  distributed?: boolean;
   countdownExpired: boolean;
   hasOnChainScores: boolean;
   sessionCounter: number;
@@ -26,6 +27,7 @@ export const getWeeklyPayoutStatus = ({
   isLoading,
   isSessionActive,
   sessionPrizePool,
+  distributed,
   countdownExpired,
   hasOnChainScores,
   sessionCounter,
@@ -48,6 +50,14 @@ export const getWeeklyPayoutStatus = ({
     return {
       phase: 'next_session_soon',
       timerLabel: 'NEXT SESSION OPENS SOON',
+      weekSubtitle,
+    };
+  }
+
+  if (distributed) {
+    return {
+      phase: 'session_complete',
+      timerLabel: 'WEEK COMPLETE',
       weekSubtitle,
     };
   }

--- a/lib/game/weeklyScoresForPlayers.ts
+++ b/lib/game/weeklyScoresForPlayers.ts
@@ -54,14 +54,17 @@ export const getWeeklyScoresForPlayers = async (
   const sessionScores = new Map<string, { score: number; startedAt: number }>();
 
   if (!options.skipSpacetime && isSpacetimeHttpConfigured()) {
-    const wallets = playerAddresses.map((a) => `'${a.toLowerCase().replace(/'/g, "''")}'`);
-    const walletFilter = wallets.length > 0 ? `wallet_address IN (${wallets.join(',')})` : 'FALSE';
+    // SpacetimeDB SQL does not support IN lists, so fetch players by session
+    // and filter to the requested wallets in-memory.
     const playerRows = await querySqlSafe<Record<string, unknown>>(
-      `SELECT * FROM players WHERE ${walletFilter} OR weekly_session_id = ${sessionCounter}`,
+      `SELECT * FROM players WHERE weekly_session_id = ${sessionCounter}`,
     );
+    const requestedWallets = new Set(playerAddresses.map((a) => a.toLowerCase()));
     for (const row of playerRows) {
       const player = mapSqlPlayerRow(row);
-      playersByWallet.set(player.walletAddress.toLowerCase(), player);
+      if (requestedWallets.has(player.walletAddress.toLowerCase())) {
+        playersByWallet.set(player.walletAddress.toLowerCase(), player);
+      }
     }
 
     const sessionRows = await querySqlSafe<Record<string, unknown>>(

--- a/tests/weekly-payout-status.test.ts
+++ b/tests/weekly-payout-status.test.ts
@@ -20,6 +20,20 @@ describe('getWeeklyPayoutStatus', () => {
     assert.equal(status.timerLabel, 'AWAITING SCORE SYNC');
   });
 
+  it('shows session complete when prizes have already been distributed', () => {
+    const status = getWeeklyPayoutStatus({
+      isLoading: false,
+      isSessionActive: false,
+      sessionPrizePool: 8,
+      distributed: true,
+      countdownExpired: true,
+      hasOnChainScores: true,
+      sessionCounter: 1,
+    });
+    assert.equal(status.phase, 'session_complete');
+    assert.equal(status.timerLabel, 'WEEK COMPLETE');
+  });
+
   it('shows payout processing when scores exist but pool remains', () => {
     const status = getWeeklyPayoutStatus({
       isLoading: false,


### PR DESCRIPTION
…E consensus uses string-compatible aggregation

- Read the on-chain 'distributed' flag in useContractUSDCBalance and pass it into getWeeklyPayoutStatus so completed sessions show 'WEEK COMPLETE' instead of 'PAYOUT PENDING'.
- Update weeklyPayoutDiagnostics to use the real distributed flag from getSessionInfo, not a prizePool heuristic.
- Fix SpacetimeDB query in weeklyScoresForPlayers to avoid unsupported IN (...) syntax; fetch by weekly_session_id and filter in JS.
- Fix CRE workflow consensus: use consensusIdenticalAggregation for HTTP API payloads instead of consensusMedianAggregation, which fails on JSON strings.
- Add test coverage for distributed-session status label.